### PR TITLE
Fix accessibility issue preventing tab navigation.

### DIFF
--- a/XamlControlsGallery/ControlPages/ScrollViewer2Page.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ScrollViewer2Page.xaml.cs
@@ -6,6 +6,7 @@ using System.Numerics;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
+using Windows.System;
 using Windows.UI.Composition;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -67,7 +68,7 @@ namespace AppUIBasics.ControlPages
                 ZoomSlider.Value = Math.Round(sender.ZoomFactor, (int)(10 * ZoomSlider.StepFrequency));
                 ZoomSlider.ValueChanged += ZoomSlider_ValueChanged;
             }
-            else 
+            else
             {
                 ZoomSlider.ValueChanged -= ZoomSlider_ValueChanged;
             }
@@ -461,8 +462,14 @@ namespace AppUIBasics.ControlPages
 
         private void Scroller_HandleKeyDown(object sender, KeyRoutedEventArgs e)
         {
-            // Swallow gamepad / keyboard input when focused to prevent the Page's ScrollViewer from scrollling
-            e.Handled = true;
+            // Swallow up and down for gamepad / keyboard input when focused to prevent the Page's ScrollViewer from scrollling
+            switch (e.Key)
+            {
+                case VirtualKey.Up:
+                case VirtualKey.Down:
+                    e.Handled = true;
+                    break;
+            }
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The sample was trying to allow scrolling via keyboard when there is no focusable element in the content (i.e. its just an image).  It makes the ScrollViewer a tab stop since it isn't by default.  It was also handling keydown so that when it reaches the extent the keydown doesn't bubble up to the scrollviewer for the page and cause the content to continue to scroll down.  The bug is that the keydown handler was marking everything as handled.  What it should be doing is only handling the up/down.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
