### PR TITLE
Fix editable ComboBox page to stop crashing at size = 8

### DIFF
--- a/XamlControlsGallery/ControlPages/ComboBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ComboBoxPage.xaml.cs
@@ -94,7 +94,12 @@ namespace AppUIBasics.ControlPages
 
         private void Combo3_TextSubmitted(ComboBox sender, ComboBoxTextSubmittedEventArgs args)
         {
-            if (double.TryParse(sender.Text, out double newValue) && newValue < 100 && newValue > 8)
+            bool isDouble = double.TryParse(sender.Text, out double newValue);
+
+            // Set the selected item if:
+            // - The value successfully parsed to double AND
+            // - The value is in the list of sizes OR is a custom value between 8 and 100
+            if (isDouble && (FontSizes.Contains(newValue) || (newValue < 100 && newValue > 8)))
             {
                 // Update the SelectedItem to the new value. 
                 sender.SelectedItem = newValue;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The original editable ComboBox logic had a bug when size = 8 because it was both inside the list of options but outside the range of 8-100 exclusive. 

The fix is to check if the value is in the list OR in the range of 8-100.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes internal bug 20255162.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual testing on Editable ComboBox page.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
