### PR TITLE
Remove Ctrl+E shortcut

### DIFF
--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml
@@ -83,10 +83,7 @@
                     QueryIcon="Find"
                     QuerySubmitted="OnControlsSearchBoxQuerySubmitted"
                     RequestedTheme="Light"
-                    TextChanged="OnControlsSearchBoxTextChanged" >
-                    <AutoSuggestBox.KeyboardAccelerators>
-                        <KeyboardAccelerator Invoked="KeyboardAccelerator_Invoked" Key="E" Modifiers="Control"/>
-                    </AutoSuggestBox.KeyboardAccelerators>
+                    TextChanged="OnControlsSearchBoxTextChanged">
                 </AutoSuggestBox>
             </mux:NavigationView.AutoSuggestBox>
 

--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
@@ -265,11 +265,6 @@ namespace AppUIBasics
             }
         }
 
-        private void KeyboardAccelerator_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
-        {
-            controlsSearchBox.Focus(FocusState.Keyboard);
-        }
-
         private void NavigationViewControl_PaneClosing(Microsoft.UI.Xaml.Controls.NavigationView sender, Microsoft.UI.Xaml.Controls.NavigationViewPaneClosingEventArgs args)
         {
             AppTitle.Visibility = Visibility.Collapsed;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Temporarily removing the app-wide search KeyboardAccelerator code.

## Description
<!--- Describe your changes in detail -->
The use of this keyboard accelerator is causing unexpected behavior on the search results page. After the shortcut is invoked, the Pivot control showing search results begins to trap the Tab key and prevents users from moving focus out of its headers. 

This fix removes the Ctrl+E keyboard accelerator, allowing us more time to investigate the problem and provide the correct solution. I have opened a new [internal bug](https://microsoft.visualstudio.com/OS/_workitems/edit/20642466) to track this.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Internal bug 20594924

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually verified

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
