### PR TITLE
Fix sun icon wrong color on high contrast in PTR page;

### DIFF
--- a/XamlControlsGallery/ControlPages/PullToRefreshPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/PullToRefreshPage.xaml.cs
@@ -57,15 +57,14 @@ namespace AppUIBasics.ControlPages
                 Image ptrImage = new Image();
                 AccessibilitySettings accessibilitySettings = new AccessibilitySettings();
                 // Checking light theme
-                if (App.RootTheme == ElementTheme.Light || Application.Current.RequestedTheme == ApplicationTheme.Light)
+                if ((App.RootTheme == ElementTheme.Light || Application.Current.RequestedTheme == ApplicationTheme.Light) 
+                    && !accessibilitySettings.HighContrast)
                 {
                     ptrImage.Source = new BitmapImage(new Uri("ms-appx:///Assets/SunBlack.png"));
                 }
                 // Checking high contrast theme
                 else if (accessibilitySettings.HighContrast
-                          && accessibilitySettings.HighContrastScheme.Equals("High Contrast White")
-                          || accessibilitySettings.HighContrastScheme.Equals("High Contrast #1")
-                          || accessibilitySettings.HighContrastScheme.Equals("High Contrast #2"))
+                          && accessibilitySettings.HighContrastScheme.Equals("High Contrast Black"))
                 {
                     ptrImage.Source = new BitmapImage(new Uri("ms-appx:///Assets/SunBlack.png"));
                 }

--- a/XamlControlsGallery/ControlPages/PullToRefreshPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/PullToRefreshPage.xaml.cs
@@ -1,21 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.Foundation;
-using Windows.Foundation.Collections;
 using Windows.Foundation.Metadata;
 using Windows.UI.Composition;
 using Windows.UI.Core;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Hosting;
-using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;
 using Windows.UI.Xaml.Navigation;
@@ -63,18 +55,24 @@ namespace AppUIBasics.ControlPages
                     new TypedEventHandler<RefreshVisualizer, RefreshStateChangedEventArgs>(rv2_RefreshStateChanged);
 
                 Image ptrImage = new Image();
-                // Checking is mode is high contrast and user uses one of the high contrast modes where white icon would be better
                 AccessibilitySettings accessibilitySettings = new AccessibilitySettings();
-                if ((App.RootTheme == ElementTheme.Light || Application.Current.RequestedTheme == ApplicationTheme.Light)
-                    && !(accessibilitySettings.HighContrast 
-                            && accessibilitySettings.HighContrastScheme.Equals("High Contrast White")
-                            || accessibilitySettings.HighContrastScheme.Equals("High Contrast #1") 
-                            || accessibilitySettings.HighContrastScheme.Equals("High Contrast #2")))
+                // Checking light theme
+                if (App.RootTheme == ElementTheme.Light || Application.Current.RequestedTheme == ApplicationTheme.Light)
                 {
                     ptrImage.Source = new BitmapImage(new Uri("ms-appx:///Assets/SunBlack.png"));
-                } else
+                }
+                // Checking high contrast theme
+                else if (accessibilitySettings.HighContrast
+                          && accessibilitySettings.HighContrastScheme.Equals("High Contrast White")
+                          || accessibilitySettings.HighContrastScheme.Equals("High Contrast #1")
+                          || accessibilitySettings.HighContrastScheme.Equals("High Contrast #2"))
+                {
+                    ptrImage.Source = new BitmapImage(new Uri("ms-appx:///Assets/SunBlack.png"));
+                }
+                else
                 {
                     ptrImage.Source = new BitmapImage(new Uri("ms-appx:///Assets/SunWhite.png"));
+
                 }
 
                 ptrImage.Width = 35;
@@ -94,7 +92,7 @@ namespace AppUIBasics.ControlPages
                 rc2.Content = lv2;
 
                 Ex2Grid.Children.Add(rc2);
-                Grid.SetRow( rc2, 1);
+                Grid.SetRow(rc2, 1);
                 Grid.SetRow(lv2, 1);
 
                 timer1.Interval = new TimeSpan(0, 0, 0, 0, 500);
@@ -201,6 +199,6 @@ namespace AppUIBasics.ControlPages
         private void rv2_RefreshStateChanged(RefreshVisualizer sender, RefreshStateChangedEventArgs args)
         {
             //visualizerContentVisual.StopAnimation("RotationAngle");
-         }
+        }
     }
 }

--- a/XamlControlsGallery/ControlPages/PullToRefreshPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/PullToRefreshPage.xaml.cs
@@ -9,6 +9,7 @@ using Windows.Foundation.Collections;
 using Windows.Foundation.Metadata;
 using Windows.UI.Composition;
 using Windows.UI.Core;
+using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
@@ -62,7 +63,13 @@ namespace AppUIBasics.ControlPages
                     new TypedEventHandler<RefreshVisualizer, RefreshStateChangedEventArgs>(rv2_RefreshStateChanged);
 
                 Image ptrImage = new Image();
-                if (App.RootTheme == ElementTheme.Light || Application.Current.RequestedTheme == ApplicationTheme.Light)
+                // Checking is mode is high contrast and user uses one of the high contrast modes where white icon would be better
+                AccessibilitySettings accessibilitySettings = new AccessibilitySettings();
+                if ((App.RootTheme == ElementTheme.Light || Application.Current.RequestedTheme == ApplicationTheme.Light)
+                    && !(accessibilitySettings.HighContrast 
+                            && accessibilitySettings.HighContrastScheme.Equals("High Contrast White")
+                            || accessibilitySettings.HighContrastScheme.Equals("High Contrast #1") 
+                            || accessibilitySettings.HighContrastScheme.Equals("High Contrast #2")))
                 {
                     ptrImage.Source = new BitmapImage(new Uri("ms-appx:///Assets/SunBlack.png"));
                 } else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed problematic icon color when using high contrast mode in the PullToRelease component.
## Description
<!--- Describe your changes in detail -->
Added a check wether:
* High contrast mode is enabled
* The high contrast mode is one of the following:
  * "High Contrast #1"
  * "High Contrast #2"
  * "High Contrast White"
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #158.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by going through all themes and contrast modes and check if color of icon is suitable.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
