### PR TITLE
Fix InkCanvas high contrast issue

### DIFF
--- a/XamlControlsGallery/ControlPages/InkCanvasPage.xaml
+++ b/XamlControlsGallery/ControlPages/InkCanvasPage.xaml
@@ -4,9 +4,9 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d">
     <StackPanel>
         <local:ControlExample x:Name="Example1" HeaderText="A basic ink canvas.">
-            <Border Background="White" Width="300" Height="300" BorderBrush="Gray" BorderThickness="1">
+            <Grid Background="{ThemeResource SystemControlBackgroundChromeWhiteBrush}" Width="300" Height="300" BorderBrush="Gray" BorderThickness="1">
                 <InkCanvas x:Name="Control1" />
-            </Border>
+            </Grid>
 
             <local:ControlExample.Options>
                 <StackPanel Width="180">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Previously, the InkCanvas was placed on a panel that had a hardcoded white background, which broke high contrast. The fix is to use a dynamically updating theme brush. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Internal bug 19620306.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual verification

## Screenshots (if appropriate):
Before
![Broken high contrast ink canvas](https://user-images.githubusercontent.com/25991996/53447796-d159a180-39ca-11e9-80c6-633e5d0ab45a.png)

After
![Fixed high contrast ink canvas](https://user-images.githubusercontent.com/25991996/53447814-d9194600-39ca-11e9-93f2-3f7c389cd721.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
