### PR TITLE
Fix AutoSuggestBox flicker

### DIFF
--- a/XamlControlsGallery/ControlPages/AutoSuggestBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AutoSuggestBoxPage.xaml.cs
@@ -26,12 +26,8 @@ namespace AppUIBasics.ControlPages
     /// </summary>
     public sealed partial class AutoSuggestBoxPage : Page
     {
-        public ObservableCollection<string> Suggestions { get; private set; }
-
         public AutoSuggestBoxPage()
         {
-            this.Suggestions = new ObservableCollection<string>();
-
             this.InitializeComponent();
         }
 
@@ -39,11 +35,13 @@ namespace AppUIBasics.ControlPages
         {
             if (args.Reason == AutoSuggestionBoxTextChangeReason.UserInput)
             {
-                Suggestions.Clear();
-                Suggestions.Add(sender.Text + "1");
-                Suggestions.Add(sender.Text + "2");
+                List<string> suggestions = new List<string>()
+                {
+                    sender.Text + "1",
+                    sender.Text + "2"
+                };
+                Control1.ItemsSource = suggestions;
             }
-            Control1.ItemsSource = Suggestions;
         }
         private void AutoSuggestBox_SuggestionChosen(AutoSuggestBox sender, AutoSuggestBoxSuggestionChosenEventArgs args)
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix a flicker in AutoSuggestBox when updating searches.

We were using ObservableCollection before, clearing the collection will close the suggestion list, adding new results into it will open the list again, which looks like a "flicker".

Creating a new list for each search now to avoid clearing the collection.
## Motivation and Context
https://microsoft.visualstudio.com/OS/_workitems/edit/20495197

## How Has This Been Tested?
Manually tested

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
