### PR TITLE
Update to CalandarView language UI 

### DIFF
--- a/XamlControlsGallery/Common/LanguageList.cs
+++ b/XamlControlsGallery/Common/LanguageList.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AppUIBasics.Common
+{
+    class LanguageList
+    {
+        private List<Language> _languages;
+        public List<Language> Languages {
+            get { return _languages; }
+        }
+
+        public LanguageList()
+        {
+            if (_languages == null)
+            {
+                _languages = new List<Language>();
+            }
+
+            _languages.Add(new Language("English", "en"));
+            _languages.Add(new Language("Arabic", "ar"));
+            _languages.Add(new Language("Afrikaans", "af"));
+            _languages.Add(new Language("Albanian", "sq"));
+            _languages.Add(new Language("Amharic", "am"));
+            _languages.Add(new Language("Armenian", "hy"));
+            _languages.Add(new Language("Assamese", "as"));
+            _languages.Add(new Language("Azerbaijani", "az"));
+            _languages.Add(new Language("Basque ", "eu"));
+            _languages.Add(new Language("Belarusian", "be"));
+            _languages.Add(new Language("Bangla", "bn"));
+            _languages.Add(new Language("Bosnian", "bs"));
+            _languages.Add(new Language("Bulgarian", "bg"));
+            _languages.Add(new Language("Catalan", "ca"));
+            _languages.Add(new Language("Chinese (Simplified)", "zh"));
+            _languages.Add(new Language("Croatian", "hr"));
+            _languages.Add(new Language("Czech", "cs"));
+            _languages.Add(new Language("Danish", "da"));
+            _languages.Add(new Language("Dari", "prs"));
+            _languages.Add(new Language("Dutch", "nl"));
+            _languages.Add(new Language("Estonian", "et"));
+            _languages.Add(new Language("Filipino", "fil"));
+            _languages.Add(new Language("Finnish", "fi"));
+            _languages.Add(new Language("French ", "fr"));
+            _languages.Add(new Language("Galician", "gl"));
+            _languages.Add(new Language("Georgian", "ka"));
+            _languages.Add(new Language("German", "de"));
+            _languages.Add(new Language("Greek", "el"));
+            _languages.Add(new Language("Gujarati", "gu"));
+            _languages.Add(new Language("Hausa", "ha"));
+            _languages.Add(new Language("Hebrew", "he"));
+            _languages.Add(new Language("Hindi", "hi"));
+            _languages.Add(new Language("Hungarian", "hu"));
+            _languages.Add(new Language("Icelandic", "is"));
+            _languages.Add(new Language("Indonesian", "id"));
+            _languages.Add(new Language("Irish", "ga"));
+            _languages.Add(new Language("isiXhosa", "xh"));
+            _languages.Add(new Language("isiZulu", "zu"));
+            _languages.Add(new Language("Italian", "it"));
+            _languages.Add(new Language("Japanese ", "ja"));
+            _languages.Add(new Language("Kannada", "kn"));
+            _languages.Add(new Language("Kazakh", "kk"));
+            _languages.Add(new Language("Khmer", "km"));
+            _languages.Add(new Language("Kinyarwanda", "rw"));
+            _languages.Add(new Language("KiSwahili", "sw"));
+            _languages.Add(new Language("Konkani", "kok"));
+            _languages.Add(new Language("Korean", "ko"));
+            _languages.Add(new Language("Lao", "lo"));
+            _languages.Add(new Language("Latvian", "lv"));
+            _languages.Add(new Language("Lithuanian", "lt"));
+            _languages.Add(new Language("Luxembourgish", "lb"));
+            _languages.Add(new Language("Macedonian", "mk"));
+            _languages.Add(new Language("Malay", "ms"));
+            _languages.Add(new Language("Malayalam", "ml"));
+            _languages.Add(new Language("Maltese", "mt"));
+            _languages.Add(new Language("Maori ", "mi"));
+            _languages.Add(new Language("Marathi", "mr"));
+            _languages.Add(new Language("Nepali", "ne"));
+            _languages.Add(new Language("Norwegian", "nb"));
+            _languages.Add(new Language("Odia", "or"));
+            _languages.Add(new Language("Persian", "fa"));
+            _languages.Add(new Language("Polish", "pl"));
+            _languages.Add(new Language("Portuguese", "pt"));
+            _languages.Add(new Language("Punjabi", "pa"));
+            _languages.Add(new Language("Quechua", "quz"));
+            _languages.Add(new Language("Romanian", "ro"));
+            _languages.Add(new Language("Russian", "ru"));
+            _languages.Add(new Language("Serbian (Latin)", "sr"));
+            _languages.Add(new Language("Sesotho sa Leboa", "nso"));
+            _languages.Add(new Language("Setswana", "tn"));
+            _languages.Add(new Language("Sinhala", "si"));
+            _languages.Add(new Language("Slovak ", "sk"));
+            _languages.Add(new Language("Slovenian", "sl"));
+            _languages.Add(new Language("Spanish", "es"));
+            _languages.Add(new Language("Swedish", "sv"));
+            _languages.Add(new Language("Tamil", "ta"));
+            _languages.Add(new Language("Telugu", "te"));
+            _languages.Add(new Language("Thai", "th"));
+            _languages.Add(new Language("Tigrinya", "ti"));
+            _languages.Add(new Language("Turkish", "tr"));
+            _languages.Add(new Language("Ukrainian", "uk"));
+            _languages.Add(new Language("Urdu", "ur"));
+            _languages.Add(new Language("Uzbek (Latin)", "uz"));
+            _languages.Add(new Language("Vietnamese", "vi"));
+            _languages.Add(new Language("Welsh", "cy"));
+            _languages.Add(new Language("Wolof", "wo"));
+            
+        }
+
+        public class Language
+        {
+            public string Name { get; set; }
+            public string Code { get; set; }
+
+            public Language (string name, string code)
+            {
+                this.Name = name;
+                this.Code = code;
+            }
+        }
+    }
+}

--- a/XamlControlsGallery/ControlPages/CalendarViewPage.xaml
+++ b/XamlControlsGallery/ControlPages/CalendarViewPage.xaml
@@ -35,19 +35,10 @@
 
                     <ComboBox x:Name="calendarIdentifier" Margin="0,10,0,0" Header="CalendarIdentifier" Width="220" />
 
-                    <TextBox
-                        x:Name="language"
-                        Width="150"
-                        Margin="0,10,0,0"
-                        HorizontalAlignment="Left"
-                        Header="Language"
-                        Text="en-US" />
+                    <ComboBox x:Name="calendarLanguages" Header="Language" Margin="0,10,0,0" Width="220"
+                              DisplayMemberPath="Name" SelectedIndex="0" SelectedValuePath="Code"
+                              SelectionChanged="calendarLanguages_SelectionChanged"/>
 
-                    <Button
-                        x:Name="setLanguage"
-                        Margin="0,16,0,0"
-                        Click="setLanguage_Click"
-                        Content="Set Language" />
                 </StackPanel>
             </local:ControlExample.Options>
 

--- a/XamlControlsGallery/ControlPages/CalendarViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/CalendarViewPage.xaml.cs
@@ -15,6 +15,7 @@ using Windows.UI.Xaml.Navigation;
 using System.Reflection;
 using Windows.Globalization;
 using Windows.UI.Popups;
+using AppUIBasics.Common;
 
 // The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
 
@@ -45,6 +46,9 @@ namespace AppUIBasics.ControlPages
 
             calendarIdentifier.ItemsSource = calendarIdentifiers;
             calendarIdentifier.SelectedItem = CalendarIdentifiers.Gregorian;
+
+            var langs = new LanguageList();
+            calendarLanguages.ItemsSource = langs.Languages;
         }
 
         private void SelectionMode_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -56,15 +60,12 @@ namespace AppUIBasics.ControlPages
             }
         }
 
-        private async void setLanguage_Click(object sender, RoutedEventArgs e)
+        private void calendarLanguages_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if(Windows.Globalization.Language.IsWellFormed(language.Text))
+            string selectedLang = calendarLanguages.SelectedValue.ToString();
+            if (Windows.Globalization.Language.IsWellFormed(selectedLang))
             {
-                Control1.Language = language.Text;
-            }
-            else
-            {
-                await new MessageDialog("That language is not valid.  Please check the language and try again.").ShowAsync();
+                Control1.Language = selectedLang;
             }
         }
     }

--- a/XamlControlsGallery/XamlControlsGallery.csproj
+++ b/XamlControlsGallery/XamlControlsGallery.csproj
@@ -252,6 +252,7 @@
     <Compile Include="Common\ComboBoxItemToStringConverter.cs" />
     <Compile Include="Common\DeviceFamilyTrigger.cs" />
     <Compile Include="Common\DoubleToIntConverter.cs" />
+    <Compile Include="Common\LanguageList.cs" />
     <Compile Include="Common\MenuItemTemplateSelector.cs" />
     <Compile Include="Common\ShowAcrylicBehindHeaderConverter.cs" />
     <Compile Include="Common\ImageLoader.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Replaced free-form TextBox language entry with predefined language list available inside a (non-editable) ComboBox.

## Description
<!--- Describe your changes in detail -->
The predefined list of languages is copied from https://docs.microsoft.com/en-us/windows/uwp/publish/supported-languages. I chose to put English first with others in alphabetical order.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixed internal bug 19973652 by removing the need for error MessageDialog.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually verified

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
