### PR TITLE
Acrylic Luminosity Sample

### DIFF
--- a/XamlControlsGallery/ControlPages/AcrylicPage.xaml
+++ b/XamlControlsGallery/ControlPages/AcrylicPage.xaml
@@ -4,6 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:AppUIBasics"
     xmlns:media="using:Windows.UI.Xaml.Media"
+    xmlns:preview="using:Microsoft.UI.Xaml.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
@@ -13,6 +14,7 @@
                 <ResourceDictionary x:Key="Default">
                     <media:AcrylicBrush x:Key="CustomAcrylicInAppBrush" BackgroundSource="Backdrop" TintOpacity="0.8" TintColor="Black" FallbackColor="Green"/>
                     <media:AcrylicBrush x:Key="CustomAcrylicBackgroundBrush" BackgroundSource="HostBackdrop" TintOpacity="0.8" TintColor="Black" FallbackColor="Green"/>
+                    <media:AcrylicBrush x:Key="CustomAcrylicInAppLuminosity" BackgroundSource="Backdrop" TintLuminosityOpacity="0.8" TintOpacity="0.8" TintColor="SkyBlue" FallbackColor="SkyBlue"/>
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
 
@@ -194,6 +196,46 @@
                 <local:ControlExampleSubstitution Key="OpacitySlider" Value="{x:Bind OpacitySlider.Value, Mode=OneWay}"/>
                 <local:ControlExampleSubstitution Key="TintColor" Value="{x:Bind ColorSelector.SelectedItem, Mode=OneWay}"/>
                 <local:ControlExampleSubstitution Key="FallbackColor" Value="{x:Bind FallbackColorSelector.SelectedItem, Mode=OneWay}"/>
+            </local:ControlExample.Substitutions>
+        </local:ControlExample>
+        <local:ControlExample x:Name="Example5" HeaderText="Luminosity with in-app Acrylic.">
+            <local:ControlExample.Example>
+                <Grid x:Name="Example5Grid" MinWidth="650" MinHeight="200">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="250"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid>
+                        <Rectangle Fill="Aqua" Height="200" Width="100" HorizontalAlignment="Left" VerticalAlignment="Top"/>
+                        <Ellipse Fill="Magenta" Height="150" Width="150" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        <Rectangle Fill="Yellow" Height="100" Width="80" HorizontalAlignment="Right" VerticalAlignment="Bottom"/>
+                    </Grid>
+                    <Rectangle x:Name="CustomAcrylicShapeLumin" Margin="12" Fill="{ThemeResource CustomAcrylicInAppLuminosity}"/>
+                </Grid>
+            </local:ControlExample.Example>
+            <local:ControlExample.Options>
+                <StackPanel>
+                    <TextBlock Text="Tint Opacity :" Margin="0,0,0,12"/>
+                    <Slider x:Name="OpacitySliderLumin" ValueChanged="Slider_ValueChanged" Minimum="0" Maximum="1" Width="200" SmallChange="0.01" StepFrequency="0.01" 
+                            HorizontalAlignment="Left" IsFocusEngagementEnabled="False" AutomationProperties.Name="tint opacity"/>
+                    <TextBlock Text="Tint Luminosity Opacity :" Margin="0,0,0,12"/>
+                    <Slider x:Name="LuminositySlider" ValueChanged="LuminositySlider_ValueChanged" Minimum="0" Maximum="1" Width="200" SmallChange="0.01" StepFrequency="0.01" 
+                            HorizontalAlignment="Left" IsFocusEngagementEnabled="False" AutomationProperties.Name="tint luminosity"/>
+                </StackPanel>
+            </local:ControlExample.Options>
+            <local:ControlExample.Xaml>
+                <x:String xml:space="preserve">
+&lt;Rectangle Fill="{ThemeResource CustomAcrylicInAppLuminosity}" /&gt;
+
+&lt;ResourceDictionary x:Key="Default"&gt;
+    &lt;media:AcrylicBrush x:Key="CustomAcrylicBrush" BackgroundSource="Backdrop"
+            TintOpacity="$(OpacitySlider)" TintLuminosityOpacity="$(TintLuminositySlider)" TintColor="SkyBlue" FallbackColor="SkyBlue" /&gt;
+&lt;/ResourceDictionary&gt;
+</x:String>
+            </local:ControlExample.Xaml>
+            <local:ControlExample.Substitutions>
+                <local:ControlExampleSubstitution Key="OpacitySlider" Value="{x:Bind OpacitySliderLumin.Value, Mode=OneWay}"/>
+                <local:ControlExampleSubstitution Key="TintLuminositySlider" Value="{x:Bind LuminositySlider.Value, Mode=OneWay}"/>
             </local:ControlExample.Substitutions>
         </local:ControlExample>
     </StackPanel>

--- a/XamlControlsGallery/ControlPages/AcrylicPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AcrylicPage.xaml.cs
@@ -24,12 +24,17 @@ namespace AppUIBasics.ControlPages
         {
             ColorSelector.SelectedIndex = ColorSelectorInApp.SelectedIndex = 0;
             FallbackColorSelector.SelectedIndex = FallbackColorSelectorInApp.SelectedIndex = 0;
-            OpacitySlider.Value = OpacitySliderInApp.Value = 0.8;
+            OpacitySlider.Value = OpacitySliderInApp.Value = OpacitySliderLumin.Value = 0.8;
+            LuminositySlider.Value = 0.8;
         }
 
         private void Slider_ValueChanged(object sender, RangeBaseValueChangedEventArgs e)
         {
             Rectangle shape = (sender == OpacitySliderInApp) ? CustomAcrylicShapeInApp : CustomAcrylicShape;
+
+            if (sender == OpacitySliderLumin)
+                shape = CustomAcrylicShapeLumin;
+
             ((AcrylicBrush)shape.Fill).TintOpacity = e.NewValue;
         }
 
@@ -43,6 +48,12 @@ namespace AppUIBasics.ControlPages
         {
             Rectangle shape = (sender == FallbackColorSelectorInApp) ? CustomAcrylicShapeInApp : CustomAcrylicShape;
             ((AcrylicBrush)shape.Fill).FallbackColor = ((SolidColorBrush)e.AddedItems.First()).Color;
+        }
+
+        private void LuminositySlider_ValueChanged(object sender, RangeBaseValueChangedEventArgs e)
+        {
+            Rectangle shape = CustomAcrylicShapeLumin;
+            ((AcrylicBrush)shape.Fill).TintLuminosityOpacity = e.NewValue;
         }
     }
 }

--- a/XamlControlsGallery/XamlControlsGallery.csproj
+++ b/XamlControlsGallery/XamlControlsGallery.csproj
@@ -10,8 +10,8 @@
     <AssemblyName>AppUIBasics</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.17134.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion>10.0.18843.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <FileAlignment>512</FileAlignment>


### PR DESCRIPTION
New 19H1 feature is the Acrylic luminosity - this PR is to add a small demo of that property to the Acrylic page.

## Description
Added a sections after the last sample on the Acrylic page with a tint opacity and luminosity opacity slider that updates the acrylic surface live to show you how the new luminosity property works in conjunction with the tint opacity property.

## Motivation and Context
The main reason why the luminosity opacity property was introduced was to improve shadow performance by removing the need for the shadow to be "cut out" with the shape of the elevated surface. Luminosity when raise and in balance with the tint opacity can almost completely mask the color black from shapes that are behind the Acrylic surface.

## How Has This Been Tested?
- Multiple screens
- Min and max window sizes
- Min and max tint and luminosity values
- Light + dark theme
- High contrast

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
