### PR TITLE
Remove ContentLink RichEditBox sample: creating new ContentLink not w…

### DIFF
--- a/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml
+++ b/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml
@@ -31,23 +31,6 @@
             </local:ControlExample.Xaml>
         </local:ControlExample>
 
-        <local:ControlExample HeaderText="RichEditBox with ContentLinks enabled."
-                              MinimumUniversalAPIContract="6"
-                              XamlSource="Text\RichEditBox\RichEditBoxSample2_xaml.txt"
-                              HorizontalContentAlignment="Stretch" VerticalAlignment="Top">
-            <StackPanel>
-                <TextBlock Margin="0,0,0,10" Text="Prefix an entry with an at-sign (@) symbol to see a list of people and place suggestions that matches the entry." TextWrapping="WrapWholeWords"/>
-                <RichEditBox Height="200" AutomationProperties.Name="Editor with content links">
-                    <contract6Present:RichEditBox.ContentLinkProviders>
-                        <contract6Present:ContentLinkProviderCollection>
-                            <contract6Present:ContactContentLinkProvider/>
-                            <contract6Present:PlaceContentLinkProvider/>
-                        </contract6Present:ContentLinkProviderCollection>
-                    </contract6Present:RichEditBox.ContentLinkProviders>
-                </RichEditBox>
-            </StackPanel>
-        </local:ControlExample>
-      
         <local:ControlExample HeaderText="Customizing RichEditBox's CommandBarFlyout - Adding 'Share'" 
                               XamlSource="Text\RichEditBox\RichEditBoxSample4_Xaml.txt"
                               CSharpSource="Text\RichEditBox\RichEditBoxSample4_cs.txt"

--- a/XamlControlsGallery/ControlPagesSampleCode/Text/RichEditBox/RichEditBoxSample2_xaml.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/Text/RichEditBox/RichEditBoxSample2_xaml.txt
@@ -1,8 +1,0 @@
-﻿<RichEditBox AutomationProperties.Name="Editor with content links" Height="200">
-    <RichEditBox.ContentLinkProviders>
-        <ContentLinkProviderCollection>
-            <ContactContentLinkProvider/>
-            <PlaceContentLinkProvider/>
-        </ContentLinkProviderCollection>
-    </RichEditBox.ContentLinkProviders>
-</RichEditBox>

--- a/XamlControlsGallery/XamlControlsGallery.csproj
+++ b/XamlControlsGallery/XamlControlsGallery.csproj
@@ -224,7 +224,6 @@
     <Content Include="ControlPagesSampleCode\NavigationView\NavigationViewSample4_cs.txt" />
     <Content Include="ControlPagesSampleCode\NavigationView\NavigationViewSample4_xaml.txt" />
     <Content Include="ControlPagesSampleCode\NavigationView\NavigationViewSample6.txt" />
-    <Content Include="ControlPagesSampleCode\Text\RichEditBox\RichEditBoxSample2_xaml.txt" />
     <Content Include="ControlPagesSampleCode\Text\RichEditBox\RichEditBoxSample3_cs.txt" />
     <Content Include="ControlPagesSampleCode\Text\RichEditBox\RichEditBoxSample3_xaml.txt" />
     <Content Include="ControlPagesSampleCode\Text\RichEditBox\RichEditBoxSample4_xaml.txt" />


### PR DESCRIPTION
Remove ContentLink RichEditBox sample
## Description
InputApp is broken and it won't show up after user hit "@" in RichEditBox, internal bug: 20189381
## Motivation and Context
Since inserting new ContentLink part of the feature is broken in latest OS, we should remove it from the sample app for now, while figuring out what to do with this feature in next release.

## How Has This Been Tested?
Manually tested.
