### PR TITLE
Add "unload" event method in PageHeader for Itempage unload; Closes #75;

### DIFF
--- a/XamlControlsGallery/ItemPage.xaml.cs
+++ b/XamlControlsGallery/ItemPage.xaml.cs
@@ -50,6 +50,13 @@ namespace AppUIBasics
 
             LayoutVisualStates.CurrentStateChanged += (s, e) => UpdateSeeAlsoPanelVerticalTranslationAnimation();
             Loaded += (s,e) => SetInitialVisuals();
+            this.Unloaded += this.ItemPage_Unloaded;
+        }
+
+        private void ItemPage_Unloaded(object sender, RoutedEventArgs e)
+        {
+            // Notifying the pageheader that this Itempage was unloaded
+            NavigationRootPage.Current.PageHeader.Event_ItemPage_Unloaded(sender, e);
         }
 
         public void SetInitialVisuals()

--- a/XamlControlsGallery/PageHeader.xaml.cs
+++ b/XamlControlsGallery/PageHeader.xaml.cs
@@ -29,6 +29,7 @@ namespace AppUIBasics
         public TeachingTip TeachingTip2 => ToggleThemeTeachingTip2;
         public TeachingTip TeachingTip3 => ToggleThemeTeachingTip3;
 
+
         public object Title
         {
             get { return GetValue(TitleProperty); }
@@ -86,6 +87,17 @@ namespace AppUIBasics
         private void ToggleThemeTeachingTip2_ActionButtonClick(Microsoft.UI.Xaml.Controls.TeachingTip sender, object args)
         {
             NavigationRootPage.Current.PageHeader.ToggleThemeAction?.Invoke();
+        }
+
+        /// <summary>
+        /// This method will be called when a <see cref="ItemPage"/> gets unloaded. 
+        /// Put any code in here that should be done when a <see cref="ItemPage"/> gets unloaded.
+        /// </summary>
+        /// <param name="sender">The sender (the ItemPage)</param>
+        /// <param name="e">The <see cref="RoutedEventArgs"/> of the ItemPage that was unloaded.</param>
+        public void Event_ItemPage_Unloaded(object sender, RoutedEventArgs e)
+        {
+
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added self made unload event for PageHeader to register if the ItemPage gets unloaded. See #75 for use case.
## Description
<!--- Describe your changes in detail -->
Added a public method in PageHeader that will be called when the ItemPage gets unloaded.
This was done to register when the PageHeader "gets unloaded". The unload event of the PageHeader does not get triggered since it is actually not being uploaded as it is part of the NavigationRootPage and not part of the ItemPages. See following diagram:
```
<App>
    <NavigationRootPage>
        <PageHeader /> <---- The PageHeader in which we want to notice the unloading
        <ItemPage> <---- Page which gets unloaded
            <-ControlSamplePage- /> 
        </ItemPage>
    </NavigationRootPage>
</App>
```
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Helps with/fixes #75;
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test by manually starting application.
Added breakpoints in the `Event_ItemPage_Unloaded` function to check if it gets triggered.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
