### PR TITLE
Fix bug with appearance of caption controls; Closes #142;

### DIFF
--- a/XamlControlsGallery/App.xaml.cs
+++ b/XamlControlsGallery/App.xaml.cs
@@ -151,18 +151,6 @@ namespace AppUIBasics
             //draw into the title bar
             CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBar = true;
             
-            //remove the solid-colored backgrounds behind the caption controls and system back button
-            ApplicationViewTitleBar titleBar = ApplicationView.GetForCurrentView().TitleBar;
-            titleBar.ButtonBackgroundColor = Colors.Transparent;
-            titleBar.ButtonInactiveBackgroundColor = Colors.Transparent;
-            if (Application.Current.RequestedTheme == ApplicationTheme.Dark)
-            {
-                titleBar.ButtonForegroundColor = Colors.White;
-            }
-            else
-            {
-                titleBar.ButtonForegroundColor = Colors.Black;
-            }
             await EnsureWindow(args);
         }
 

--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
@@ -28,6 +28,7 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 using Windows.Foundation.Metadata;
+using Windows.UI;
 
 namespace AppUIBasics
 {
@@ -96,6 +97,39 @@ namespace AppUIBasics
             CoreApplication.GetCurrentView().TitleBar.LayoutMetricsChanged += (s, e) => UpdateAppTitle(s);
 
             _isKeyboardConnected = Convert.ToBoolean(new KeyboardCapabilities().KeyboardPresent);
+
+
+            // remove the solid-colored backgrounds behind the caption controls and system back button
+            // This is done when the app is loaded since before that the actual theme that is used is not "determined" yet
+            Loaded += delegate (object sender, RoutedEventArgs e) {
+                ApplicationViewTitleBar titleBar = ApplicationView.GetForCurrentView().TitleBar;
+                titleBar.ButtonBackgroundColor = Colors.Transparent;
+                titleBar.ButtonInactiveBackgroundColor = Colors.Transparent;
+
+                var currentTheme = App.RootTheme.ToString();
+                bool darkTheme = false;
+
+                switch (currentTheme)
+                {
+                    case "Dark":
+                        darkTheme = true;
+                        break;
+                    case "Default":
+                        if (Application.Current.RequestedTheme == ApplicationTheme.Dark)
+                        {
+                            darkTheme = true;
+                        }
+                        break;
+                }
+                if (darkTheme)
+                {
+                    titleBar.ButtonForegroundColor = Colors.White;
+                }
+                else
+                {
+                    titleBar.ButtonForegroundColor = Colors.Black;
+                }
+            };
         }
 
         void UpdateAppTitle(CoreApplicationViewTitleBar coreTitleBar)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed a bug with the appearance of the caption controls which would sometimes be white with white background/black with black background.
## Description
<!--- Describe your changes in detail -->
Improved the logic which is used to detect the current theme and moved the changing of the color to the Loaded event of the root page, since only when the app is loaded the "real" theme is determined and not the requested/user theme.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #142 .
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by running steps in issue #142.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
