### PR TITLE
Fix bug where narrator would not shift-tab to scrollviewer; Closes #181;

### DIFF
--- a/XamlControlsGallery/ControlPages/ScrollViewer2Page.xaml
+++ b/XamlControlsGallery/ControlPages/ScrollViewer2Page.xaml
@@ -21,6 +21,7 @@
             <muxcontrols:ScrollViewer x:Name="scroller1"
                                       ContentOrientation="{x:Bind ObjectToContentOrientation(cbContentOrientation.SelectedValue), Mode=OneWay}"
                                       Height="420"
+                                      AutomationProperties.Name="Scrollviewer with item grid inside"
                                       IsTabStop="True"
                                       KeyDown="Scroller_HandleKeyDown">
 
@@ -284,6 +285,7 @@
                                       IsTabStop="True"
                                       VerticalScrollChainingMode="Never"
                                       HorizontalScrollChainingMode="Never"
+                                      AutomationProperties.Name="Scrollviewer with image inside"
                                       ZoomMode="Enabled"
                                       Height="420"
                                       KeyDown="Scroller_HandleKeyDown">
@@ -351,8 +353,10 @@
                                       ScrollAnimationStarting="Scroller4_ScrollAnimationStarting"
                                       ZoomAnimationStarting="Scroller4_ZoomAnimationStarting"
                                       HorizontalAlignment="Left"
+                                      AutomationProperties.Name="Scrollviewer with image inside"
                                       VerticalAlignment="Top"
                                       Height="420"
+                                      IsTabStop="True"
                                       KeyDown="Scroller_HandleKeyDown">
                 <Image Source="{StaticResource BitmapImageSource}"
                        Stretch="None"

--- a/XamlControlsGallery/ControlPages/ScrollViewer2Page.xaml
+++ b/XamlControlsGallery/ControlPages/ScrollViewer2Page.xaml
@@ -134,6 +134,7 @@
                                       VerticalScrollBarVisibility="{x:Bind ObjectToScrollControllerVisibility(vsbvCombo.SelectedItem), Mode=OneWay}"
                                       ZoomMode="Disabled"
                                       Height="420"
+                                      AutomationProperties.Name="Scrollviewer with image inside"
                                       KeyDown="Scroller_HandleKeyDown">
                 <Image x:Name="image" Source="{StaticResource BitmapImageSource}" Stretch="None" HorizontalAlignment="Left"
                         VerticalAlignment="Top" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed a bug where navigating with narrator would not allow focusing of scrollviewer with image
## Description
<!--- Describe your changes in detail -->
Added "AutomationProperties.Name" property
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #181 .
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by navigating through page with narrator and press shift tab to get to the scrollviewer.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
