### PR TITLE
Updated Image on CommandBarFlyout page to be accessible with keyboard

### DIFF
--- a/XamlControlsGallery/ControlPages/CommandBarFlyoutPage.xaml
+++ b/XamlControlsGallery/ControlPages/CommandBarFlyoutPage.xaml
@@ -6,8 +6,9 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:muxcontrols="using:Microsoft.UI.Xaml.Controls"
       mc:Ignorable="d">
+    
     <Page.Resources>
-        <muxcontrols:CommandBarFlyout Placement="Right" x:Name="CommandBarFlyout1" Closed="OnClosed">
+        <muxcontrols:CommandBarFlyout Placement="Right" x:Name="CommandBarFlyout1">
             <AppBarButton Label="Share" Icon="Share" Click="OnElementClicked" />
             <AppBarButton Label="Save" Icon="Save" Click="OnElementClicked" />
             <AppBarButton Label="Delete" Icon="Delete" Click="OnElementClicked" />
@@ -17,15 +18,16 @@
             </muxcontrols:CommandBarFlyout.SecondaryCommands>
         </muxcontrols:CommandBarFlyout>
     </Page.Resources>
+    
     <StackPanel>
         <local:ControlExample HeaderText="CommandBarFlyout for commands on an in-app object" XamlSource="CommandBarFlyout/CommandBarFlyoutSample1_xaml.txt"
                               CSharpSource="CommandBarFlyout/CommandBarFlyoutSample1_cs.txt">
             <StackPanel>
                 <TextBlock Text="Click or right click the image to open a CommandBarFlyout" />
-                <Border x:Name="myImageBorder" BorderBrush="Transparent" VerticalAlignment="Center" HorizontalAlignment="Center" BorderThickness="2">
-                    <Image x:Name="Image1" Height="300" Source="/Assets/SampleMedia/rainier.jpg" PointerPressed="Image_PointerPressed"
-                           PointerReleased="Image_PointerReleased" ContextFlyout="{x:Bind CommandBarFlyout1}"/>
-                </Border>
+                <Button x:Name="myImageButton" AutomationProperties.Name="mountain" Padding="0" Margin="0,12"
+                        Click="MyImageButton_Click" ContextRequested="MyImageButton_ContextRequested" >
+                    <Image x:Name="Image1" Height="300" Source="/Assets/SampleMedia/rainier.jpg"/>
+                </Button>
                 <TextBlock x:Name="SelectedOptionText" Text="" />
             </StackPanel>
         </local:ControlExample>

--- a/XamlControlsGallery/ControlPages/CommandBarFlyoutPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/CommandBarFlyoutPage.xaml.cs
@@ -9,49 +9,40 @@ namespace AppUIBasics.ControlPages
 {
     public sealed partial class CommandBarFlyoutPage : Page
     {
-        private bool wasLeftPointerPressed = false;
-
         public CommandBarFlyoutPage()
         {
             this.InitializeComponent();
-        }
-
-        public void OnClosed(object sender, object args)
-        {
-            myImageBorder.BorderBrush = new SolidColorBrush(Colors.Transparent);
-        }
-
-        public void Image_PointerPressed(object sender, PointerRoutedEventArgs args)
-        {
-            wasLeftPointerPressed = args.GetCurrentPoint(myImageBorder).Properties.IsLeftButtonPressed;
-        }
-
-        public void Image_PointerReleased(object sender, PointerRoutedEventArgs args)
-        {
-            myImageBorder.BorderBrush = new SolidColorBrush(Colors.Blue);
-
-            if (wasLeftPointerPressed)
-            {
-                if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 7))
-                {
-                    FlyoutShowOptions myOption = new FlyoutShowOptions();
-                    myOption.ShowMode = FlyoutShowMode.Transient;
-                    myOption.Placement = FlyoutPlacementMode.RightEdgeAlignedTop;
-                    CommandBarFlyout1.ShowAt(Image1, myOption);
-                }
-                else
-                {
-                    CommandBarFlyout1.ShowAt(Image1);
-                }
-                wasLeftPointerPressed = false;
-            }
-            args.Handled = true;
         }
 
         private void OnElementClicked(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
             // Do custom logic
             SelectedOptionText.Text = "You clicked: " + (sender as AppBarButton).Label;
+        }
+
+        private void ShowMenu()
+        {
+            if(ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 7))
+            {
+                FlyoutShowOptions myOption = new FlyoutShowOptions();
+                myOption.ShowMode = FlyoutShowMode.Transient;
+                myOption.Placement = FlyoutPlacementMode.RightEdgeAlignedTop;
+                CommandBarFlyout1.ShowAt(Image1, myOption);
+            }
+            else
+            {
+                CommandBarFlyout1.ShowAt(Image1);
+            }
+        }
+
+        private void MyImageButton_ContextRequested(Windows.UI.Xaml.UIElement sender, ContextRequestedEventArgs args)
+        {
+            ShowMenu();
+        }
+
+        private void MyImageButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            ShowMenu();
         }
     }
 }

--- a/XamlControlsGallery/ControlPagesSampleCode/CommandBarFlyout/CommandBarFlyoutSample1_cs.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/CommandBarFlyout/CommandBarFlyoutSample1_cs.txt
@@ -1,21 +1,16 @@
-﻿public void OnClosed(object sender, object args)
+﻿private void ShowMenu()
 {
-    myImageBorder.BorderBrush = new SolidColorBrush(Colors.Transparent);
+    FlyoutShowOptions myOption = new FlyoutShowOptions();
+    myOption.ShowMode = FlyoutShowMode.Transient;
+    CommandBarFlyout1.ShowAt(Image1, myOption);
 }
 
-public void Image_PointerPressed(object sender, PointerRoutedEventArgs args)
+private void MyImageButton_ContextRequested(Windows.UI.Xaml.UIElement sender, ContextRequestedEventArgs args)
 {
-    wasLeftPointerPressed = args.GetCurrentPoint(myImageBorder).Properties.IsLeftButtonPressed;
+    ShowMenu();
 }
 
-public void Image_PointerReleased(object sender, PointerRoutedEventArgs args)
+private void MyImageButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
 {
-    if (wasLeftPointerPressed)
-    {
-        myImageBorder.BorderBrush = new SolidColorBrush(Colors.Red);
-        FlyoutShowOptions myOption = new FlyoutShowOptions();
-        myOption.ShowMode = FlyoutShowMode.Transient;
-        CommandBarFlyout1.ShowAt(Image1, myOption);
-        wasLeftPointerPressed = false;
-    }
+    ShowMenu();
 }

--- a/XamlControlsGallery/ControlPagesSampleCode/CommandBarFlyout/CommandBarFlyoutSample1_xaml.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/CommandBarFlyout/CommandBarFlyoutSample1_xaml.txt
@@ -1,5 +1,5 @@
 ﻿<Page.Resources>
-    <muxcontrols:CommandBarFlyout Placement="Right" x:Name="CommandBarFlyout1"  Closed="OnClosed">
+    <muxcontrols:CommandBarFlyout Placement="Right" x:Name="CommandBarFlyout1">
         <AppBarButton x:Name="ShareButton1" Label="Share" Icon="Share" Click="OnElementClicked" />
         <AppBarButton x:Name="SaveButton1" Label="Save" Icon="Save" Click="OnElementClicked" />
         <AppBarButton x:Name="DeleteButton1" Label="Delete" Icon="Delete" Click="OnElementClicked" />
@@ -10,6 +10,7 @@
     </muxcontrols:CommandBarFlyout>
 </Page.Resources>
 
-<Border x:Name="myImageBorder" BorderBrush="Transparent" BorderThickness="2">
-    <Image x:Name="Image1" Width="200" Height="200" Source="/Assets/SampleMedia/rainier.jpg" PointerPressed="onMyPointerPressed" PointerReleased="OnMyPointerReleased" ContextFlyout="{x:Bind CommandBarFlyout1}"/>
-</Border>
+<Button x:Name="myImageButton" AutomationProperties.Name="mountain" Padding="0"
+    Click="MyImageButton_Click" ContextRequested="MyImageButton_ContextRequested" >
+    <Image x:Name="Image1" Height="300" Source="/Assets/SampleMedia/rainier.jpg"/>
+</Button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updated CommandBarFlyout page to use a Button instead of Border and cleaned up associated events. 

## Description
<!--- Describe your changes in detail -->
Neither Border nor Image accept keyboard focus, so this page was broken for that input device. By placing the image inside a Button, I got focus and Click events for free. There is one difference from the previous version of this page - the Button's border no longer changes color when the CommandBarFlyout is open. I chose to omit that feature because it violated HC colors - hard-coding color values does not respect user theme preferences.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Internal bug 19244959

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually verified

## Screenshots (if appropriate):
Rest:
![image](https://user-images.githubusercontent.com/13142665/51779782-411ff800-20be-11e9-89a2-b20bfc68e158.png)

Keyboard focus:
![image](https://user-images.githubusercontent.com/13142665/51779790-509f4100-20be-11e9-9666-445096678d46.png)

With CommandBarFlyout:
![image](https://user-images.githubusercontent.com/13142665/51779795-601e8a00-20be-11e9-8105-a67876586a60.png)




## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
