### PR TITLE
Fix bug where zoomslider would jump when sliding; Closes #182;

### DIFF
--- a/XamlControlsGallery/ControlPages/ScrollViewer2Page.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ScrollViewer2Page.xaml.cs
@@ -47,9 +47,6 @@ namespace AppUIBasics.ControlPages
             scroller2MouseIsOver = true;
         }
 
-        private void ZoomSlider_ValueChanged1(object sender, RangeBaseValueChangedEventArgs e)
-        {
-        }
 
         #region Zooming
 

--- a/XamlControlsGallery/ControlPages/ScrollViewer2Page.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ScrollViewer2Page.xaml.cs
@@ -27,11 +27,28 @@ namespace AppUIBasics.ControlPages
     /// </summary>
     public sealed partial class ScrollViewer2Page : ItemsPageBase
     {
+        private bool scroller2MouseIsOver = false;
         public ScrollViewer2Page()
         {
             this.InitializeComponent();
 
             this.scroller2.StateChanged += Scroller_StateChanged;
+            this.scroller2.PointerEntered += this.Scroller2_PointerEntered;
+            this.scroller2.PointerExited += this.Scroller2_PointerExited;
+        }
+
+        private void Scroller2_PointerExited(object sender, PointerRoutedEventArgs e)
+        {
+            scroller2MouseIsOver = false;
+        }
+
+        private void Scroller2_PointerEntered(object sender, PointerRoutedEventArgs e)
+        {
+            scroller2MouseIsOver = true;
+        }
+
+        private void ZoomSlider_ValueChanged1(object sender, RangeBaseValueChangedEventArgs e)
+        {
         }
 
         #region Zooming
@@ -62,15 +79,13 @@ namespace AppUIBasics.ControlPages
 
         private void Scroller_StateChanged(muxc.ScrollViewer sender, object args)
         {
-            // each time it comes to rest update the slider to reflect the current zoom factor
-            if (sender.State == muxc.InteractionState.Idle)
+            
+            // Checking if sender is idle and the scrollviewer has the mouse over itsself 
+            // since when using slider, the sender may sometimes still be idle while
+            // user is still changing the slider
+            if (sender.State == muxc.InteractionState.Idle && scroller2MouseIsOver)
             {
                 ZoomSlider.Value = Math.Round(sender.ZoomFactor, (int)(10 * ZoomSlider.StepFrequency));
-                ZoomSlider.ValueChanged += ZoomSlider_ValueChanged;
-            }
-            else
-            {
-                ZoomSlider.ValueChanged -= ZoomSlider_ValueChanged;
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed a bug where zoomslider would jump around and not stay in the position it should be.
## Description
<!--- Describe your changes in detail -->
Added a check if the user actually is zooming with the mouse by detecting mouse over.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #182.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested following scenarios:
- Zooming with mouse over scrollviewer
- Focus on zoomslider, Zooming with mouse over scrollviewer
- Zooming using zoomslider 
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
