### PR TITLE
Updated state of app title

### DIFF
--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml
@@ -58,7 +58,8 @@
                 Canvas.ZIndex="1">
             <TextBlock x:Name="AppTitle"
                        Text="XAML Controls Gallery"
-                       VerticalAlignment="Center"
+                       VerticalAlignment="Top"
+                       Margin="0,8,0,0"
                        Style="{StaticResource CaptionTextBlockStyle}" />
         </Border>
 

--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml
@@ -72,6 +72,7 @@
             IsTabStop="False"
             PaneOpening="NavigationViewControl_PaneOpened"
             PaneClosing="NavigationViewControl_PaneClosing"
+            DisplayModeChanged="NavigationViewControl_DisplayModeChanged"
             ItemInvoked="OnNavigationViewItemInvoked">
             <mux:NavigationView.AutoSuggestBox>
                 <AutoSuggestBox

--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
@@ -27,6 +27,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
+using Windows.Foundation.Metadata;
 
 namespace AppUIBasics
 {
@@ -281,19 +282,34 @@ namespace AppUIBasics
 
         private void NavigationViewControl_PaneClosing(Microsoft.UI.Xaml.Controls.NavigationView sender, Microsoft.UI.Xaml.Controls.NavigationViewPaneClosingEventArgs args)
         {
-            AppTitle.Visibility = Visibility.Collapsed;
+            UpdateAppTitleMargin(sender);
         }
 
         private void NavigationViewControl_PaneOpened(Microsoft.UI.Xaml.Controls.NavigationView sender, object args)
         {
-            AppTitle.Visibility = Visibility.Visible;
-            if (sender.DisplayMode == Microsoft.UI.Xaml.Controls.NavigationViewDisplayMode.Expanded)
+            UpdateAppTitleMargin(sender);
+        }
+
+        private void NavigationViewControl_DisplayModeChanged(Microsoft.UI.Xaml.Controls.NavigationView sender, Microsoft.UI.Xaml.Controls.NavigationViewDisplayModeChangedEventArgs args)
+        {
+            UpdateAppTitleMargin(sender);
+        }
+
+        private void UpdateAppTitleMargin(Microsoft.UI.Xaml.Controls.NavigationView sender)
+        {
+            if (!(ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 7)))
             {
-                AppTitleBar.Margin = new Thickness(40, 0, 0, 0);
+                AppTitle.TranslationTransition = new Vector3Transition();
+            }
+
+            if (sender.IsPaneOpen == false && (sender.DisplayMode == Microsoft.UI.Xaml.Controls.NavigationViewDisplayMode.Expanded ||
+                sender.DisplayMode == Microsoft.UI.Xaml.Controls.NavigationViewDisplayMode.Compact))
+            {
+                AppTitle.Translation = new System.Numerics.Vector3(34, 0, 0);
             }
             else
             {
-                AppTitleBar.Margin = new Thickness();
+                AppTitle.Translation = new System.Numerics.Vector3(0);
             }
         }
     }

--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
@@ -297,19 +297,35 @@ namespace AppUIBasics
 
         private void UpdateAppTitleMargin(Microsoft.UI.Xaml.Controls.NavigationView sender)
         {
-            if (!(ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 7)))
+            const int smallLeftIndent = 0, largeLeftIndent = 34;
+
+            if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 7))
             {
                 AppTitle.TranslationTransition = new Vector3Transition();
-            }
-
-            if (sender.IsPaneOpen == false && (sender.DisplayMode == Microsoft.UI.Xaml.Controls.NavigationViewDisplayMode.Expanded ||
-                sender.DisplayMode == Microsoft.UI.Xaml.Controls.NavigationViewDisplayMode.Compact))
-            {
-                AppTitle.Translation = new System.Numerics.Vector3(34, 0, 0);
+                
+                if (sender.IsPaneOpen == false && (sender.DisplayMode == Microsoft.UI.Xaml.Controls.NavigationViewDisplayMode.Expanded ||
+                    sender.DisplayMode == Microsoft.UI.Xaml.Controls.NavigationViewDisplayMode.Compact))
+                {
+                    AppTitle.Translation = new System.Numerics.Vector3(largeLeftIndent, 0, 0);
+                }
+                else
+                {
+                    AppTitle.Translation = new System.Numerics.Vector3(smallLeftIndent, 0, 0);
+                }
             }
             else
             {
-                AppTitle.Translation = new System.Numerics.Vector3(0);
+                Thickness currMargin = AppTitle.Margin;
+
+                if (sender.IsPaneOpen == false && (sender.DisplayMode == Microsoft.UI.Xaml.Controls.NavigationViewDisplayMode.Expanded ||
+                    sender.DisplayMode == Microsoft.UI.Xaml.Controls.NavigationViewDisplayMode.Compact))
+                {
+                    AppTitle.Margin = new Thickness(largeLeftIndent, currMargin.Top, currMargin.Right, currMargin.Bottom);
+                }
+                else
+                {
+                    AppTitle.Margin = new Thickness(smallLeftIndent, currMargin.Top, currMargin.Right, currMargin.Bottom);
+                }
             }
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Ensured app title remains visible in all NavigationView modes and states.

## Description
<!--- Describe your changes in detail -->
Previously, the "XAML Controls Gallery" title of the app would be hidden whenever the primary NavigationView's pane was closed. As a result, when the gallery ran in a small window its app title would not be visible most of the time. This change keeps the title visible but moves it out of the way of the pane sliver when needed. The title moves to avoid overlapping the pane when appropriate, so I added an implicit animation to make the transition more visually appealing.

Also updated the vertical alignment of the title to look more centered relative to caption controls.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As a best practice, apps should have a visible title. When drawing into the window title bar, the burden to have a title falls on the app itself. The gallery was drawing a title, but this textblock was being hidden on smaller widths when NavigationView defaults to Compact or Minimal modes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually verified.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/13142665/61657579-221eaf00-ac78-11e9-8c3f-81560a6e0414.png)

![image](https://user-images.githubusercontent.com/13142665/61657595-28149000-ac78-11e9-9be4-a067234f4fa8.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
