### PR TITLE
More button in ColorPicker page

### DIFF
--- a/XamlControlsGallery/ControlPages/ColorPickerPage.xaml
+++ b/XamlControlsGallery/ControlPages/ColorPickerPage.xaml
@@ -7,6 +7,7 @@
         <local:ControlExample x:Name="Example1" HeaderText="ColorPicker Properties." HorizontalContentAlignment="Left">
 
             <ColorPicker x:Name="colorPicker"
+                IsMoreButtonVisible="{x:Bind moreBtn.IsChecked.Value, Mode=OneWay}"
                 IsColorSliderVisible="{x:Bind colorSlider.IsChecked.Value, Mode=OneWay}"
                 IsColorChannelTextInputVisible="{x:Bind colorChannelInput.IsChecked.Value, Mode=OneWay}"
                 IsHexInputVisible="{x:Bind hexInput.IsChecked.Value, Mode=OneWay}"
@@ -16,6 +17,7 @@
 
             <local:ControlExample.Options>
                 <StackPanel Width="250" Margin="0,-5,0,0">
+                    <CheckBox Content="IsMoreButtonVisible" x:Name="moreBtn" IsChecked="False"/>
                     <CheckBox Content="IsColorSliderVisible" x:Name="colorSlider" IsChecked="True" />
                     <CheckBox Content="IsColorChannelTextInputVisible" x:Name="colorChannelInput" IsChecked="True" />
                     <CheckBox Content="IsHexInputVisible" x:Name="hexInput" IsChecked="True" />
@@ -39,6 +41,7 @@
             <local:ControlExample.Xaml>
                 <x:String xml:space="preserve">
 &lt;ColorPicker
+      IsMoreButtonVisible="$(IsMoreButtonVisible)"
       IsColorSliderVisible="$(IsColorSliderVisible)"
       IsColorChannelTextInputVisible="$(IsColorChannelTextInputVisible)"
       IsHexInputVisible="$(IsHexInputVisible)"
@@ -48,6 +51,7 @@
 </x:String>
             </local:ControlExample.Xaml>
             <local:ControlExample.Substitutions>
+                <local:ControlExampleSubstitution Key="IsMoreButtonVisible" Value="{x:Bind moreBtn.IsChecked, Mode=OneWay}"/>
                 <local:ControlExampleSubstitution Key="IsColorSliderVisible" Value="{x:Bind colorSlider.IsChecked, Mode=OneWay}"/>
                 <local:ControlExampleSubstitution Key="IsColorChannelTextInputVisible" Value="{x:Bind colorChannelInput.IsChecked, Mode=OneWay}"/>
                 <local:ControlExampleSubstitution Key="IsHexInputVisible" Value="{x:Bind hexInput.IsChecked, Mode=OneWay}"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added More button to the sample.

## Description
<!--- Describe your changes in detail -->
Added a toggle to show the More/Less button built into the ColorPicker control.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We found an [internal bug](https://microsoft.visualstudio.com/OS/_workitems/edit/22974472) where the hover state of the More button wasn't always correct. I wasn't able to verify whether this was an issue with the common Xaml control because the Gallery didn't show the More button. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually verified.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/13142665/61664746-4da99580-ac88-11e9-93e1-f40f4ceed829.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
