### PR TITLE
Fix bug where first ScrollViewer was not focusable; Closes #160;

### DIFF
--- a/XamlControlsGallery/ControlPages/ScrollViewer2Page.xaml
+++ b/XamlControlsGallery/ControlPages/ScrollViewer2Page.xaml
@@ -1,4 +1,4 @@
-﻿<local:ItemsPageBase
+<local:ItemsPageBase
     x:Class="AppUIBasics.ControlPages.ScrollViewer2Page"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -21,6 +21,7 @@
             <muxcontrols:ScrollViewer x:Name="scroller1"
                                       ContentOrientation="{x:Bind ObjectToContentOrientation(cbContentOrientation.SelectedValue), Mode=OneWay}"
                                       Height="420"
+                                      IsTabStop="True"
                                       KeyDown="Scroller_HandleKeyDown">
 
                 <VariableSizedWrapGrid HorizontalAlignment="Left" VerticalAlignment="Top" Orientation="Horizontal">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed bug where the first ScrollViewer in the "ScrollViewer (preview)" page was not focusable.
## Description
<!--- Describe your changes in detail -->
Added a ' IsTabStop="True" ' to the ScrollViewer.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #160.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by tabbing through page.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
