### PR TITLE
Fix "bug" where OnNavigatedFrom was not called; Closes #74;

### DIFF
--- a/XamlControlsGallery/ItemPage.xaml.cs
+++ b/XamlControlsGallery/ItemPage.xaml.cs
@@ -203,6 +203,8 @@ namespace AppUIBasics
                 ConnectedAnimationService.GetForCurrentView().PrepareToAnimate("controlAnimation", target);
             }
 
+            // We use reflection to call the OnNavigatedFrom function the user leaves this page
+            // See this PR for more information: https://github.com/microsoft/Xaml-Controls-Gallery/pull/145
             Frame contentFrameAsFrame = contentFrame as Frame;
             Page innerPage = contentFrameAsFrame.Content as Page;
             MethodInfo dynMethod = innerPage.GetType().GetMethod("OnNavigatedFrom",

--- a/XamlControlsGallery/ItemPage.xaml.cs
+++ b/XamlControlsGallery/ItemPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿//*********************************************************
+//*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
 // THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
@@ -26,6 +26,7 @@ using Windows.UI.Xaml.Hosting;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media.Animation;
 using Windows.UI.Xaml.Navigation;
+using System.Reflection;
 
 namespace AppUIBasics
 {
@@ -201,6 +202,12 @@ namespace AppUIBasics
                 var target = NavigationRootPage.Current.PageHeader.TitlePanel;
                 ConnectedAnimationService.GetForCurrentView().PrepareToAnimate("controlAnimation", target);
             }
+
+            Frame contentFrameAsFrame = contentFrame as Frame;
+            Page innerPage = contentFrameAsFrame.Content as Page;
+            MethodInfo dynMethod = innerPage.GetType().GetMethod("OnNavigatedFrom",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            dynMethod.Invoke(innerPage, new object[] { e });
 
             base.OnNavigatedFrom(e);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed a "bug" where the OnNavigatedFrom event of the ControlPages were not being called.
## Description
<!--- Describe your changes in detail -->
I added a call to the OnNavigatedFrom method from the Pages manually in the ItemPage.xaml.cs file. 

This change/fix is a bit more complex since the OnNavigatedFrom method is not being called because the hierarchical structure of the Page/XAML is not layed out in a way that would trigger the method on the ControlPage.
Oversimplified diagram of controls nesting:
```
<App>
    <NavigationRootPage>
        <ItemPage> <---- "Root" page / "source of frame"
            <-ControlSamplePage- /> <--------- Not the root page / "source of frame"
        </ItemPage>
    </NavigationRootPage>
</App>
```

Since the individual control pages are not the source of frame, OnNavigatedFrom will not be called (at least according to [this](https://stackoverflow.com/questions/53109162/uwp-page-onnavigatedfrom-not-called-when-app-is-terminated) )
However since the ItemPage(.xaml) is the source of frame its OnNavigatedFrom will be called. 
In the ItemPages OnNavigatedFrom method the nested controls page  OnNavigatedFrom method will now be called. This is done using reflection since the methode Page.OnNavigatedFrom is protected and can not be accessed otherwise. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #74.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by starting application and checking execution of PullToRefreshPage.xaml.cs using debugger.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
