### PR TITLE
Fix several typos in markup samples (ListView, Compact Sizing, ToolTip)

### DIFF
--- a/XamlControlsGallery/ControlPages/CompactSizingPage.xaml
+++ b/XamlControlsGallery/ControlPages/CompactSizingPage.xaml
@@ -35,10 +35,10 @@
             <local:ControlExample.Xaml>
                 <RichTextBlock Style="{StaticResource XamlCodeRichTextBlockStyle}">
                     <Paragraph>&lt;Application.Resources&gt;</Paragraph>
-                    <Paragraph TextIndent="12">&lt;ResourceDictionary/&gt;</Paragraph>
+                    <Paragraph TextIndent="12">&lt;ResourceDictionary&gt;</Paragraph>
                     <Paragraph TextIndent="24">&lt;ResourceDictionary.MergedDictionaries&gt;</Paragraph>
-                    <Paragraph TextIndent="36">&lt;ResourceDictionary Source="CompactSize.xaml"&gt;</Paragraph>
-                    <Paragraph TextIndent="24">&lt;ResourceDictionary.MergedDictionaries/&gt;</Paragraph>
+                    <Paragraph TextIndent="36">&lt;ResourceDictionary Source="CompactSize.xaml"/&gt;</Paragraph>
+                    <Paragraph TextIndent="24">&lt;/ResourceDictionary.MergedDictionaries&gt;</Paragraph>
                     <Paragraph TextIndent="12">&lt;/ResourceDictionary&gt;</Paragraph>
                     <Paragraph>&lt;/Application.Resources&gt;</Paragraph>
                 </RichTextBlock>

--- a/XamlControlsGallery/ControlPages/ListViewPage.xaml
+++ b/XamlControlsGallery/ControlPages/ListViewPage.xaml
@@ -86,6 +86,15 @@
     </Page.Resources>
     <StackPanel>
         <local:ControlExample HeaderText="A Simple ListView with Selection support">
+            <ListView
+                x:Name="Control2"
+                CanDragItems="True"
+                CanReorderItems="True"
+                AllowDrop="True"
+                BorderThickness="1"
+                BorderBrush="DimGray"
+                MinWidth="550" 
+                Height="400"/>
             <local:ControlExample.Options>
                 <StackPanel>
                     <ComboBox SelectionChanged="SelectionModeComboBox_SelectionChanged" Header="SelectionMode"
@@ -97,15 +106,6 @@
                     </ComboBox>
                 </StackPanel>
             </local:ControlExample.Options>
-            <Grid MinWidth="550" Height="400">
-                <ListView
-                    x:Name="Control2"
-                    CanDragItems="True"
-                    CanReorderItems="True"
-                    AllowDrop="True"
-                    BorderThickness="1"
-                    BorderBrush="DimGray" />
-            </Grid>
 
             <local:ControlExample.Xaml>
                 <RichTextBlock Style="{StaticResource XamlCodeRichTextBlockStyle}">
@@ -117,154 +117,96 @@
             </local:ControlExample.Xaml>
         </local:ControlExample>
 
-        <local:ControlExample HeaderText="A ListView with Grouped Headers">
-            <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" MinWidth="550"/>
-                </Grid.ColumnDefinitions>
+        <local:ControlExample HeaderText="A ListView with Grouped Headers" XamlSource="ListView\ListViewGroupedHeaderSample_xaml.txt">
+            <ListView 
+                ItemsSource="{x:Bind ContactsCVS.View, Mode=OneWay}"
+                ItemTemplate="{StaticResource ContactListViewTemplate}"
+                SelectionMode="Single"
+                ShowsScrollingPlaceholders="True"
+                Height="400"
+                MinWidth="550"
+                BorderThickness="1"
+                BorderBrush="DimGray">
+                <ListView.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <ItemsStackPanel AreStickyGroupHeadersEnabled="False" />
+                    </ItemsPanelTemplate>
+                </ListView.ItemsPanel>
 
-                <ListView 
-                    ItemsSource="{x:Bind ContactsCVS.View, Mode=OneWay}"
-                    ItemTemplate="{StaticResource ContactListViewTemplate}"
-                    SelectionMode="Single"
-                    ShowsScrollingPlaceholders="True"
-                    Grid.Row="1" 
-                    Grid.ColumnSpan="2"
-                    Height="400"
-                    BorderThickness="1"
-                    BorderBrush="DimGray">
-                    <ListView.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <ItemsStackPanel AreStickyGroupHeadersEnabled="False" />
-                        </ItemsPanelTemplate>
-                    </ListView.ItemsPanel>
-
-                    <ListView.GroupStyle>
-                        <GroupStyle >
-                            <GroupStyle.HeaderTemplate>
-                                <DataTemplate x:DataType="local1:GroupInfoList">
-                                    <TextBlock Text="{x:Bind Key}"
-                                       Style="{ThemeResource TitleTextBlockStyle}"/>
-                                </DataTemplate>
-                            </GroupStyle.HeaderTemplate>
-                        </GroupStyle>
-                    </ListView.GroupStyle>
-                </ListView>
-            </Grid>
-
-            <local:ControlExample.Xaml>
-                <RichTextBlock Style="{StaticResource XamlCodeRichTextBlockStyle}">
-                    <Paragraph>&lt;CollectionViewSource x:Name="ContactsCVS" IsSourceGrouped="True"/&gt;</Paragraph>
-                    <Paragraph />
-                    <Paragraph>&lt;ListView ItemsSource="{x:Bind Contacts}"/&gt;</Paragraph>
-                    <Paragraph TextIndent="12">&lt;ListView.ItemsPanel/&gt;</Paragraph>
-                    <Paragraph TextIndent="24">&lt;ItemsPanelTemplate/&gt;</Paragraph>
-                    <Paragraph TextIndent="36">&lt;ItemsStackPanel AreStickyGroupHeadersEnabled="False"/&gt;</Paragraph>
-                    <Paragraph TextIndent="24">&lt;ItemsPanelTemplate /&gt;</Paragraph>
-                    <Paragraph TextIndent="12">&lt;ListView.ItemsPanel/&gt;</Paragraph>
-                    <Paragraph>&lt;ListView/&gt;</Paragraph>
-                </RichTextBlock>
-            </local:ControlExample.Xaml>
+                <ListView.GroupStyle>
+                    <GroupStyle >
+                        <GroupStyle.HeaderTemplate>
+                            <DataTemplate x:DataType="local1:GroupInfoList">
+                                <TextBlock Text="{x:Bind Key}" Style="{ThemeResource TitleTextBlockStyle}"/>
+                            </DataTemplate>
+                        </GroupStyle.HeaderTemplate>
+                    </GroupStyle>
+                </ListView.GroupStyle>
+            </ListView>
         </local:ControlExample>
 
-        <local:ControlExample HeaderText="A ListView with Grouped Sticky Headers">
-            <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" MinWidth="550"/>
-                </Grid.ColumnDefinitions>
+        <local:ControlExample HeaderText="A ListView with Grouped Sticky Headers" XamlSource="ListView\ListViewStickyHeaderSample_xaml.txt">
+            <ListView 
+                ItemsSource="{x:Bind ContactsCVS.View, Mode=OneWay}"
+                ItemTemplate="{StaticResource ContactListViewTemplate}"
+                SelectionMode="Single"
+                ShowsScrollingPlaceholders="True"
+                Height="400" 
+                MinWidth="550"
+                BorderThickness="1"
+                BorderBrush="DimGray">
+                <ListView.GroupStyle>
+                    <GroupStyle >
+                        <GroupStyle.HeaderTemplate>
+                            <DataTemplate x:DataType="local1:GroupInfoList">
+                                <TextBlock Text="{x:Bind Key}" Style="{ThemeResource TitleTextBlockStyle}"/>
+                            </DataTemplate>
+                        </GroupStyle.HeaderTemplate>
+                    </GroupStyle>
+                </ListView.GroupStyle>
+            </ListView>
 
-                <ListView 
-                    ItemsSource="{x:Bind ContactsCVS.View, Mode=OneWay}"
-                    ItemTemplate="{StaticResource ContactListViewTemplate}"
-                    SelectionMode="Single"
-                    ShowsScrollingPlaceholders="True"
-                    Grid.Row="1"
-                    Grid.ColumnSpan="2"
-                    Height="400" 
-                    BorderThickness="1"
-                    BorderBrush="DimGray">
-                    <ListView.GroupStyle>
-                        <GroupStyle >
-                            <GroupStyle.HeaderTemplate>
-                                <DataTemplate x:DataType="local1:GroupInfoList">
-                                    <TextBlock Text="{x:Bind Key}"
-                                       Style="{ThemeResource TitleTextBlockStyle}"/>
-                                </DataTemplate>
-                            </GroupStyle.HeaderTemplate>
-                        </GroupStyle>
-                    </ListView.GroupStyle>
-                </ListView>
-            </Grid>
-
-            <local:ControlExample.Xaml>
-                <RichTextBlock Style="{StaticResource XamlCodeRichTextBlockStyle}">
-                    <Paragraph>&lt;CollectionViewSource x:Name="ContactsCVS" IsSourceGrouped="True"/&gt;</Paragraph>
-                    <Paragraph />
-                    <Paragraph>&lt;ListView ItemsSource="{x:Bind Contacts}"/&gt;</Paragraph>
-                    <Paragraph TextIndent="12">&lt;ListView.ItemsPanel/&gt;</Paragraph>
-                    <Paragraph TextIndent="24">&lt;ItemsPanelTemplate/&gt;</Paragraph>
-                    <Paragraph TextIndent="36">&lt;ItemsStackPanel AreStickyGroupHeadersEnabled="True"/&gt;</Paragraph>
-                    <Paragraph TextIndent="24">&lt;ItemsPanelTemplate /&gt;</Paragraph>
-                    <Paragraph TextIndent="12">&lt;ListView.ItemsPanel/&gt;</Paragraph>
-                    <Paragraph>&lt;ListView/&gt;</Paragraph>
-                </RichTextBlock>
-            </local:ControlExample.Xaml>
         </local:ControlExample>
 
         <local:ControlExample HeaderText="A ListView with Images">
-            <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
+            <ListView x:Name="Control4"
+                      CanDragItems="True"
+                      CanReorderItems="True"
+                      CanDrag="True"
+                      AllowDrop="True"
+                      Height="400"
+                      MinWidth="550"
+                      BorderThickness="1"
+                      BorderBrush="DimGray">
+                <ListView.ItemTemplate>
+                    <DataTemplate x:DataType="local1:CustomDataObject">
+                        <Grid Margin="0,12,0,12">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" MinWidth="150"/>
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <Image Source="{x:Bind ImageLocation}" MaxHeight="100" Stretch="Fill"/>
 
-                <ListView x:Name="Control4"
-                          CanDragItems="True"
-                          CanReorderItems="True"
-                          CanDrag="True"
-                          AllowDrop="True"
-                          Height="400"
-                          Width="550"
-                          BorderThickness="1"
-                          BorderBrush="DimGray">
-                    <ListView.ItemTemplate>
-                        <DataTemplate x:DataType="local1:CustomDataObject">
-                            <Grid Margin="0,12,0,12">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" MinWidth="150"/>
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <Image Source="{x:Bind ImageLocation}" MaxHeight="100" Stretch="Fill"/>
-
-                                <StackPanel Margin="12,0,0,0" Grid.Column="1" >
-                                    <TextBlock Text="{x:Bind Title}" FontFamily="Segoe UI" FontSize="14" FontWeight="SemiBold" Style="{ThemeResource BaseTextBlockStyle}" HorizontalAlignment="Left" Margin="0,0,0,6" LineHeight="20"/>
-                                    <StackPanel Orientation="Horizontal">
-                                        <TextBlock Text="{x:Bind Description}" FontFamily="Segoe UI" FontWeight="Normal" LineHeight="20" Style="{ThemeResource BodyTextBlockStyle}" TextTrimming="CharacterEllipsis" Width="350" MaxLines="1"/>
-                                    </StackPanel>
-                                    <StackPanel Orientation="Horizontal">
-                                        <TextBlock Text="{x:Bind Views}" FontFamily="Segoe UI" FontSize="12" FontWeight="Normal" HorizontalAlignment="Left" Style="{ThemeResource CaptionTextBlockStyle}" Margin="0,0,0,0"/>
-                                        <TextBlock Text=" Views " FontFamily="Segoe UI" FontSize="12" FontWeight="Normal" HorizontalAlignment="Left" Style="{ThemeResource CaptionTextBlockStyle}"/>
-                                        <TextBlock Text=" &#x22C5; " FontFamily="Segoe UI" FontSize="12" FontWeight="Bold" HorizontalAlignment="Left"/>
-                                        <TextBlock Text="{x:Bind Likes}" FontFamily="Segoe UI" FontSize="12" FontWeight="Normal" HorizontalAlignment="Left" Style="{ThemeResource CaptionTextBlockStyle}" Margin="5,0,0,0"/>
-                                        <TextBlock Text=" Likes" FontFamily="Segoe UI" FontSize="12" FontWeight="Normal" HorizontalAlignment="Left" Style="{ThemeResource CaptionTextBlockStyle}"/>
-                                    </StackPanel>
+                            <StackPanel Margin="12,0,0,0" Grid.Column="1" >
+                                <TextBlock Text="{x:Bind Title}" FontFamily="Segoe UI" FontSize="14" FontWeight="SemiBold" Style="{ThemeResource BaseTextBlockStyle}" HorizontalAlignment="Left" Margin="0,0,0,6" LineHeight="20"/>
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="{x:Bind Description}" FontFamily="Segoe UI" FontWeight="Normal" LineHeight="20" Style="{ThemeResource BodyTextBlockStyle}" TextTrimming="CharacterEllipsis" Width="350" MaxLines="1"/>
                                 </StackPanel>
-                            </Grid>
-                        </DataTemplate>
-                    </ListView.ItemTemplate>
-                </ListView>
-            </Grid>
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="{x:Bind Views}" FontFamily="Segoe UI" FontSize="12" FontWeight="Normal" HorizontalAlignment="Left" Style="{ThemeResource CaptionTextBlockStyle}" Margin="0,0,0,0"/>
+                                    <TextBlock Text=" Views " FontFamily="Segoe UI" FontSize="12" FontWeight="Normal" HorizontalAlignment="Left" Style="{ThemeResource CaptionTextBlockStyle}"/>
+                                    <TextBlock Text=" &#x22C5; " FontFamily="Segoe UI" FontSize="12" FontWeight="Bold" HorizontalAlignment="Left"/>
+                                    <TextBlock Text="{x:Bind Likes}" FontFamily="Segoe UI" FontSize="12" FontWeight="Normal" HorizontalAlignment="Left" Style="{ThemeResource CaptionTextBlockStyle}" Margin="5,0,0,0"/>
+                                    <TextBlock Text=" Likes" FontFamily="Segoe UI" FontSize="12" FontWeight="Normal" HorizontalAlignment="Left" Style="{ThemeResource CaptionTextBlockStyle}"/>
+                                </StackPanel>
+                            </StackPanel>
+                        </Grid>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
             <local:ControlExample.Xaml>
                 <RichTextBlock TextWrapping="WrapWholeWords">
-                    <Paragraph>Refer to the DataTemplate on the ListViewPage.xaml page to get this visual of Images in a list</Paragraph>
+                    <Paragraph>Refer to the DataTemplate on the ListViewPage.xaml page to see the full sample code.</Paragraph>
                 </RichTextBlock>
             </local:ControlExample.Xaml>
         </local:ControlExample>

--- a/XamlControlsGallery/ControlPages/ToolTipPage.xaml
+++ b/XamlControlsGallery/ControlPages/ToolTipPage.xaml
@@ -40,10 +40,10 @@
             </local:ControlExample.Example>
             <local:ControlExample.Xaml>
                 <RichTextBlock Style="{StaticResource XamlCodeRichTextBlockStyle}">
-                    <Paragraph>&lt;TextBlock Text="TextBlock with an offset ToolTip."/&gt;</Paragraph>
-                    <Paragraph TextIndent="12">&lt;ToolTipService.ToolTip/&gt;</Paragraph>
+                    <Paragraph>&lt;TextBlock Text="TextBlock with an offset ToolTip."&gt;</Paragraph>
+                    <Paragraph TextIndent="12">&lt;ToolTipService.ToolTip&gt;</Paragraph>
                     <Paragraph TextIndent="24">&lt;ToolTip Content="Offset ToolTip." HorizontalOffset="100" VerticalOffset="-80"/&gt;</Paragraph>
-                    <Paragraph TextIndent="12">&lt;/ToolTipService.ToolTip/&gt;</Paragraph>
+                    <Paragraph TextIndent="12">&lt;/ToolTipService.ToolTip&gt;</Paragraph>
                     <Paragraph>&lt;/TextBlock&gt;</Paragraph>
                 </RichTextBlock>
             </local:ControlExample.Xaml>

--- a/XamlControlsGallery/ControlPagesSampleCode/ListView/ListViewGroupedHeaderSample_xaml.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/ListView/ListViewGroupedHeaderSample_xaml.txt
@@ -1,0 +1,23 @@
+﻿<!-- In Page.Resources -->
+<CollectionViewSource x:Name="ContactsCVS" IsSourceGrouped="True" />
+
+<ListView 
+    ItemsSource="{x:Bind ContactsCVS.View, Mode=OneWay}"
+    ItemTemplate="{StaticResource ContactListViewTemplate}"
+    SelectionMode="Single">
+    <ListView.ItemsPanel>
+        <ItemsPanelTemplate>
+            <ItemsStackPanel AreStickyGroupHeadersEnabled="False" />
+        </ItemsPanelTemplate>
+    </ListView.ItemsPanel>
+
+    <ListView.GroupStyle>
+        <GroupStyle>
+            <GroupStyle.HeaderTemplate>
+                <DataTemplate x:DataType="local1:GroupInfoList">
+                    <TextBlock Text="{x:Bind Key}" Style="{ThemeResource TitleTextBlockStyle}"/>
+                </DataTemplate>
+            </GroupStyle.HeaderTemplate>
+        </GroupStyle>
+    </ListView.GroupStyle>
+</ListView>

--- a/XamlControlsGallery/ControlPagesSampleCode/ListView/ListViewStickyHeaderSample_xaml.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/ListView/ListViewStickyHeaderSample_xaml.txt
@@ -1,0 +1,17 @@
+﻿<!-- In Page.Resources -->
+<CollectionViewSource x:Name="ContactsCVS" IsSourceGrouped="True" />
+
+<ListView 
+    ItemsSource="{x:Bind ContactsCVS.View, Mode=OneWay}"
+    ItemTemplate="{StaticResource ContactListViewTemplate}"
+    SelectionMode="Single">
+    <ListView.GroupStyle>
+        <GroupStyle>
+            <GroupStyle.HeaderTemplate>
+                <DataTemplate x:DataType="local1:GroupInfoList">
+                    <TextBlock Text="{x:Bind Key}" Style="{ThemeResource TitleTextBlockStyle}"/>
+                </DataTemplate>
+            </GroupStyle.HeaderTemplate>
+        </GroupStyle>
+    </ListView.GroupStyle>
+</ListView>

--- a/XamlControlsGallery/XamlControlsGallery.csproj
+++ b/XamlControlsGallery/XamlControlsGallery.csproj
@@ -211,6 +211,8 @@
     <Content Include="ControlPagesSampleCode\Buttons\DropDown\DropDownButton_Simple.txt" />
     <Content Include="ControlPagesSampleCode\Buttons\SplitButton\SplitButtonSample1.txt" />
     <Content Include="ControlPagesSampleCode\Buttons\ToggleSplitButton\ToggleSplitButtonSample1.txt" />
+    <Content Include="ControlPagesSampleCode\ListView\ListViewGroupedHeaderSample_xaml.txt" />
+    <Content Include="ControlPagesSampleCode\ListView\ListViewStickyHeaderSample_xaml.txt" />
     <Content Include="ControlPagesSampleCode\MenuBar\MenuBarSample1.txt" />
     <Content Include="ControlPagesSampleCode\MenuBar\MenuBarSample2.txt" />
     <Content Include="ControlPagesSampleCode\NavigationView\NavigationViewSample5_cs.txt" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change fixes several syntax typos for sample markup related to incorrect closing tags. The fixed pages are ListView, ToolTip, CompactSizing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Further fixes towards #14 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
