### PR TITLE
Clarify ToggleMenuFlyoutItem sample

### DIFF
--- a/XamlControlsGallery/ControlPages/MenuFlyoutPage.xaml
+++ b/XamlControlsGallery/ControlPages/MenuFlyoutPage.xaml
@@ -49,8 +49,8 @@
                     <MenuFlyout>
                         <MenuFlyoutItem Text="Reset" />
                         <MenuFlyoutSeparator />
-                        <ToggleMenuFlyoutItem Text="Repeat" />
-                        <ToggleMenuFlyoutItem Text="Shuffle" />
+                        <ToggleMenuFlyoutItem x:Name="RepeatToggleMenuFlyoutItem" Text="Repeat" IsChecked="True" />
+                        <ToggleMenuFlyoutItem x:Name="ShuffleToggleMenuFlyoutItem" Text="Shuffle" IsChecked="True" />
                     </MenuFlyout>
                 </Button.Flyout>
             </Button>
@@ -61,13 +61,17 @@
         &lt;MenuFlyout&gt;
             &lt;MenuFlyoutItem Text="Reset"/&gt;
             &lt;MenuFlyoutSeparator/&gt;
-            &lt;ToggleMenuFlyoutItem Text="Repeat"/&gt;
-            &lt;ToggleMenuFlyoutItem Text="Shuffle"/&gt;
+            &lt;ToggleMenuFlyoutItem Text="Repeat" IsChecked="$(RepeatToggle)"/&gt;
+            &lt;ToggleMenuFlyoutItem Text="Shuffle" IsChecked="$(ShuffleToggle)"/&gt;
         &lt;/MenuFlyout&gt;
     &lt;/Button.Flyout&gt;
 &lt;/Button&gt;
                 </x:String>
             </local:ControlExample.Xaml>
+            <local:ControlExample.Substitutions>
+                <local:ControlExampleSubstitution Key="RepeatToggle" Value="{x:Bind RepeatToggleMenuFlyoutItem.IsChecked, Mode=OneWay}"/>
+                <local:ControlExampleSubstitution Key="ShuffleToggle" Value="{x:Bind ShuffleToggleMenuFlyoutItem.IsChecked, Mode=OneWay}"/>
+            </local:ControlExample.Substitutions>
         </local:ControlExample>
         <local:ControlExample x:Name="Example3" HeaderText="A MenuFlyout with cascading menus.">
             <Button x:Name="Control3" Content="File Options">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
#112 highlighted an issue where the ToggleMenuFlyout sample looked strange because the flyout was reserving space for the checkmark, but it wasn't initially clear that the item was toggle'able. This change makes the ToggleMenuFlyout samples checked by default so it's clear why the space is needed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#112 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual

## Screenshots (if appropriate):
Before:
![image](https://user-images.githubusercontent.com/25991996/60549393-9699aa00-9cd9-11e9-88bf-32b03ff14f36.png)

After:
![image](https://user-images.githubusercontent.com/25991996/60549412-a4e7c600-9cd9-11e9-9823-b3177e9c97c0.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
