### PR TITLE
Fix Image URI for AnimatedVisualPlayer.FallbackContent

### DIFF
--- a/XamlControlsGallery/ControlPages/AnimatedVisualPlayerPage.xaml
+++ b/XamlControlsGallery/ControlPages/AnimatedVisualPlayerPage.xaml
@@ -44,7 +44,7 @@
                             <!-- Fallback since Lottie-Windows is only supported on OS version 17763 and above -->
                             <muxcontrols:AnimatedVisualPlayer.FallbackContent>
                                 <DataTemplate>
-                                    <Image Source="Assets/LottieLogo1.png"/>
+                                    <Image Source="/Assets/LottieLogo1.png"/>
                                 </DataTemplate>
                             </muxcontrols:AnimatedVisualPlayer.FallbackContent>
                         </muxcontrols:AnimatedVisualPlayer>


### PR DESCRIPTION
## Description
Image URI on AnimatedVisualPlayer page was incorrect.

## Motivation and Context
Fixes issue where AnimatedVisualPlayer's FallbackContent doesn't show static fallback image.

## How Has This Been Tested?
locally on 17763

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
