### PR TITLE
Hide the Acrylic luminosity sample that is causing crashes.

### DIFF
--- a/XamlControlsGallery/ControlPages/AcrylicPage.xaml
+++ b/XamlControlsGallery/ControlPages/AcrylicPage.xaml
@@ -198,7 +198,10 @@
                 <local:ControlExampleSubstitution Key="FallbackColor" Value="{x:Bind FallbackColorSelector.SelectedItem, Mode=OneWay}"/>
             </local:ControlExample.Substitutions>
         </local:ControlExample>
-        <local:ControlExample x:Name="Example5" HeaderText="Luminosity with in-app Acrylic.">
+        
+        <!-- Disable this sample until we find the root cause of the Luminosity slider crash. -->
+        <local:ControlExample x:Name="Example5" HeaderText="Luminosity with in-app Acrylic." 
+                              Visibility="Collapsed">
             <local:ControlExample.Example>
                 <Grid x:Name="Example5Grid" MinWidth="650" MinHeight="200">
                     <Grid.ColumnDefinitions>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The Acrylic luminosity sample is causing crashes. This change collapses the sample so that it is not visible while we get to the bottom of the crash. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#107 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested against x64/Release

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
