### PR TITLE
Enable GridView sample options to be activated with Caps+Enter

### DIFF
--- a/XamlControlsGallery/ControlPages/GridViewPage.xaml
+++ b/XamlControlsGallery/ControlPages/GridViewPage.xaml
@@ -107,23 +107,23 @@
                     <StackPanel>
                         <TextBlock Margin="0,0,0,10" Text="ItemTemplate" />
                         <RadioButton
-                            Click="ItemTemplate_Click"
+                            Checked="ItemTemplate_Checked"
                             Content="Image overlay"
                             GroupName="Template"
                             IsChecked="True"
                             Tag="ImageOverlayTemplate" />
                         <RadioButton
-                            Click="ItemTemplate_Click"
+                            Checked="ItemTemplate_Checked"
                             Content="Icon/Text"
                             GroupName="Template"
                             Tag="IconTextTemplate" />
                         <RadioButton
-                            Click="ItemTemplate_Click"
+                            Checked="ItemTemplate_Checked"
                             Content="Image/Text"
                             GroupName="Template"
                             Tag="ImageTextTemplate" />
                         <RadioButton
-                            Click="ItemTemplate_Click"
+                            Checked="ItemTemplate_Checked"
                             Content="Text"
                             GroupName="Template"
                             Tag="TextTemplate" />

--- a/XamlControlsGallery/ControlPages/GridViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/GridViewPage.xaml.cs
@@ -34,11 +34,15 @@ namespace AppUIBasics.ControlPages
             Items = ControlInfoDataSource.Instance.Groups.Take(3).SelectMany(g => g.Items).ToList();
         }
 
-        private void ItemTemplate_Click(object sender, RoutedEventArgs e)
+        private void ItemTemplate_Checked(object sender, RoutedEventArgs e)
         {
-            var template = (sender as FrameworkElement).Tag.ToString();
-            Control1.ItemTemplate = (DataTemplate)this.Resources[template];
-            itemTemplate.Text = template;
+            var tag = (sender as FrameworkElement).Tag;
+            if (tag != null)
+            {
+                var template = tag.ToString();
+                Control1.ItemTemplate = (DataTemplate)this.Resources[template];
+                itemTemplate.Text = template;
+            }
         }
 
         private void Control1_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -94,5 +98,6 @@ namespace AppUIBasics.ControlPages
                 }
             }
         }
+
     }
 }

--- a/XamlControlsGallery/ControlPages/GridViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/GridViewPage.xaml.cs
@@ -98,6 +98,5 @@ namespace AppUIBasics.ControlPages
                 }
             }
         }
-
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updated GridView options to use Checked events instead of Click to allow for activation with automation.

## Description
<!--- Describe your changes in detail -->
The Click handlers need to be replaced with Checked handlers because those are expected to be triggered by automation peers too. The Checked/Unchecked events are the abstract ones that are universally called no matter which input is used. See how the Checked event is handled in the https://docs.microsoft.com/en-us/uwp/api/Windows.UI.Xaml.Controls.RadioButton help page.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Internal bug 19913251

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually verified

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
