### PR TITLE
Fix bug with togglesplitbutton and touch displays; Closes #166

### DIFF
--- a/XamlControlsGallery/ControlPages/ToggleSplitButtonPage.xaml
+++ b/XamlControlsGallery/ControlPages/ToggleSplitButtonPage.xaml
@@ -16,7 +16,7 @@
                     <ColumnDefinition/>
                 </Grid.ColumnDefinitions>
 
-                <muxcontrols:ToggleSplitButton x:Name="myListButton" AutomationProperties.Name="Bullets" VerticalAlignment="Top" Click="myListButton_Click">
+                <muxcontrols:ToggleSplitButton x:Name="myListButton" AutomationProperties.Name="Bullets" VerticalAlignment="Top" IsCheckedChanged="MyListButton_IsCheckedChanged">
                     <SymbolIcon x:Name="mySymbolIcon" Symbol="List"/>
                     <muxcontrols:ToggleSplitButton.Flyout>
                         <Flyout Placement="Bottom">

--- a/XamlControlsGallery/ControlPages/ToggleSplitButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ToggleSplitButtonPage.xaml.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using Windows.UI.Text;
+﻿using Windows.UI.Text;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Automation;
 using Windows.UI.Xaml.Controls;

--- a/XamlControlsGallery/ControlPages/ToggleSplitButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ToggleSplitButtonPage.xaml.cs
@@ -39,7 +39,7 @@ namespace AppUIBasics.ControlPages
 
         private void MyListButton_IsCheckedChanged(Microsoft.UI.Xaml.Controls.ToggleSplitButton sender, Microsoft.UI.Xaml.Controls.ToggleSplitButtonIsCheckedChangedEventArgs args)
         {
-            if ((sender as Microsoft.UI.Xaml.Controls.ToggleSplitButton).IsChecked)
+            if (sender.IsChecked)
             {
                 //add bulleted list
                 myRichEditBox.Document.Selection.ParagraphFormat.ListType = _type;

--- a/XamlControlsGallery/ControlPages/ToggleSplitButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ToggleSplitButtonPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Windows.UI.Text;
+﻿using System.Diagnostics;
+using Windows.UI.Text;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Automation;
 using Windows.UI.Xaml.Controls;
@@ -11,20 +12,6 @@ namespace AppUIBasics.ControlPages
         public ToggleSplitButtonPage()
         {
             this.InitializeComponent();
-        }
-
-        private void myListButton_Click(Microsoft.UI.Xaml.Controls.SplitButton sender, Microsoft.UI.Xaml.Controls.SplitButtonClickEventArgs args)
-        {
-            if ((sender as Microsoft.UI.Xaml.Controls.ToggleSplitButton).IsChecked)
-            {
-                //add bulleted list
-                myRichEditBox.Document.Selection.ParagraphFormat.ListType = _type;                
-            }
-            else
-            {
-                //remove bulleted list
-                myRichEditBox.Document.Selection.ParagraphFormat.ListType = MarkerType.None;
-            }            
         }
 
         private void BulletButton_Click(object sender, RoutedEventArgs e)
@@ -49,6 +36,20 @@ namespace AppUIBasics.ControlPages
             myListButton.IsChecked = true;
             myListButton.Flyout.Hide();
             myRichEditBox.Focus(FocusState.Keyboard);
+        }
+
+        private void MyListButton_IsCheckedChanged(Microsoft.UI.Xaml.Controls.ToggleSplitButton sender, Microsoft.UI.Xaml.Controls.ToggleSplitButtonIsCheckedChangedEventArgs args)
+        {
+            if ((sender as Microsoft.UI.Xaml.Controls.ToggleSplitButton).IsChecked)
+            {
+                //add bulleted list
+                myRichEditBox.Document.Selection.ParagraphFormat.ListType = _type;
+            }
+            else
+            {
+                //remove bulleted list
+                myRichEditBox.Document.Selection.ParagraphFormat.ListType = MarkerType.None;
+            }
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed bug where ToggleSplitButton could not be activated on touch displays.
## Description
<!--- Describe your changes in detail -->
Removed the "Click" event and replaced it with "IsCheckedChanged" event.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #166.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by starting XCG in windows simulator with touch enabled and tripple tapped button. Also tested behavior with cursor.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
