### PR TITLE
Custom focus

### DIFF
--- a/XamlControlsGallery/ItemPage.xaml
+++ b/XamlControlsGallery/ItemPage.xaml
@@ -105,11 +105,7 @@
         <!--  Content Region  -->
         <ScrollViewer
             x:Name="svPanel"
-            GotFocus="OnSvPanelGotFocus"
-            IsTabStop="True"
-            KeyDown="OnSvPanelKeyDown"
-            Loaded="OnSvPanelLoaded"
-            UseSystemFocusVisuals="False"
+
             VerticalScrollBarVisibility="Auto"
             VerticalScrollMode="Auto">
             <Grid x:Name="contentRoot" Padding="24,0,0,0" SizeChanged="OnContentRootSizeChanged">

--- a/XamlControlsGallery/ItemPage.xaml.cs
+++ b/XamlControlsGallery/ItemPage.xaml.cs
@@ -205,52 +205,6 @@ namespace AppUIBasics
             base.OnNavigatedFrom(e);
         }
 
-        private void OnSvPanelLoaded(object sender, RoutedEventArgs e)
-        {
-            svPanel.XYFocusDown = contentFrame.GetDescendantsOfType<Control>().FirstOrDefault(c => c.IsTabStop) ?? svPanel.GetDescendantsOfType<Control>().FirstOrDefault(c => c.IsTabStop);
-        }
-
-        private void OnSvPanelGotFocus(object sender, RoutedEventArgs e)
-        {
-            if (e.OriginalSource == sender && NavigationRootPage.Current.IsFocusSupported)
-            {
-                bool isElementFound = false;
-                var elements = contentFrame.GetDescendantsOfType<Control>().Where(c => c.IsTabStop);
-                foreach (var element in elements)
-                {
-                    Rect elementRect = element.TransformToVisual(svPanel).TransformBounds(new Rect(0.0, 0.0, element.ActualWidth, element.ActualHeight));
-                    Rect panelRect = new Rect(0.0, 70.0, svPanel.ActualWidth, svPanel.ActualHeight);
-
-                    if (elementRect.Top < panelRect.Bottom)
-                    {
-                        element.Focus(FocusState.Programmatic);
-                        isElementFound = true;
-                        break;
-                    }
-                }
-                if (!isElementFound)
-                {
-                    svPanel.UseSystemFocusVisuals = true;
-                }
-            }
-        }
-
-        private void OnSvPanelKeyDown(object sender, KeyRoutedEventArgs e)
-        {
-            if (e.Key == VirtualKey.Up)
-            {
-                var nextElement = FocusManager.FindNextElement(FocusNavigationDirection.Up);
-                if (nextElement.GetType() == typeof(Microsoft.UI.Xaml.Controls.NavigationViewItem))
-                {
-                    NavigationRootPage.Current.PageHeader.Focus(FocusState.Programmatic);
-                }
-                else
-                {
-                    FocusManager.TryMoveFocus(FocusNavigationDirection.Up);
-                }
-            }
-        }
-
         private void OnContentRootSizeChanged(object sender, SizeChangedEventArgs e)
         {
             string targetState = "NormalFrameContent";

--- a/XamlControlsGallery/ItemsPageBase.cs
+++ b/XamlControlsGallery/ItemsPageBase.cs
@@ -71,7 +71,7 @@ namespace AppUIBasics
             if (e.Key == VirtualKey.Up)
             {
                 var nextElement = FocusManager.FindNextElement(FocusNavigationDirection.Up);
-                if (nextElement.GetType() == typeof(NavigationViewItem))
+                if (nextElement != null && nextElement.GetType() == typeof(Microsoft.UI.Xaml.Controls.NavigationViewItem))
                 {
                     NavigationRootPage.Current.PageHeader.Focus(FocusState.Programmatic);
                 }

--- a/XamlControlsGallery/ItemsPageBase.cs
+++ b/XamlControlsGallery/ItemsPageBase.cs
@@ -71,7 +71,7 @@ namespace AppUIBasics
             if (e.Key == VirtualKey.Up)
             {
                 var nextElement = FocusManager.FindNextElement(FocusNavigationDirection.Up);
-                if (nextElement != null && nextElement.GetType() == typeof(Microsoft.UI.Xaml.Controls.NavigationViewItem))
+                if (nextElement?.GetType() == typeof(Microsoft.UI.Xaml.Controls.NavigationViewItem))
                 {
                     NavigationRootPage.Current.PageHeader.Focus(FocusState.Programmatic);
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Removing custom focus logic, which I believe to be intended to improve gamepad navigation.

## Description
<!--- Describe your changes in detail -->
The primary ScrollViewer was inadvertently trapping focus, prevent users from being able to Tab pas the first element. This also resulted in Tab and Shift+Tab showing different behavior. Removing three private methods (Loaded, GotFocus, KeyDown) responsible for unpredictable keyboard behavior.

Also updated if statement in another private KeyDown method to use MUXC instead of WUXC NavigationViewItem, and added null check.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
internal bug 19414657

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually verified with keyboard and gamepad

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
