### PR TITLE
Fix misleading click message output; Closes #187;

### DIFF
--- a/XamlControlsGallery/ControlPages/GridViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/GridViewPage.xaml.cs
@@ -55,7 +55,7 @@ namespace AppUIBasics.ControlPages
 
         private void Control1_ItemClick(object sender, ItemClickEventArgs e)
         {
-            ClickOutput.Text = "You clicked " + e.ClickedItem.ToString() + ".";
+            ClickOutput.Text = "You clicked " + (e.ClickedItem as CustomDataObject).Title + ".";
         }
 
         private void ItemClickCheckBox_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed misleading click message output for GridView item click
## Description
<!--- Describe your changes in detail -->
Casted the sender component into its correct class and accessed the title that way to generate a user readable output
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #187
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by repeating steps in issue
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
