### PR TITLE
Fix coloring behaviour with RichEditBox; Closes #139;

### DIFF
--- a/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml
+++ b/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml
@@ -155,6 +155,7 @@
                              RelativePanel.Below="openFileButton" 
                              RelativePanel.AlignLeftWithPanel="True" 
                              RelativePanel.AlignRightWithPanel="True" 
+                             TextChanged="Editor_TextChanged"
                              GotFocus="Editor_GotFocus"/>
                 <StackPanel Orientation="Horizontal" 
                             RelativePanel.Below="editor" 

--- a/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
@@ -24,6 +24,8 @@ namespace AppUIBasics.ControlPages
 {
     public sealed partial class RichEditBoxPage : Page
     {
+        private Color currentColor = Colors.Black;
+
         public RichEditBoxPage()
         {
             this.InitializeComponent();
@@ -119,6 +121,7 @@ namespace AppUIBasics.ControlPages
 
             fontColorButton.Flyout.Hide();
             editor.Focus(Windows.UI.Xaml.FocusState.Keyboard);
+            currentColor = color;
         }
 
         private void FindBoxHighlightMatches()
@@ -197,6 +200,12 @@ namespace AppUIBasics.ControlPages
                 REBCustom.SelectionFlyout.Opening -= Menu_Opening;
                 REBCustom.ContextFlyout.Opening -= Menu_Opening;
             }
-        } 
+        }
+
+        private void Editor_TextChanged(object sender, RoutedEventArgs e)
+        {
+            editor.Document.Selection.CharacterFormat.ForegroundColor = currentColor;
+
+        }
     }
 }

--- a/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
@@ -205,7 +205,6 @@ namespace AppUIBasics.ControlPages
         private void Editor_TextChanged(object sender, RoutedEventArgs e)
         {
             editor.Document.Selection.CharacterFormat.ForegroundColor = currentColor;
-
         }
     }
 }

--- a/XamlControlsGallery/ControlPages/SplitButtonPage.xaml
+++ b/XamlControlsGallery/ControlPages/SplitButtonPage.xaml
@@ -88,7 +88,7 @@
                     </muxcontrols:SplitButton.Flyout>
                 </muxcontrols:SplitButton>
 
-                <RichEditBox x:Name="myRichEditBox" Grid.Column="1" MinWidth="240" MinHeight="96" PlaceholderText="Type something here"/>
+                <RichEditBox x:Name="myRichEditBox" Grid.Column="1" MinWidth="240" MinHeight="96" PlaceholderText="Type something here" TextChanged="MyRichEditBox_TextChanged"/>
             </Grid>
         </local:ControlExample>
     </StackPanel>

--- a/XamlControlsGallery/ControlPages/SplitButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/SplitButtonPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Windows.UI.Xaml;
+﻿using Windows.UI;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 
@@ -6,6 +7,8 @@ namespace AppUIBasics.ControlPages
 {
     public sealed partial class SplitButtonPage : Page
     {
+        private Color currentColor = Colors.Black;
+
         public SplitButtonPage()
         {
             this.InitializeComponent();
@@ -26,6 +29,7 @@ namespace AppUIBasics.ControlPages
 
             myColorButton.Flyout.Hide();
             myRichEditBox.Focus(Windows.UI.Xaml.FocusState.Keyboard);
+            currentColor = color;
         }
 
         private void myColorButton_Click(Microsoft.UI.Xaml.Controls.SplitButton sender, Microsoft.UI.Xaml.Controls.SplitButtonClickEventArgs args)
@@ -34,6 +38,12 @@ namespace AppUIBasics.ControlPages
             var color = ((Windows.UI.Xaml.Media.SolidColorBrush)rectangle.Fill).Color;
 
             myRichEditBox.Document.Selection.CharacterFormat.ForegroundColor = color;
+            currentColor = color;
+        }
+
+        private void MyRichEditBox_TextChanged(object sender, RoutedEventArgs e)
+        {
+            myRichEditBox.Document.Selection.CharacterFormat.ForegroundColor = currentColor;
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed a bug where color was not applied to the typed text when the users changes position in the RichEditBox.
## Description
<!--- Describe your changes in detail -->
Fixed the bug by saving the last saved color and reapply anytime the user types
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #139.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by starting application. 
Tested adding text, clicking to random position in text and typing text.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
