### PR TITLE
Improve search to be more inclusive; Closes #96;

### DIFF
--- a/XamlControlsGallery/ControlPages/AutoSuggestBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AutoSuggestBoxPage.xaml.cs
@@ -135,11 +135,27 @@ namespace AppUIBasics.ControlPages
         {
             var suggestions = new List<ControlInfoDataItem>();
 
+            var querySplit = query.Split(" ");
             foreach (var group in ControlInfoDataSource.Instance.Groups)
             {
                 var matchingItems = group.Items.Where(
-                    item => item.Title.IndexOf(query, StringComparison.CurrentCultureIgnoreCase) >= 0);
-
+                    item =>
+                    {
+                        // Idea: check for every word entered (separated by space) if it is in the name,  
+                        // e.g. for query "split button" the only result should "SplitButton" since its the only query to contain "split" and "button" 
+                        // If any of the sub tokens is not in the string, we ignore the item. So the search gets more precise with more words 
+                        bool flag = true;
+                        foreach (string queryToken in querySplit)
+                        {
+                            // Check if token is not in string 
+                            if (item.Title.IndexOf(queryToken, StringComparison.CurrentCultureIgnoreCase) < 0)
+                            {
+                                // Token is not in string, so we ignore this item. 
+                                flag = false;
+                            }
+                        }
+                        return flag;
+                    });
                 foreach (var item in matchingItems)
                 {
                     suggestions.Add(item);

--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
@@ -246,11 +246,27 @@ namespace AppUIBasics
             {
                 var suggestions = new List<ControlInfoDataItem>();
 
+                var querySplit = sender.Text.Split(" ");
                 foreach (var group in ControlInfoDataSource.Instance.Groups)
                 {
                     var matchingItems = group.Items.Where(
-                        item => item.Title.IndexOf(sender.Text, StringComparison.CurrentCultureIgnoreCase) >= 0);
-
+                        item =>
+                        {
+                            // Idea: check for every word entered (separated by space) if it is in the name, 
+                            // e.g. for query "split button" the only result should "SplitButton" since its the only query to contain "split" and "button"
+                            // If any of the sub tokens is not in the string, we ignore the item. So the search gets more precise with more words
+                            bool flag = true;
+                            foreach (string queryToken in querySplit)
+                            {
+                                // Check if token is not in string
+                                if (item.Title.IndexOf(queryToken, StringComparison.CurrentCultureIgnoreCase) < 0)
+                                {
+                                    // Token is not in string, so we ignore this item.
+                                    flag = false;
+                                }
+                            }
+                            return flag;
+                        });
                     foreach (var item in matchingItems)
                     {
                         suggestions.Add(item);

--- a/XamlControlsGallery/SearchResultsPage.xaml.cs
+++ b/XamlControlsGallery/SearchResultsPage.xaml.cs
@@ -76,14 +76,28 @@ namespace AppUIBasics
                 // creating a list of user-selectable result categories:
                 var filterList = new List<Filter>();
 
+                // Query is already lowercase
+                var querySplit = queryText.ToLower().Split(" ");
                 foreach (var group in ControlInfoDataSource.Instance.Groups)
                 {
                     var matchingItems =
                         group.Items.Where(item =>
-                            item.Title.ToLower().Contains(queryText) ||
-                            item.Subtitle.ToLower().Contains(queryText))
-                        .ToList();
-
+                        {
+                            // Idea: check for every word entered (separated by space) if it is in the name, 
+                            // e.g. for query "split button" the only result should "SplitButton" since its the only query to contain "split" and "button"
+                            // If any of the sub tokens is not in the string, we ignore the item. So the search gets more precise with more words
+                            bool flag = true;
+                            foreach (string queryToken in querySplit)
+                            {
+                                // Check if token is in title or subtitle
+                                if (!item.Title.ToLower().Contains(queryToken) && !item.Subtitle.ToLower().Contains(queryToken))
+                                {
+                                    // Neither title nor sub title contain one of the tokens so we discard this item!
+                                    flag = false;
+                                }
+                            }
+                            return flag;
+                        }).ToList();
                     int numberOfMatchingItems = matchingItems.Count();
 
                     if (numberOfMatchingItems > 0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Improved the search to be more inclusive. See #96 for more info.
## Description
<!--- Describe your changes in detail -->
Tokenized the query by splitting it using the character " " (whitespace) and accept queries/items if they contain every token of the query. 
For example the query "split button" generates the tokens "split" and "button" so every item that contains both "split" and "button" will be accepted (unlike before where "splitbutton" was rejected)
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #96.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by starting application and entering queries that have been rejected before (e.g. "split button").
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
