### PR TITLE
Fix bug with narrator not switching item at first try; Closes #168;

### DIFF
--- a/XamlControlsGallery/ControlPages/GridViewPage.xaml
+++ b/XamlControlsGallery/ControlPages/GridViewPage.xaml
@@ -18,9 +18,7 @@
     
     <Page.Resources>
         <DataTemplate x:Key="ImageTemplate" x:DataType="local1:CustomDataObject">
-            <Grid AutomationProperties.Name="{x:Bind Title}" Width="190" Height="130">
-                <Image Stretch="UniformToFill" Source="{x:Bind ImageLocation}" />
-            </Grid>
+                <Image Stretch="UniformToFill" Source="{x:Bind ImageLocation}" AutomationProperties.Name="{x:Bind Title}" Width="190" Height="130" AutomationProperties.AccessibilityView="Raw" />
         </DataTemplate>
 
         <DataTemplate x:Key="IconTextTemplate" x:DataType="local1:CustomDataObject">

--- a/XamlControlsGallery/ControlPages/GridViewPage.xaml
+++ b/XamlControlsGallery/ControlPages/GridViewPage.xaml
@@ -18,7 +18,7 @@
     
     <Page.Resources>
         <DataTemplate x:Key="ImageTemplate" x:DataType="local1:CustomDataObject">
-                <Image Stretch="UniformToFill" Source="{x:Bind ImageLocation}" AutomationProperties.Name="{x:Bind Title}" Width="190" Height="130" AutomationProperties.AccessibilityView="Raw" />
+            <Image Stretch="UniformToFill" Source="{x:Bind ImageLocation}" AutomationProperties.Name="{x:Bind Title}" Width="190" Height="130" AutomationProperties.AccessibilityView="Raw" />
         </DataTemplate>
 
         <DataTemplate x:Key="IconTextTemplate" x:DataType="local1:CustomDataObject">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed bug where navigating to the next image in the gridview would take two key activations.
## Description
<!--- Describe your changes in detail -->
Removed containing grid of the image and added AssessibilityView="Raw"
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #168.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by navigating through grid with narrator enabled in item mode.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
