### PR TITLE
Remove fixed locales from URL's; Closes #58;

### DIFF
--- a/XamlControlsGallery/Common/DeviceFamilyTrigger.cs
+++ b/XamlControlsGallery/Common/DeviceFamilyTrigger.cs
@@ -3,7 +3,7 @@ using Windows.UI.Xaml;
 
 namespace AppUIBasics
 {
-    // https://docs.microsoft.com/en-us/windows/uwp/input-and-devices/designing-for-tv#custom-visual-state-trigger-for-xbox
+    // https://docs.microsoft.com/windows/uwp/input-and-devices/designing-for-tv#custom-visual-state-trigger-for-xbox
     class DeviceFamilyTrigger : StateTriggerBase
     {
         private string _actualDeviceFamily;

--- a/XamlControlsGallery/ControlExample.xaml
+++ b/XamlControlsGallery/ControlExample.xaml
@@ -68,7 +68,7 @@
         <RichTextBlock x:Name="ErrorTextBlock" Visibility="Collapsed" Grid.Row="1" Margin="0,0,0,12" Foreground="Red" IsTextSelectionEnabled="True">
             <Paragraph>
                 This sample requires a later version of Windows to be fully functional. Learn more about version adaptive apps:
-                <Hyperlink NavigateUri="https://docs.microsoft.com/en-us/windows/uwp/debug-test-perf/version-adaptive-apps">https://docs.microsoft.com/en-us/windows/uwp/debug-test-perf/version-adaptive-apps</Hyperlink>
+                <Hyperlink NavigateUri="https://docs.microsoft.com/windows/uwp/debug-test-perf/version-adaptive-apps">https://docs.microsoft.com/windows/uwp/debug-test-perf/version-adaptive-apps</Hyperlink>
             </Paragraph>
         </RichTextBlock>
 

--- a/XamlControlsGallery/ControlPages/PersonPicturePage.xaml
+++ b/XamlControlsGallery/ControlPages/PersonPicturePage.xaml
@@ -13,7 +13,7 @@
             <local:ControlExample.Example>
                 <PersonPicture x:Name="personPicture" Height="300"
                 VerticalAlignment="Top"
-                ProfilePicture="{Binding IsChecked, ElementName=ProfileImageRadio, Converter={StaticResource booleanToValueConverter}, ConverterParameter='https://docs.microsoft.com/en-us/windows/uwp/contacts-and-calendar/images/shoulder-tap-static-payload.png'}"
+                ProfilePicture="{Binding IsChecked, ElementName=ProfileImageRadio, Converter={StaticResource booleanToValueConverter}, ConverterParameter='https://docs.microsoft.com/windows/uwp/contacts-and-calendar/images/shoulder-tap-static-payload.png'}"
                 DisplayName="{x:Bind DisplayNameRadio.IsChecked, Mode=OneWay, Converter={StaticResource booleanToValueConverter}, ConverterParameter='Jane Doe'}"
                 Initials="{x:Bind InitialsRadio.IsChecked, Mode=OneWay, Converter={StaticResource booleanToValueConverter}, ConverterParameter='SB'}" />
             </local:ControlExample.Example>
@@ -31,7 +31,7 @@
                 </x:String>
             </local:ControlExample.Xaml>
             <local:ControlExample.Substitutions>
-                <local:ControlExampleSubstitution Key="ProfilePicture" IsEnabled="{x:Bind ProfileImageRadio.IsChecked.Value, Mode=OneWay}" Value="ProfilePicture=&quot;https://docs.microsoft.com/en-us/windows/uwp/contacts-and-calendar/images/shoulder-tap-static-payload.png&quot;" />
+                <local:ControlExampleSubstitution Key="ProfilePicture" IsEnabled="{x:Bind ProfileImageRadio.IsChecked.Value, Mode=OneWay}" Value="ProfilePicture=&quot;https://docs.microsoft.com/windows/uwp/contacts-and-calendar/images/shoulder-tap-static-payload.png&quot;" />
                 <local:ControlExampleSubstitution Key="DisplayName" IsEnabled="{x:Bind DisplayNameRadio.IsChecked.Value, Mode=OneWay}" Value="DisplayName=&quot;Jane Doe&quot;" />
                 <local:ControlExampleSubstitution Key="Initials" IsEnabled="{x:Bind InitialsRadio.IsChecked.Value, Mode=OneWay}" Value="Initials=&quot;SB&quot;" />
             </local:ControlExample.Substitutions>

--- a/XamlControlsGallery/ControlPages/WebViewPage.xaml
+++ b/XamlControlsGallery/ControlPages/WebViewPage.xaml
@@ -16,6 +16,8 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d">
 
+    <!-- URL's on this page have a en-us as localization since having them not have a fixed locale results in the page having the language used by the user, 
+        which may be a different language than the app is using. This was quite confusing to see and was not intuitive.-->
     <local:ControlExample HeaderText="A simple WebView " HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
         <local:ControlExample.Example>
             <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">

--- a/XamlControlsGallery/DataModel/ControlInfoData.json
+++ b/XamlControlsGallery/DataModel/ControlInfoData.json
@@ -1175,11 +1175,11 @@
           "Docs": [
             {
               "Title": "ScrollViewer - API",
-              "Uri": "https://docs.microsoft.com/en-us/uwp/api/microsoft.ui.xaml.controls.scrollviewer"
+              "Uri": "https://docs.microsoft.com/uwp/api/microsoft.ui.xaml.controls.scrollviewer"
             },
             {
               "Title": "Guidance",
-              "Uri": "https://docs.microsoft.com/en-us/windows/uwp/design/controls-and-patterns/scroll-controls"
+              "Uri": "https://docs.microsoft.com/windows/uwp/design/controls-and-patterns/scroll-controls"
             }
           ],
           "RelatedControls": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Removed the "/en-us/" string from documentation URL's
## Description
<!--- Describe your changes in detail -->
Removed the "/en-us/" in all documentation URL's in which it was present for it in order to change locale based on user settings. The only page where this was not done is the WebView page where it would have resulted in quite confusing behavior.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #58 .
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by starting application and checking the changed links still work.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
