### PR TITLE
Retarget to 19h1 and WinUI 2.2

### DIFF
--- a/XamlControlsGallery/XamlControlsGallery.csproj
+++ b/XamlControlsGallery/XamlControlsGallery.csproj
@@ -10,7 +10,7 @@
     <AssemblyName>AppUIBasics</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17134.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
@@ -1078,7 +1078,7 @@
       <Version>6.1.9</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
-      <Version>2.1.190405004</Version>
+      <Version>2.2.190611001-prerelease</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed">
       <Version>2.0.0</Version>


### PR DESCRIPTION
Retargets the project to the now-public 19H1 (18362) SDK and the latest WinUI 2.2 package.

I had to update the SDK since WinUI now requires it. If you're not ready to update the SDK for the project yet then you can leave this PR in limbo, but I offer it just so you know there's new goodness out there. :)