### PR TITLE
Change StandardUICommandPage to select the item it is for; Closes #106;

### DIFF
--- a/XamlControlsGallery/ControlPages/StandardUICommandPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/StandardUICommandPage.xaml.cs
@@ -98,8 +98,8 @@ namespace AppUIBasics.ControlPages
             ListItemData data = (ListItemData)args.Item;
             MenuFlyoutItem item = new MenuFlyoutItem() { Command = data.Command };
             flyout.Opened += delegate (object element, object e) {
-                var flyOutElement = element as MenuFlyout;
-                var elementToHighlight = flyOutElement.Target as ListViewItem;
+                MenuFlyout flyoutElement = element as MenuFlyout;
+                ListViewItem elementToHighlight = flyoutElement.Target as ListViewItem;
                 elementToHighlight.IsSelected = true;
             };
             flyout.Items.Add(item);

--- a/XamlControlsGallery/ControlPages/StandardUICommandPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/StandardUICommandPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.ObjectModel;
 using System.Windows.Input;
 using Windows.Foundation.Metadata;
@@ -96,7 +96,12 @@ namespace AppUIBasics.ControlPages
         {
             MenuFlyout flyout = new MenuFlyout();
             ListItemData data = (ListItemData)args.Item;
-            MenuFlyoutItem item = new MenuFlyoutItem() { Command = data.Command};
+            MenuFlyoutItem item = new MenuFlyoutItem() { Command = data.Command };
+            flyout.Opened += delegate (object element, object e) {
+                var flyOutElement = element as MenuFlyout;
+                var elementToHighlight = flyOutElement.Target as ListViewItem;
+                elementToHighlight.IsSelected = true;
+            };
             flyout.Items.Add(item);
             args.ItemContainer.ContextFlyout = flyout;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed a bug where the context menu in the StandardUICommandPage would not delete the item when it was not selected.
## Description
<!--- Describe your changes in detail -->
Made the menu flyout automatically select the component it is being created for. By doing that, the item in the list is being selected and the deletion of the item will work. In addition to that it is clear to which component the context menu belongs.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #106.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by starting application.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
