### PR TITLE
Don't reuse treeview nodes across treeviews.

### DIFF
--- a/XamlControlsGallery/ControlPages/TreeViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/TreeViewPage.xaml.cs
@@ -23,8 +23,14 @@ namespace AppUIBasics.ControlPages
         {
             this.InitializeComponent();
             this.DataContext = this;
-            DataSource = GetData();          
+            DataSource = GetData();
 
+            InitializeSampleTreeView();
+            InitializeSampleTreeView2();
+        }
+
+        private void InitializeSampleTreeView()
+        {
             mux.TreeViewNode workFolder = new mux.TreeViewNode() { Content = "Work Documents" };
             workFolder.IsExpanded = true;
 
@@ -45,23 +51,39 @@ namespace AppUIBasics.ControlPages
             personalFolder.IsExpanded = true;
             personalFolder.Children.Add(remodelFolder);
 
+            sampleTreeView.RootNodes.Add(workFolder);
+            sampleTreeView.RootNodes.Add(personalFolder);
+        }
+        private void InitializeSampleTreeView2()
+        {
+            mux.TreeViewNode workFolder = new mux.TreeViewNode() { Content = "Work Documents" };
+            workFolder.IsExpanded = true;
+
+            workFolder.Children.Add(new mux.TreeViewNode() { Content = "XYZ Functional Spec" });
+            workFolder.Children.Add(new mux.TreeViewNode() { Content = "Feature Schedule" });
+            workFolder.Children.Add(new mux.TreeViewNode() { Content = "Overall Project Plan" });
+            workFolder.Children.Add(new mux.TreeViewNode() { Content = "Feature Resources Allocation" });
+
+            mux.TreeViewNode remodelFolder = new mux.TreeViewNode() { Content = "Home Remodel" };
+            remodelFolder.IsExpanded = true;
+
+            remodelFolder.Children.Add(new mux.TreeViewNode() { Content = "Contractor Contact Info" });
+            remodelFolder.Children.Add(new mux.TreeViewNode() { Content = "Paint Color Scheme" });
+            remodelFolder.Children.Add(new mux.TreeViewNode() { Content = "Flooring woodgrain type" });
+            remodelFolder.Children.Add(new mux.TreeViewNode() { Content = "Kitchen cabinet style" });
+
             personalFolder2 = new mux.TreeViewNode() { Content = "Personal Documents" };
             personalFolder2.IsExpanded = true;
             personalFolder2.Children.Add(remodelFolder);
 
-            sampleTreeView.RootNodes.Add(workFolder);
-            sampleTreeView.RootNodes.Add(personalFolder);
-
             sampleTreeView2.RootNodes.Add(workFolder);
             sampleTreeView2.RootNodes.Add(personalFolder2);
-
         }
 
         private void sampleTreeView_ItemInvoked(mux.TreeView sender, mux.TreeViewItemInvokedEventArgs args)
         {
             return;
         }
-            
         
         private ObservableCollection<ExplorerItem> GetData()
         {


### PR DESCRIPTION
we should not reuse the same TreeViewNodes across multiple treeviews. This causes weird behavior during drag and drop because the nodes were raise events that both treeviews were messing with and changing state on the nodes.

## Motivation and Context
When dragging and dropping, the dragged element is still in the previous location and the tree of nodes gets messed up. 
internal bug: https://microsoft.visualstudio.com/OS/_queries/edit/19973161/?triage=true

## How Has This Been Tested?
manually tested the treeview page and ensured that drag drop did not cause weird behavior.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
