### PR TITLE
Updated RichEditBox's custom menu example

### DIFF
--- a/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
@@ -29,7 +29,7 @@ namespace AppUIBasics.ControlPages
             this.InitializeComponent();
         }
 
-        private void ContextFlyout_Opening(object sender, object e)
+        private void Menu_Opening(object sender, object e)
         {
             CommandBarFlyout myFlyout = sender as CommandBarFlyout;
             if (myFlyout.Target == REBCustom)
@@ -181,7 +181,11 @@ namespace AppUIBasics.ControlPages
             // Prior to UniversalApiContract 7, RichEditBox did not have a default ContextFlyout set.
             if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 7))
             {
-                REBCustom.ContextFlyout.Opening += ContextFlyout_Opening;
+                // customize the menu that opens on text selection
+                REBCustom.SelectionFlyout.Opening += Menu_Opening;
+
+                // also customize the context menu to match selection menu
+                REBCustom.ContextFlyout.Opening += Menu_Opening;
             }
         }
 
@@ -190,7 +194,8 @@ namespace AppUIBasics.ControlPages
             // Prior to UniversalApiContract 7, RichEditBox did not have a default ContextFlyout set.
             if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 7))
             {
-                REBCustom.ContextFlyout.Opening -= ContextFlyout_Opening;
+                REBCustom.SelectionFlyout.Opening -= Menu_Opening;
+                REBCustom.ContextFlyout.Opening -= Menu_Opening;
             }
         } 
     }

--- a/XamlControlsGallery/ControlPagesSampleCode/Text/RichEditBox/RichEditBoxSample4_cs.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/Text/RichEditBox/RichEditBoxSample4_cs.txt
@@ -1,4 +1,4 @@
-﻿private void ContextFlyout_Opening(object sender, object e)
+﻿private void Menu_Opening(object sender, object e)
 {
     CommandBarFlyout myFlyout = sender as CommandBarFlyout;
     if (myFlyout.Target == REBCustom)
@@ -11,10 +11,12 @@
 
 private void REBCustom_Loaded(object sender, RoutedEventArgs e)
 {
-    REBCustom.ContextFlyout.Opening += ContextFlyout_Opening;
+    REBCustom.SelectionFlyout.Opening += Menu_Opening;
+    REBCustom.ContextFlyout.Opening += Menu_Opening;
 }
 
 private void REBCustom_Unloaded(object sender, RoutedEventArgs e)
 {
-    REBCustom.ContextFlyout.Opening -= ContextFlyout_Opening;
+    REBCustom.SelectionFlyout.Opening -= Menu_Opening;
+    REBCustom.ContextFlyout.Opening -= Menu_Opening;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Our sample code was modifying the context menu but no the selection menu. As a result, users would see a different set of available commands depending on how they opened floatie.

## Description
<!--- Describe your changes in detail -->
Added Opening event code to SelectionFlyout in addition to ContextFlyout.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The sample now provides a consistent user experience. Before this fix, highlighting some text to select it would show a closed CommandBarFlyout without the custom "share" command.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually verified.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
