### PR TITLE
Remove setting PlaceholderForeground explicitly in App.xaml.

### DIFF
--- a/XamlControlsGallery/App.xaml
+++ b/XamlControlsGallery/App.xaml
@@ -72,14 +72,6 @@
                 <Setter Property="HorizontalContentAlignment" Value="Stretch" />
             </Style>
 
-            <Style TargetType="TextBox">
-                <Setter Property="PlaceholderForeground" Value="{ThemeResource TextControlPlaceholderForeground}" />
-            </Style>
-
-            <Style TargetType="ComboBox">
-                <Setter Property="PlaceholderForeground" Value="{ThemeResource ComboBoxPlaceHolderForeground}" />
-            </Style>
-
             <Style x:Key="CustomAutoSuggestBoxTextBoxStyle" TargetType="TextBox">
                 <Setter Property="MinWidth" Value="{ThemeResource TextControlThemeMinWidth}" />
                 <Setter Property="MinHeight" Value="{ThemeResource TextControlThemeMinHeight}" />


### PR DESCRIPTION
Remove setting PlaceholderForeground explicitly in App.xaml.

## Description
There is a product bug 19027035 which can be partially blamed on the Control Gallery app since it is used by tester to generate that bug.
Part of the bug description: Hint text should be visible in the focused TextBox in dark theme.
Debugging the Control Gallery app, I realized PlaceholderForeground  property is set explicitly in App.xaml for TextBox and ComboBox style, and it is causing trouble for focused visual state. 

## Motivation and Context
Internal bug 19027035 

##How Has This Been Tested?
Manually verified.

This is my first pull request for XAML Control Gallery , please let me know if I am missing anything.