### PR TITLE
CommandBarFlyout's show modes

### DIFF
--- a/XamlControlsGallery/ControlPages/CommandBarFlyoutPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/CommandBarFlyoutPage.xaml.cs
@@ -36,8 +36,9 @@ namespace AppUIBasics.ControlPages
         }
 
         private void MyImageButton_ContextRequested(Windows.UI.Xaml.UIElement sender, ContextRequestedEventArgs args)
-        {            
-            ShowMenu((sender as Button).IsPointerOver);
+        {   
+            // always show a context menue in standard mode
+            ShowMenu(false);
         }
 
         private void MyImageButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)

--- a/XamlControlsGallery/ControlPages/CommandBarFlyoutPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/CommandBarFlyoutPage.xaml.cs
@@ -37,7 +37,7 @@ namespace AppUIBasics.ControlPages
 
         private void MyImageButton_ContextRequested(Windows.UI.Xaml.UIElement sender, ContextRequestedEventArgs args)
         {   
-            // always show a context menue in standard mode
+            // always show a context menu in standard mode
             ShowMenu(false);
         }
 

--- a/XamlControlsGallery/ControlPages/CommandBarFlyoutPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/CommandBarFlyoutPage.xaml.cs
@@ -20,12 +20,12 @@ namespace AppUIBasics.ControlPages
             SelectedOptionText.Text = "You clicked: " + (sender as AppBarButton).Label;
         }
 
-        private void ShowMenu()
+        private void ShowMenu(bool isTransient)
         {
             if(ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 7))
             {
                 FlyoutShowOptions myOption = new FlyoutShowOptions();
-                myOption.ShowMode = FlyoutShowMode.Transient;
+                myOption.ShowMode = isTransient ? FlyoutShowMode.Transient : FlyoutShowMode.Standard;
                 myOption.Placement = FlyoutPlacementMode.RightEdgeAlignedTop;
                 CommandBarFlyout1.ShowAt(Image1, myOption);
             }
@@ -36,13 +36,13 @@ namespace AppUIBasics.ControlPages
         }
 
         private void MyImageButton_ContextRequested(Windows.UI.Xaml.UIElement sender, ContextRequestedEventArgs args)
-        {
-            ShowMenu();
+        {            
+            ShowMenu((sender as Button).IsPointerOver);
         }
 
         private void MyImageButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
-            ShowMenu();
+            ShowMenu((sender as Button).IsPointerOver);
         }
     }
 }

--- a/XamlControlsGallery/ControlPagesSampleCode/CommandBarFlyout/CommandBarFlyoutSample1_cs.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/CommandBarFlyout/CommandBarFlyoutSample1_cs.txt
@@ -7,7 +7,7 @@
 
 private void MyImageButton_ContextRequested(Windows.UI.Xaml.UIElement sender, ContextRequestedEventArgs args)
 {
-    // always show a context menue in standard mode
+    // always show a context menu in standard mode
     ShowMenu(false);
 }
 

--- a/XamlControlsGallery/ControlPagesSampleCode/CommandBarFlyout/CommandBarFlyoutSample1_cs.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/CommandBarFlyout/CommandBarFlyoutSample1_cs.txt
@@ -1,16 +1,16 @@
-﻿private void ShowMenu()
+﻿private void ShowMenu(bool isTransient)
 {
     FlyoutShowOptions myOption = new FlyoutShowOptions();
-    myOption.ShowMode = FlyoutShowMode.Transient;
+    myOption.ShowMode = isTransient ? FlyoutShowMode.Transient : FlyoutShowMode.Standard;
     CommandBarFlyout1.ShowAt(Image1, myOption);
 }
 
 private void MyImageButton_ContextRequested(Windows.UI.Xaml.UIElement sender, ContextRequestedEventArgs args)
 {
-    ShowMenu();
+    ShowMenu((sender as Button).IsPointerOver);
 }
 
 private void MyImageButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
 {
-    ShowMenu();
+    ShowMenu((sender as Button).IsPointerOver);
 }

--- a/XamlControlsGallery/ControlPagesSampleCode/CommandBarFlyout/CommandBarFlyoutSample1_cs.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/CommandBarFlyout/CommandBarFlyoutSample1_cs.txt
@@ -7,7 +7,8 @@
 
 private void MyImageButton_ContextRequested(Windows.UI.Xaml.UIElement sender, ContextRequestedEventArgs args)
 {
-    ShowMenu((sender as Button).IsPointerOver);
+    // always show a context menue in standard mode
+    ShowMenu(false);
 }
 
 private void MyImageButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added check for whether pointer is over the button target to determine correct mode for CommandBarFlyout.

## Description
<!--- Describe your changes in detail -->
When invoked with keyboard, users must be able to navigate with keyboard within the CommandBarFlyout. When invoked with a pointer, users should see the more compact, transient CommandBarFlyout. Unfortunately, the Click and ContextRequested events don't have arguments detailing which input device was used to fire them. So I'm using pointer position (Buton's IsPointerOver property) as a proxy. Unfortunately this approach is not full-proof, nothing prevents users from moving their cursor over the button and pressing the Space key. But this seems better than always showing the expanded Standard flyout mode.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Internal bug 20144165

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually verified

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
