### PR TITLE
Updated colors used by RichEditBox custom editor

### DIFF
--- a/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml
+++ b/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml
@@ -21,7 +21,7 @@
     mc:Ignorable="d">
 
     <StackPanel>
-
+        
         <local:ControlExample HeaderText="A simple text editor using RichEditBox." HorizontalContentAlignment="Stretch" VerticalAlignment="Top">
             <RichEditBox AutomationProperties.Name="simple text editor"/>
             <local:ControlExample.Xaml>
@@ -171,7 +171,8 @@
                 <RichEditBox x:Name="editor" Height="200" AutomationProperties.Name="Custom editor"
                              RelativePanel.Below="openFileButton" 
                              RelativePanel.AlignLeftWithPanel="True" 
-                             RelativePanel.AlignRightWithPanel="True" />
+                             RelativePanel.AlignRightWithPanel="True" 
+                             GotFocus="Editor_GotFocus"/>
                 <StackPanel Orientation="Horizontal" 
                             RelativePanel.Below="editor" 
                             RelativePanel.AlignLeftWith="editor" 

--- a/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
@@ -18,6 +18,7 @@ using Windows.UI.Text;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
 
 namespace AppUIBasics.ControlPages
 {
@@ -124,13 +125,17 @@ namespace AppUIBasics.ControlPages
         {
             FindBoxRemoveHighlights();
 
+            Color highlightBackgroundColor = (Color)App.Current.Resources["SystemColorHighlightColor"];
+            Color highlightForegroundColor = (Color)App.Current.Resources["SystemColorHighlightTextColor"];
+
             string textToFind = findBox.Text;
             if (textToFind != null)
             {
                 ITextRange searchRange = editor.Document.GetRange(0, 0);
                 while (searchRange.FindText(textToFind, TextConstants.MaxUnitCount, FindOptions.None) > 0)
                 {
-                    searchRange.CharacterFormat.BackgroundColor = Colors.Yellow;
+                    searchRange.CharacterFormat.BackgroundColor = highlightBackgroundColor;
+                    searchRange.CharacterFormat.ForegroundColor = highlightForegroundColor;
                 }
             }
         }
@@ -138,7 +143,25 @@ namespace AppUIBasics.ControlPages
         private void FindBoxRemoveHighlights()
         {
             ITextRange documentRange = editor.Document.GetRange(0, TextConstants.MaxUnitCount);
-            documentRange.CharacterFormat.BackgroundColor = Colors.Transparent;
+            SolidColorBrush defaultBackground = editor.Background as SolidColorBrush;
+            SolidColorBrush defaultForeground = editor.Foreground as SolidColorBrush;
+
+            documentRange.CharacterFormat.BackgroundColor = defaultBackground.Color;
+            documentRange.CharacterFormat.ForegroundColor = defaultForeground.Color;
+        }
+
+        private void Editor_GotFocus(object sender, RoutedEventArgs e)
+        {
+            // reset colors to correct defaults for Focused state
+            ITextRange documentRange = editor.Document.GetRange(0, TextConstants.MaxUnitCount);
+            SolidColorBrush background = (SolidColorBrush)App.Current.Resources["TextControlBackgroundFocused"];
+            SolidColorBrush foreground = (SolidColorBrush)App.Current.Resources["TextControlForegroundFocused"];
+
+            if (background != null && foreground != null)
+            {
+                documentRange.CharacterFormat.BackgroundColor = background.Color;
+                documentRange.CharacterFormat.ForegroundColor = foreground.Color;
+            }
         }
 
         private void Page_SizeChanged(object sender, SizeChangedEventArgs e)
@@ -169,6 +192,6 @@ namespace AppUIBasics.ControlPages
             {
                 REBCustom.ContextFlyout.Opening -= ContextFlyout_Opening;
             }
-        }
+        } 
     }
 }

--- a/XamlControlsGallery/ControlPagesSampleCode/Text/RichEditBox/RichEditBoxSample3_cs.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/Text/RichEditBox/RichEditBoxSample3_cs.txt
@@ -84,13 +84,17 @@ private void FindBoxHighlightMatches()
 {
     FindBoxRemoveHighlights();
 
+    Color highlightBackgroundColor = (Color)App.Current.Resources["SystemColorHighlightColor"];
+    Color highlightForegroundColor = (Color)App.Current.Resources["SystemColorHighlightTextColor"];
+
     string textToFind = findBox.Text;
     if (textToFind != null)
     {
         ITextRange searchRange = editor.Document.GetRange(0, 0);
         while (searchRange.FindText(textToFind, TextConstants.MaxUnitCount, FindOptions.None) > 0)
         {
-            searchRange.CharacterFormat.BackgroundColor = Colors.Yellow;
+            searchRange.CharacterFormat.BackgroundColor = highlightBackgroundColor;
+            searchRange.CharacterFormat.ForegroundColor = highlightForegroundColor;
         }
     }
 }
@@ -98,5 +102,23 @@ private void FindBoxHighlightMatches()
 private void FindBoxRemoveHighlights()
 {
     ITextRange documentRange = editor.Document.GetRange(0, TextConstants.MaxUnitCount);
-    documentRange.CharacterFormat.BackgroundColor = Colors.Transparent;
+    SolidColorBrush defaultBackground = editor.Background as SolidColorBrush;
+    SolidColorBrush defaultForeground = editor.Foreground as SolidColorBrush;
+
+    documentRange.CharacterFormat.BackgroundColor = defaultBackground.Color;
+    documentRange.CharacterFormat.ForegroundColor = defaultForeground.Color;
+}
+
+private void Editor_GotFocus(object sender, RoutedEventArgs e)
+{
+    // reset colors to correct defaults for Focused state
+    ITextRange documentRange = editor.Document.GetRange(0, TextConstants.MaxUnitCount);
+    SolidColorBrush background = (SolidColorBrush)App.Current.Resources["TextControlBackgroundFocused"];
+    SolidColorBrush foreground = (SolidColorBrush)App.Current.Resources["TextControlForegroundFocused"];
+
+    if (background != null && foreground != null)
+    {
+        documentRange.CharacterFormat.BackgroundColor = background.Color;
+        documentRange.CharacterFormat.ForegroundColor = foreground.Color;
+    }
 }

--- a/XamlControlsGallery/ControlPagesSampleCode/Text/RichEditBox/RichEditBoxSample3_xaml.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/Text/RichEditBox/RichEditBoxSample3_xaml.txt
@@ -103,7 +103,8 @@
     <RichEditBox x:Name="editor" Height="200" 
                  RelativePanel.Below="openFileButton" 
                  RelativePanel.AlignLeftWithPanel="True" 
-                 RelativePanel.AlignRightWithPanel="True" />
+                 RelativePanel.AlignRightWithPanel="True"
+                 GotFocus="Editor_GotFocus" />
     <StackPanel Orientation="Horizontal" 
                 RelativePanel.Below="editor" 
                 RelativePanel.AlignLeftWith="editor" 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updated the highlight colors and default focused/unfocused colors used by the "custom editor" sample on RichEditBoxPage.

## Description
<!--- Describe your changes in detail -->
When searching for a substring, the sample now draws with the user's accent color as the search highlight in light/dark theme, and with the text selection background color in HC. The foreground color also gets updated to complement the highlight background and remain legible. (Highlighting in yellow on dark theme, which draws text in white, was not legible.) The code also resets both background and foreground color when the search is cleared, ensuring appropriate colors for the theme and state (focused/unfocused) are drawn.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Internal bug 20388743

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually verified in light, dark, and HC

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
