### PR TITLE
Add missing quotation mark in MenuFlyout example

### DIFF
--- a/XamlControlsGallery/ControlPages/MenuFlyoutPage.xaml
+++ b/XamlControlsGallery/ControlPages/MenuFlyoutPage.xaml
@@ -35,7 +35,7 @@
         &lt;MenuFlyout&gt;
             &lt;MenuFlyoutItem Text="By rating" Click="MenuFlyoutItem_Click" Tag="rating"&gt;
             &lt;MenuFlyoutItem Text="By match" Click="MenuFlyoutItem_Click" Tag="match"&gt;
-            &lt;MenuFlyoutItem Text="By distance" Click="MenuFlyoutItem_Click" Tag="distance&gt;
+            &lt;MenuFlyoutItem Text="By distance" Click="MenuFlyoutItem_Click" Tag="distance"&gt;
         &lt;/MenuFlyout&gt;
     &lt;/AppBarButton.Flyout&gt;
 &lt;/AppBarButton&gt;


### PR DESCRIPTION
## Description
Adds a missing " that made the example code invalid

## Motivation and Context
The example code did not compile

## How Has This Been Tested?
Has not been tested

## Screenshots (if appropriate):
![](https://cdn.discordapp.com/attachments/150662382874525696/568564229276172318/unknown.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
