### PR TITLE
Fix bug where app crashes when input was invalid; Fix bug where enter key was not registered in TextBox; Closes #3;

### DIFF
--- a/XamlControlsGallery/ControlPages/ImplicitTransitionPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ImplicitTransitionPage.xaml.cs
@@ -201,19 +201,19 @@ namespace AppUIBasics.ControlPages
         {
             if (e.Key == Windows.System.VirtualKey.Enter)
             {
-                if ((String)(sender as TextBox).Header == "Opacity")
+                if ((String)(sender as TextBox).Header == "Opacity (0.0 to 1.0)")
                 {
                     OpacityButton_Click(null, null);
                 }
-                if ((String)(sender as TextBox).Header == "Rotation")
+                if ((String)(sender as TextBox).Header == "Rotation (0.0 to 360.0)")
                 {
                     RotationButton_Click(null, null);
                 }
-                if ((String)(sender as TextBox).Header == "Scale")
+                if ((String)(sender as TextBox).Header == "Scale (0.0 to 5.0)")
                 {
                     ScaleButton_Click(null, null);
                 }
-                if ((String)(sender as TextBox).Header == "Translation")
+                if ((String)(sender as TextBox).Header == "Translation (0.0 to 200.0)")
                 {
                     TranslateButton_Click(null, null);
                 }

--- a/XamlControlsGallery/ControlPages/ImplicitTransitionPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ImplicitTransitionPage.xaml.cs
@@ -35,12 +35,25 @@ namespace AppUIBasics.ControlPages
             // If the implicit animation API is not present, simply no-op. 
             if (!(ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 7))) return;
 
-            var customValue = Convert.ToDouble(OpacityTextBox.Text);
+            var customValue = 0.0;
+            try
+            {
+                customValue = Convert.ToDouble(OpacityTextBox.Text);
+            }
+            catch (FormatException)
+            {
+                GenerateErrorFlyout(OpacityTextBox);
+                return;
+            }
 
             if (customValue >= 0.0 && customValue <= 1.0)
             {
                 OpacityRectangle.Opacity = customValue;
                 OpacityValue.Value = customValue;
+            }
+            else
+            {
+                GenerateErrorFlyout(OpacityTextBox, "Input must be between 0 and 1");
             }
         }
         private void RotationButton_Click(object sender, RoutedEventArgs e)
@@ -50,7 +63,16 @@ namespace AppUIBasics.ControlPages
 
             RotationRectangle.CenterPoint = new System.Numerics.Vector3((float)RotationRectangle.ActualWidth / 2, (float)RotationRectangle.ActualHeight / 2, 0f);
 
-            float customValue = (float)Convert.ToDouble(RotationTextBox.Text);
+            float customValue = 0;
+            try
+            {
+                customValue = (float)Convert.ToDouble(RotationTextBox.Text);
+            }
+            catch (FormatException)
+            {
+                GenerateErrorFlyout(RotationTextBox);
+                return;
+            }
 
             if (customValue >= 0.0 && customValue <= 360.0)
             {
@@ -59,6 +81,7 @@ namespace AppUIBasics.ControlPages
             else
             {
                 RotationRectangle.Rotation = 0;
+                GenerateErrorFlyout(RotationTextBox, "Input must be between 0 and 360");
             }
             RotationValue.Value = RotationRectangle.Rotation;
         }
@@ -74,19 +97,40 @@ namespace AppUIBasics.ControlPages
                                          ((ScaleZ.IsChecked == true) ? Vector3TransitionComponents.Z : 0);
 
             float customValue;
+
             if (sender != null && (sender as Button).Tag != null)
             {
-                customValue = (float)Convert.ToDouble((sender as Button).Tag);
+                try
+                {
+                    customValue = (float)Convert.ToDouble((sender as Button).Tag);
+                }
+                catch (FormatException)
+                {
+                    GenerateErrorFlyout(sender as Button);
+                    return;
+                }
             }
             else
             {
-                customValue = (float)Convert.ToDouble(ScaleTextBox.Text);
+                try
+                {
+                    customValue = (float)Convert.ToDouble(ScaleTextBox.Text);
+                }
+                catch (FormatException)
+                {
+                    GenerateErrorFlyout(ScaleTextBox);
+                    return;
+                }
             }
 
             if (customValue > 0.0 && customValue <= 5)
             {
                 ScaleRectangle.Scale = new Vector3(customValue);
                 ScaleValue.Value = customValue;
+            }
+            else
+            {
+                GenerateErrorFlyout(ScaleTextBox, "The number must be between 0 (not equal to 0) and 5 ");
             }
         }
 
@@ -104,11 +148,28 @@ namespace AppUIBasics.ControlPages
             float customValue;
             if (sender != null && (sender as Button).Tag != null)
             {
-                customValue = (float)Convert.ToDouble((sender as Button).Tag);
+                try
+                {
+                    customValue = (float)Convert.ToDouble((sender as Button).Tag);
+                }
+                catch (FormatException)
+                {
+                    GenerateErrorFlyout(sender as Button);
+                    return;
+                }
             }
             else
             {
-                customValue = (float)Convert.ToDouble(TranslationTextBox.Text);
+                try
+                {
+
+                    customValue = (float)Convert.ToDouble(TranslationTextBox.Text);
+                }
+                catch (FormatException)
+                {
+                    GenerateErrorFlyout(TranslationTextBox);
+                    return;
+                }
             }
 
             if (customValue >= 0.0 && customValue <= 200.0)
@@ -116,8 +177,26 @@ namespace AppUIBasics.ControlPages
                 TranslateRectangle.Translation = new Vector3(customValue);
                 TranslationValue.Value = customValue;
             }
+            else
+            {
+                GenerateErrorFlyout(TranslationTextBox, "THe input must be between 0 and 200");
+            }
         }
 
+        /// <summary>
+        /// Generates a flyout for the given element. 
+        /// If no message is specified the default message "The input must be a number" will be used.
+        /// </summary>
+        /// <param name="element">The element to apply the flyout to</param>
+        /// <param name="message">The message that will be displayed</param>
+        private void GenerateErrorFlyout(FrameworkElement element, string message = "The input must be a number")
+        {
+            Flyout formatFlyout = new Flyout();
+            formatFlyout.Content = new TextBlock();
+            (formatFlyout.Content as TextBlock).Text = message;
+            formatFlyout.Placement = Windows.UI.Xaml.Controls.Primitives.FlyoutPlacementMode.Top;
+            formatFlyout.ShowAt(element);
+        }
         private void TextBox_KeyDown(object sender, KeyRoutedEventArgs e)
         {
             if (e.Key == Windows.System.VirtualKey.Enter)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed a bug where the application would crash if input was not sanitized. Also added flyouts if the input is out of range and fixed the code relating to registering enter key in TextBox.
## Description
<!--- Describe your changes in detail -->
Added a Flyout that gets rendered when either: 
- the input is not a number 
- the input is not in range for the respective transition attribute/element 

This was done by surrounding the parsing with try/catch blocks and adding else cases to the if cases that check if the input is in range. In case of "failure" a method gets called that creates a Flyout for the respective textbox.
The registering of the enter key was fixed by using the actual header text of the TextBoxes (the wrong header was expected thus the checks failed).
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #3
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by starting application.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
