### PR TITLE
Focus searchbar onstart

### DIFF
--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml
@@ -71,8 +71,6 @@
             Header=" "
             HeaderTemplate="{StaticResource NavigationViewHeaderTemplate}"
             IsTabStop="False"
-            IsPaneOpen="False"
-            PaneDisplayMode="Auto"
             PaneOpening="NavigationViewControl_PaneOpened"
             PaneClosing="NavigationViewControl_PaneClosing"
             DisplayModeChanged="NavigationViewControl_DisplayModeChanged"

--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml
@@ -71,6 +71,7 @@
             Header=" "
             HeaderTemplate="{StaticResource NavigationViewHeaderTemplate}"
             IsTabStop="False"
+            IsPaneOpen="False"
             PaneOpening="NavigationViewControl_PaneOpened"
             PaneClosing="NavigationViewControl_PaneClosing"
             DisplayModeChanged="NavigationViewControl_DisplayModeChanged"

--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml
@@ -71,6 +71,8 @@
             Header=" "
             HeaderTemplate="{StaticResource NavigationViewHeaderTemplate}"
             IsTabStop="False"
+            IsPaneOpen="False"
+            PaneDisplayMode="Auto"
             PaneOpening="NavigationViewControl_PaneOpened"
             PaneClosing="NavigationViewControl_PaneClosing"
             DisplayModeChanged="NavigationViewControl_DisplayModeChanged"

--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
@@ -169,9 +169,8 @@ namespace AppUIBasics
         {
             if (IsFocusSupported)
             {
-                _newControlsMenuItem.Focus(FocusState.Keyboard);
+                controlsSearchBox.Focus(FocusState.Keyboard);
             }
-            _newControlsMenuItem.IsSelected = true;
         }
 
         private void OnGamepadRemoved(object sender, Gamepad e)

--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
@@ -167,7 +167,7 @@ namespace AppUIBasics
 
         private void OnNewControlsMenuItemLoaded(object sender, RoutedEventArgs e)
         {
-            if (IsFocusSupported)
+            if (IsFocusSupported && NavigationViewControl.IsPaneOpen)
             {
                 controlsSearchBox.Focus(FocusState.Keyboard);
             }

--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
@@ -167,7 +167,7 @@ namespace AppUIBasics
 
         private void OnNewControlsMenuItemLoaded(object sender, RoutedEventArgs e)
         {
-            if (IsFocusSupported && NavigationViewControl.IsPaneOpen)
+            if (IsFocusSupported && NavigationViewControl.DisplayMode == Microsoft.UI.Xaml.Controls.NavigationViewDisplayMode.Expanded)
             {
                 controlsSearchBox.Focus(FocusState.Keyboard);
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Made app focus the searchbar (AutoSuggestBox) at app start.
## Description
<!--- Describe your changes in detail -->
Changed the function OnNewControlsMenuItemLoaded to instead of focusing the "New page" tab to focus the searchbar.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #109.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by starting application.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
