### PR TITLE
Fix decolorization of text in REB; Closes #146;

### DIFF
--- a/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
@@ -163,7 +163,6 @@ namespace AppUIBasics.ControlPages
             if (background != null && foreground != null)
             {
                 documentRange.CharacterFormat.BackgroundColor = background.Color;
-                documentRange.CharacterFormat.ForegroundColor = foreground.Color;
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed bug where changing color in RichEditBox will color previously entered text black.
## Description
<!--- Describe your changes in detail -->
Removed the line that colored text black when RichEditBox got focus.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #146.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by reproducing steps in the issue.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
