### PR TITLE
Fixing a bug with ContextMenuFlyout of the StandardUICommand sample.

### DIFF
--- a/XamlControlsGallery/ControlPages/StandardUICommandPage.xaml
+++ b/XamlControlsGallery/ControlPages/StandardUICommandPage.xaml
@@ -16,7 +16,7 @@
             <Setter Property="BorderThickness" Value="0"/>
         </Style>
     </Page.Resources>
-
+    
     <StackPanel>
         <local:ControlExample HeaderText="Exposing a command in multiple controls using StandardUICommand"
                               XamlSource="StandardUICommand\StandardUICommandSample1_xaml.txt"
@@ -55,15 +55,10 @@
                     </muxcontrols:MenuBarItem>
                 </muxcontrols:MenuBar>
 
-                <ListView x:Name="ListViewRight" Grid.Row="2" Height="500" Loaded="ListView_Loaded" IsItemClickEnabled="True" SelectionMode="Single" SelectionChanged="ListView_SelectionChanged" ItemContainerStyle="{StaticResource HorizontalSwipe}">
+                <ListView x:Name="ListViewRight" Grid.Row="2" Height="500" Loaded="ListView_Loaded" ContainerContentChanging="ListViewRight_ContainerContentChanging" IsItemClickEnabled="True" SelectionMode="Single" SelectionChanged="ListView_SelectionChanged" ItemContainerStyle="{StaticResource HorizontalSwipe}">
                     <ListView.ItemTemplate>
                         <DataTemplate x:DataType="local2:ListItemData">
                             <UserControl PointerEntered="ListViewSwipeContainer_PointerEntered" PointerExited="ListViewSwipeContainer_PointerExited">
-                                <UserControl.ContextFlyout>
-                                    <MenuFlyout>
-                                        <MenuFlyoutItem Command="{x:Bind Command}" CommandParameter="{x:Bind Text}" />
-                                    </MenuFlyout>
-                                </UserControl.ContextFlyout>
                                 <Grid AutomationProperties.Name="{x:Bind Text}">
                                     <VisualStateManager.VisualStateGroups>
                                         <VisualStateGroup x:Name="HoveringStates">

--- a/XamlControlsGallery/ControlPages/StandardUICommandPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/StandardUICommandPage.xaml.cs
@@ -91,5 +91,14 @@ namespace AppUIBasics.ControlPages
                 }
             }
         }
+
+        private void ListViewRight_ContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)
+        {
+            MenuFlyout flyout = new MenuFlyout();
+            ListItemData data = (ListItemData)args.Item;
+            MenuFlyoutItem item = new MenuFlyoutItem() { Command = data.Command};
+            flyout.Items.Add(item);
+            args.ItemContainer.ContextFlyout = flyout;
+        }
     }
 }

--- a/XamlControlsGallery/ControlPagesSampleCode/StandardUICommand/StandardUICommandSample1_cs.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/StandardUICommand/StandardUICommandSample1_cs.txt
@@ -1,9 +1,21 @@
-﻿var deleteCommand = new StandardUICommand(StandardUICommandKind.Delete);
-deleteCommand.ExecuteRequested += DeleteCommand_ExecuteRequested;
-
-DeleteFlyoutItem.Command = deleteCommand;
-
-for (var i = 0; i < 15; i++)
+﻿private void ControlExample_Loaded(object sender, RoutedEventArgs e)
 {
-    collection.Add(new ListItemData { Text = i.ToString(), Command = deleteCommand });
+    var deleteCommand = new StandardUICommand(StandardUICommandKind.Delete);
+    deleteCommand.ExecuteRequested += DeleteCommand_ExecuteRequested;
+
+    DeleteFlyoutItem.Command = deleteCommand;
+
+    for (var i = 0; i < 15; i++)
+    {
+        collection.Add(new ListItemData { Text = "List item " + i.ToString(), Command = deleteCommand });
+    }
+}
+
+private void ListViewRight_ContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)
+{
+    MenuFlyout flyout = new MenuFlyout();
+    ListItemData data = (ListItemData)args.Item;
+    MenuFlyoutItem item = new MenuFlyoutItem() { Command = data.Command};
+    flyout.Items.Add(item);
+    args.ItemContainer.ContextFlyout = flyout;
 }

--- a/XamlControlsGallery/ControlPagesSampleCode/StandardUICommand/StandardUICommandSample1_xaml.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/StandardUICommand/StandardUICommandSample1_xaml.txt
@@ -1,5 +1,4 @@
-﻿<MenuFlyoutItem Command="{x:Bind Command}" CommandParameter="{x:Bind Text}" />
+﻿<SwipeItem x:Name="DeleteSwipeItem" Background="Red" Command="{x:Bind Command}" CommandParameter="{x:Bind Text}" />
 
-<SwipeItem x:Name="DeleteSwipeItem" Background="Red" Command="{x:Bind Command}" CommandParameter="{x:Bind Text}" />
-
-<AppBarButton x:Name="HoverButton" IsTabStop="False" HorizontalAlignment="Right" Visibility="Collapsed" Command="{x:Bind Command}" CommandParameter="{x:Bind Text}" />    
+<AppBarButton x:Name="HoverButton" IsTabStop="False" HorizontalAlignment="Right" Visibility="Collapsed" 
+ Command="{x:Bind Command}" CommandParameter="{x:Bind Text}" />    


### PR DESCRIPTION
I added a workaround to enable proper context menu behavior, fixing and issue with invocation (Shift-F10, etc). Due to limitations in declaration of context menu's in markup with listview, the context menu for this sample is now created instead in code behind.
