### PR TITLE
Accessibility bugs

### DIFF
--- a/XamlControlsGallery/ControlPages/NavigationViewPage.xaml
+++ b/XamlControlsGallery/ControlPages/NavigationViewPage.xaml
@@ -261,8 +261,8 @@
                     <CheckBox x:Name="paneFooterCheck" Content="PaneFooter visible" IsChecked="False" Click="paneFooterCheck_Click"/>
 
                     <TextBlock Text="PanePosition:" Margin="0,12,0,0"/>
-                    <RadioButton Content="Left" IsChecked="True" Click="panePositionLeft_Click"/>
-                    <RadioButton Content="Top" Click="panePositionTop_Click" Margin="0,0,0,12"/>
+                    <RadioButton Content="Left" IsChecked="True" Checked="panePositionLeft_Checked"/>
+                    <RadioButton Content="Top" Checked="panePositionTop_Checked" Margin="0,0,0,12"/>
 
                     <CheckBox x:Name="sffCheck" Content="Keyboard SelectionFollowsFocus" IsChecked="False" Click="sffCheck_Click"/>
                     <CheckBox x:Name="suppressselectionCheck_Checked" Content="Selection of Menu Item2 suppressed" IsChecked="False" Click="suppressselectionCheck_Checked_Click"/>

--- a/XamlControlsGallery/ControlPages/NavigationViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/NavigationViewPage.xaml.cs
@@ -262,18 +262,25 @@ namespace AppUIBasics.ControlPages
             }
         }
 
-        private void panePositionLeft_Click(object sender, RoutedEventArgs e)
+        private void panePositionLeft_Checked(object sender, RoutedEventArgs e)
         {
-            nvSample.PaneDisplayMode = Microsoft.UI.Xaml.Controls.NavigationViewPaneDisplayMode.Left;
-            nvSample.IsPaneOpen = true;
-            FooterStackPanel.Orientation = Orientation.Vertical;
+            if ((sender as RadioButton).IsChecked == true && nvSample != null)
+            {
+                nvSample.PaneDisplayMode = Microsoft.UI.Xaml.Controls.NavigationViewPaneDisplayMode.Left;
+                nvSample.IsPaneOpen = true;
+                FooterStackPanel.Orientation = Orientation.Vertical;
+            }
         }
 
-        private void panePositionTop_Click(object sender, RoutedEventArgs e)
+
+        private void panePositionTop_Checked(object sender, RoutedEventArgs e)
         {
-            nvSample.PaneDisplayMode = Microsoft.UI.Xaml.Controls.NavigationViewPaneDisplayMode.Top;
-            nvSample.IsPaneOpen = false;
-            FooterStackPanel.Orientation = Orientation.Horizontal;
+            if ((sender as RadioButton).IsChecked == true && nvSample != null)
+            {
+                nvSample.PaneDisplayMode = Microsoft.UI.Xaml.Controls.NavigationViewPaneDisplayMode.Top;
+                nvSample.IsPaneOpen = false;
+                FooterStackPanel.Orientation = Orientation.Horizontal;
+            }
         }
 
         private void sffCheck_Click(object sender, RoutedEventArgs e)

--- a/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml
+++ b/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml
@@ -36,7 +36,7 @@
                               XamlSource="Text\RichEditBox\RichEditBoxSample2_xaml.txt"
                               HorizontalContentAlignment="Stretch" VerticalAlignment="Top">
             <StackPanel>
-                <TextBlock Margin="0,0,0,10" Text="Prefix an entry with an at-sign (@) symbol to see a list of people and place suggestions that matches the entry."/>
+                <TextBlock Margin="0,0,0,10" Text="Prefix an entry with an at-sign (@) symbol to see a list of people and place suggestions that matches the entry." TextWrapping="WrapWholeWords"/>
                 <RichEditBox Height="200">
                     <contract6Present:RichEditBox.ContentLinkProviders>
                         <contract6Present:ContentLinkProviderCollection>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixing two accessibility bugs pertaining to 200% text scaling and radio button invocation with Narrator.

## Description
<!--- Describe your changes in detail -->
- Added text wrapping property.
- Updated NavigationView options' RadioButtons to use more specific Checked events instead of more generic Click events.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Bug 19597343: Text Scaling Desktop: XAML Controls Gallery : Information present for RichEditBox is clipped in 200% Text Scaling.
- Bug 19440518: Narrator Desktop : XAML Controls Gallery : Unable to change the position of navigation pane using caps+enter 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manual verification

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
