### PR TITLE
Updated DataGrid page to use TextBlock instead of RichTextBlock

### DIFF
--- a/XamlControlsGallery/ControlPages/DataGridPage.xaml
+++ b/XamlControlsGallery/ControlPages/DataGridPage.xaml
@@ -10,10 +10,12 @@
         <StackPanel Margin="0,12,0,0">
             <Image Source="https://github.com/MicrosoftDocs/WindowsCommunityToolkitDocs/raw/16ea181576ff06cd18b8b43d4a4394851fe2d0b7/docs/resources/images/Controls/DataGrid/DataGrid.gif" 
                    AutomationProperties.Name="Example of DataGrid in an app" />
-            <RichTextBlock TextWrapping="WrapWholeWords" Margin="0,12">
-                <Paragraph>The built-in column types include a text column, a check box column, and a template column for hosting custom content. The built-in row type includes a drop-down details section that you can use to display additional content below the cell values. </Paragraph>
-                <Paragraph Margin="0,8,0,0">The DataGrid control supports common table formatting options, such as alternating row backgrounds and foregrounds and the ability to show or hide headers, grid lines, and scroll bars. Additionally, the control provides several style and template properties that you can use to completely change the appearance of the control and its rows, columns, cells, and row or column headers.</Paragraph>
-            </RichTextBlock>
+            <TextBlock TextWrapping="WrapWholeWords" Margin="0,12,0,0">
+                The built-in column types include a text column, a check box column, and a template column for hosting custom content. The built-in row type includes a drop-down details section that you can use to display additional content below the cell values.
+            </TextBlock>
+            <TextBlock TextWrapping="WrapWholeWords" Margin="0,8,0,12">
+                The DataGrid control supports common table formatting options, such as alternating row backgrounds and foregrounds and the ability to show or hide headers, grid lines, and scroll bars. Additionally, the control provides several style and template properties that you can use to completely change the appearance of the control and its rows, columns, cells, and row or column headers.
+            </TextBlock>
 
             <TextBlock Margin="0,24,0,0" Text="DataGrid is included as a part of the Windows Community Toolkit." />
             <HyperlinkButton Margin="0,8,0,0" Content="Launch the Windows Community Toolkit Sample App" Click="LaunchToolkitButton_Click" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
It appears that RichTextBlocks do not respond well to the Win+Backspace shortcut while in caret browsing mode. This combination frequently causes the Gallery app to crash. Replacing RichTextBlocks with TextBlocks appears to prevent the crash from occurring.

I'm not able to repro this problem reliably in a stand-alone test app.

## Description
<!--- Describe your changes in detail -->
Replaced the RichTextBlock on DataGrid page with two TextBlock controls.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Internal bug 20036436

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually verified. Also compared before/after screenshots to make sure the change in controls did not result in any changes to layout visuals.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
