### PR TITLE
Fixed ListView sample code

### DIFF
--- a/XamlControlsGallery/ControlPages/ListViewPage.xaml
+++ b/XamlControlsGallery/ControlPages/ListViewPage.xaml
@@ -151,13 +151,13 @@
                 <x:String xml:space="preserve">
 &lt;CollectionViewSource x:Name="ContactsCVS" IsSourceGrouped="True"/&gt;
 
-&lt;ListView ItemsSource="{x:Bind Contacts}"/&gt;
-    &lt;ListView.ItemsPanel/&gt;
-        &lt;ItemsPanelTemplate/&gt;
+&lt;ListView ItemsSource="{x:Bind Contacts}"&gt;
+    &lt;ListView.ItemsPanel&gt;
+        &lt;ItemsPanelTemplate&gt;
             &lt;ItemsStackPanel AreStickyGroupHeadersEnabled="False"/&gt;
-        &lt;ItemsPanelTemplate /&gt;
-    &lt;ListView.ItemsPanel/&gt;
-&lt;ListView/&gt;
+        &lt;/ItemsPanelTemplate&gt;
+    &lt;/ListView.ItemsPanel&gt;
+&lt;/ListView&gt;
                 </x:String>
             </local:ControlExample.Xaml>
             
@@ -190,13 +190,13 @@
                 <x:String xml:space="preserve">
 &lt;CollectionViewSource x:Name="ContactsCVS" IsSourceGrouped="True"/&gt;
 
-&lt;ListView ItemsSource="{x:Bind Contacts}"/&gt;
-    &lt;ListView.ItemsPanel/&gt;
-        &lt;ItemsPanelTemplate/&gt;
+&lt;ListView ItemsSource="{x:Bind Contacts}"&gt;
+    &lt;ListView.ItemsPanel&gt;
+        &lt;ItemsPanelTemplate&gt;
             &lt;ItemsStackPanel AreStickyGroupHeadersEnabled="True"/&gt;
-        &lt;ItemsPanelTemplate /&gt;
-    &lt;ListView.ItemsPanel/&gt;
-&lt;ListView/&gt;
+        &lt;/ItemsPanelTemplate &gt;
+    &lt;/ListView.ItemsPanel&gt;
+&lt;/ListView&gt;
                 </x:String>
             </local:ControlExample.Xaml>
         </local:ControlExample>


### PR DESCRIPTION
This is how the ListView sample code looks like now:

```xml
<ListView ItemsSource="{x:Bind Contacts}"/>
   <ListView.ItemsPanel/>
      <ItemsPanelTemplate/>
         <ItemsStackPanel AreStickyGroupHeadersEnabled="False"/>
      <ItemsPanelTemplate />
   <ListView.ItemsPanel/>
<ListView/>
```
It is obviously invalid XAML because all the tags are self closing, so I moved the slashes back where they belong:

```xml
<ListView ItemsSource="{x:Bind Contacts}">
   <ListView.ItemsPanel>
      <ItemsPanelTemplate>
         <ItemsStackPanel AreStickyGroupHeadersEnabled="False"/>
      </ItemsPanelTemplate >
   </ListView.ItemsPanel>
</ListView>
```

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
