### PR TITLE
Fix bug with sliders where not all values were reachable by keyboard…

### DIFF
--- a/XamlControlsGallery/ControlPages/ScrollViewer2Page.xaml
+++ b/XamlControlsGallery/ControlPages/ScrollViewer2Page.xaml
@@ -239,6 +239,7 @@
                             Minimum="{x:Bind scroller2.MinZoomFactor, Mode=OneWay}"
                             Value="1.0"
                             StepFrequency="0.1"
+                            SmallChange="0.1"
                             TickFrequency="1.0"
                             ValueChanged="ZoomSlider_ValueChanged" />
 
@@ -443,6 +444,7 @@
                     <Slider x:Name="zoomFactorSlider"
                             StepFrequency="0.1"
                             TickFrequency="0.2"
+                            SmallChange="0.1"
                             Minimum="0.1"
                             Maximum="2.0"
                             Value="1.0"


### PR DESCRIPTION
…; Closes #184;
Fixed a bug where values that where not whole numbers where not reachable using keyboard.
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added the "SmallStep" property and that seemed to fix it.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #184.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by tabbing through page and using arrow keys to change slider values.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
