### PR TITLE
Fix to text scaling and overflow on Reveal page

### DIFF
--- a/XamlControlsGallery/ControlPages/RevealPage.xaml
+++ b/XamlControlsGallery/ControlPages/RevealPage.xaml
@@ -20,7 +20,7 @@
                 <Grid BorderThickness="0,0,0,1" BorderBrush="{ThemeResource ButtonBackground}" Margin="0,10,10,10">
                     <TextBlock Margin="5" TextWrapping="WrapWholeWords" Text="Reveal is on by default for many of our controls. For those controls, no enabling of Reveal is required. Please see the guidance documention for a full list."/>
                 </Grid>
-                <CommandBar Width="350" OverflowButtonVisibility="Collapsed" DefaultLabelPosition="Right" HorizontalAlignment="Left">
+                <CommandBar OverflowButtonVisibility="Visible" DefaultLabelPosition="Right" HorizontalAlignment="Left">
                     <AppBarButton Icon="Admin" Label="Admin"/>
                     <AppBarButton Icon="AllApps" Label="All Apps"/>
                     <AppBarSeparator/>


### PR DESCRIPTION
CommandBar items were getting cut off in 200%+ text scaling.

## Description
Fixed the CommandBar to show the overflow button and to not have a fixed width so it will adapt better to text and window sizes.

## Motivation and Context
Internal bug 19231991.

## How Has This Been Tested?
At 200% text scaling and maximum text scaling as well as min and max window widths. All appear to work as intended now.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)