### PR TITLE
Fixing crash caused by NavigationView sample

### DIFF
--- a/XamlControlsGallery/ControlPages/NavigationViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/NavigationViewPage.xaml.cs
@@ -73,11 +73,14 @@ namespace AppUIBasics.ControlPages
             else
             {
                 var selectedItem = (Microsoft.UI.Xaml.Controls.NavigationViewItem)args.SelectedItem;
-                string selectedItemTag = ((string)selectedItem.Tag);
-                sender.Header = "Sample Page " + selectedItemTag.Substring(selectedItemTag.Length - 1);
-                string pageName = "AppUIBasics.SamplePages." + selectedItemTag;
-                Type pageType = Type.GetType(pageName);
-                contentFrame.Navigate(pageType);
+                if (selectedItem != null)
+                {
+                    string selectedItemTag = ((string)selectedItem.Tag);
+                    sender.Header = "Sample Page " + selectedItemTag.Substring(selectedItemTag.Length - 1);
+                    string pageName = "AppUIBasics.SamplePages." + selectedItemTag;
+                    Type pageType = Type.GetType(pageName);
+                    contentFrame.Navigate(pageType);
+                }
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added a check to avoid trying to access NavigationViewItem components when the item is null.

## Description
<!--- Describe your changes in detail -->
NavigationView raises a SelectionChanged event when its PaneDisplayMode is updated. This event incorrectly reports that Settings is not selected. I opened a [Microsoft-ui-xaml issue](https://github.com/Microsoft/microsoft-ui-xaml/issues/148) to track this control bug.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Internal bug 19380715.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually verified

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
