### PR TITLE
Add header and margin to button for PageTransitions page; Closes #163;

### DIFF
--- a/XamlControlsGallery/ControlPages/PageTransitionPage.xaml
+++ b/XamlControlsGallery/ControlPages/PageTransitionPage.xaml
@@ -13,13 +13,16 @@
     <local:ControlExample x:Name="Example1" HeaderText="Page transitions" HorizontalAlignment="Stretch">
         <local:ControlExample.Options>
             <StackPanel>
+                <TextBlock Margin="0,0,0,8">Transition modes</TextBlock>
                 <RadioButton x:Name="DefaultRB" Content="Default" IsChecked="True" Checked="TransitionRadioButton_Checked" AutomationProperties.Name="Default NavigationTransitionInfo"/>
                 <RadioButton x:Name="EntranceRB" Content="Entrance" Checked="TransitionRadioButton_Checked" AutomationProperties.Name="EntranceNavigationTransitionInfo" />
                 <RadioButton x:Name="DrillRB" Content="Drill" Checked="TransitionRadioButton_Checked" AutomationProperties.Name="DrillNavigationTransitionInfo" />
                 <RadioButton x:Name="SuppressRB" Content="Suppress" Checked="TransitionRadioButton_Checked" AutomationProperties.Name="SuppressNavigationTransitionInfo" />
                 <contract7Present:RadioButton x:Name="SlideFromRightRB" Content="Slide from Right" Checked="TransitionRadioButton_Checked" AutomationProperties.Name="SlideNavigationTransitionInfo From Right" />
                 <contract7Present:RadioButton x:Name="SlideFromLeftRB" Content="Slide from Left" Checked="TransitionRadioButton_Checked" AutomationProperties.Name="SlideNavigationTransitionInfo From Left" />
-                <Button Content="Navigate Forward" Click="ForwardButton1_Click" HorizontalAlignment="Stretch" />
+
+                <TextBlock Margin="0,8,0,8">Navigate</TextBlock>
+                <Button Content="Navigate Forward" Click="ForwardButton1_Click" HorizontalAlignment="Stretch" Margin="0,0,0,5   "/>
                 <Button Content="Navigate Backward" Click="BackwardButton1_Click" HorizontalAlignment="Stretch" />
             </StackPanel>
         </local:ControlExample.Options>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added headers for the button on the PageTransitions page. Also added small margin to bottom buttons so they are not glued together.
## Description
<!--- Describe your changes in detail -->
Added the header "Transition modes" for radio buttons and header "Navigate" to bottom to buttons. Added 5px margin to "Navigate Forward" button.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #163. 
Button margin: Distinct the navigate buttons a bit more from each other (previously no margin between them, so the were right next to each other looking like one button)
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by starting application.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
