### PR TITLE
Add Reveal styles (and Accent style) to samples

### DIFF
--- a/XamlControlsGallery/ControlPages/AppBarButtonPage.xaml
+++ b/XamlControlsGallery/ControlPages/AppBarButtonPage.xaml
@@ -110,5 +110,15 @@
                 </x:String>
             </local:ControlExample.Xaml>
         </local:ControlExample>
+        <local:ControlExample HeaderText="An AppBarButton with Reveal style applied">
+            <local:ControlExample.Example>
+                <AppBarButton Style="{StaticResource AppBarButtonRevealStyle}" Icon="Add" Label="Add item" />
+            </local:ControlExample.Example>
+            <local:ControlExample.Xaml>
+                <x:String>
+                    &lt;AppBarButton Style="{StaticResource AppBarButtonRevealStyle}" Icon="Add" Label="Add item" /&gt;
+                </x:String>
+            </local:ControlExample.Xaml>
+        </local:ControlExample>
     </StackPanel>
 </Page>

--- a/XamlControlsGallery/ControlPages/AppBarButtonPage.xaml
+++ b/XamlControlsGallery/ControlPages/AppBarButtonPage.xaml
@@ -110,7 +110,7 @@
                 </x:String>
             </local:ControlExample.Xaml>
         </local:ControlExample>
-        <local:ControlExample HeaderText="An AppBarButton with Reveal style applied">
+        <local:ControlExample HeaderText="An AppBarButton with Reveal style.">
             <local:ControlExample.Example>
                 <AppBarButton Style="{StaticResource AppBarButtonRevealStyle}" Icon="Add" Label="Add item" />
             </local:ControlExample.Example>

--- a/XamlControlsGallery/ControlPages/AppBarToggleButtonPage.xaml
+++ b/XamlControlsGallery/ControlPages/AppBarToggleButtonPage.xaml
@@ -97,7 +97,7 @@
                 </x:String>
             </local:ControlExample.Xaml>
         </local:ControlExample>
-        <local:ControlExample HeaderText="An AppBarToggleButton with Reveal style applied">
+        <local:ControlExample HeaderText="An AppBarToggleButton with Reveal style applied.">
             <local:ControlExample.Example>
                 <AppBarToggleButton Style="{StaticResource AppBarToggleButtonRevealStyle}" Icon="Shuffle" Label="Shuffle" />
             </local:ControlExample.Example>

--- a/XamlControlsGallery/ControlPages/AppBarToggleButtonPage.xaml
+++ b/XamlControlsGallery/ControlPages/AppBarToggleButtonPage.xaml
@@ -97,5 +97,15 @@
                 </x:String>
             </local:ControlExample.Xaml>
         </local:ControlExample>
+        <local:ControlExample HeaderText="An AppBarToggleButton with Reveal style applied">
+            <local:ControlExample.Example>
+                <AppBarToggleButton Style="{StaticResource AppBarToggleButtonRevealStyle}" Icon="Shuffle" Label="Shuffle" />
+            </local:ControlExample.Example>
+            <local:ControlExample.Xaml>
+                <x:String>
+                    &lt;AppBarToggleButton Style="{StaticResource AppBarToggleButtonRevealStyle}" Icon="Shuffle" Label="Shuffle" /&gt;
+                </x:String>
+            </local:ControlExample.Xaml>
+        </local:ControlExample>
     </StackPanel>
 </Page>

--- a/XamlControlsGallery/ControlPages/ButtonPage.xaml
+++ b/XamlControlsGallery/ControlPages/ButtonPage.xaml
@@ -57,7 +57,7 @@
                 </x:String>
             </local:ControlExample.Xaml>
         </local:ControlExample>
-        <local:ControlExample HeaderText="Reveal style applied on Button">
+        <local:ControlExample HeaderText="Reveal style applied to Button.">
             <local:ControlExample.Example>
                 <Button Style="{StaticResource ButtonRevealStyle}" Content="Button"/>
             </local:ControlExample.Example>
@@ -67,13 +67,13 @@
                 </x:String>
             </local:ControlExample.Xaml>
         </local:ControlExample>
-        <local:ControlExample HeaderText="Accent style applied on Button">
+        <local:ControlExample HeaderText="Accent style applied to Button.">
             <local:ControlExample.Example>
                 <Button Style="{StaticResource AccentButtonStyle}" Content="Button"/>
             </local:ControlExample.Example>
             <local:ControlExample.Xaml>
                 <x:String >
-                    &lt;Button Style="{StaticResource ButtonRevealStyle}" Content="Button" /&gt;
+                    &lt;Button Style="{StaticResource AccentButtonStyle}" Content="Button" /&gt;
                 </x:String>
             </local:ControlExample.Xaml>
         </local:ControlExample>

--- a/XamlControlsGallery/ControlPages/ButtonPage.xaml
+++ b/XamlControlsGallery/ControlPages/ButtonPage.xaml
@@ -57,6 +57,26 @@
                 </x:String>
             </local:ControlExample.Xaml>
         </local:ControlExample>
+        <local:ControlExample HeaderText="Reveal style applied on Button">
+            <local:ControlExample.Example>
+                <Button Style="{StaticResource ButtonRevealStyle}" Content="Button"/>
+            </local:ControlExample.Example>
+            <local:ControlExample.Xaml>
+                <x:String >
+                    &lt;Button Style="{StaticResource ButtonRevealStyle}" Content="Button" /&gt;
+                </x:String>
+            </local:ControlExample.Xaml>
+        </local:ControlExample>
+        <local:ControlExample HeaderText="Accent style applied on Button">
+            <local:ControlExample.Example>
+                <Button Style="{StaticResource AccentButtonStyle}" Content="Button"/>
+            </local:ControlExample.Example>
+            <local:ControlExample.Xaml>
+                <x:String >
+                    &lt;Button Style="{StaticResource ButtonRevealStyle}" Content="Button" /&gt;
+                </x:String>
+            </local:ControlExample.Xaml>
+        </local:ControlExample>
         <local:ControlExample x:Name="Example3" HeaderText="Custom button appearance" XamlSource="Buttons/Button/CustomButtonStyle.txt">
             <local:ControlExample.Example>
                 <StackPanel Orientation="Horizontal">

--- a/XamlControlsGallery/ControlPages/RepeatButtonPage.xaml
+++ b/XamlControlsGallery/ControlPages/RepeatButtonPage.xaml
@@ -39,5 +39,19 @@
                                                   Value= "IsEnabled=&quot;False&quot; "/>
             </local:ControlExample.Substitutions>
         </local:ControlExample>
+        <local:ControlExample HeaderText="A RepeatButton with Reveal style applied">
+            <local:ControlExample.Example>
+                <StackPanel Orientation="Horizontal">
+                    <RepeatButton Style="{StaticResource RepeatButtonRevealStyle}" Content="Button" Click="RepeatButtonReveal_Click"/>
+                    <TextBlock x:Name="ControlRevealOutput" Margin="8,0,0,0" VerticalAlignment="Center" />
+                </StackPanel>
+            </local:ControlExample.Example>
+            <local:ControlExample.Xaml>
+                <x:String>
+                    &lt;RepeatButton Style="{StaticResource RepeatButtonRevealStyle}" Content="Button"/&gt;
+                </x:String>
+            </local:ControlExample.Xaml>
+        </local:ControlExample>
+
     </StackPanel>
 </Page>

--- a/XamlControlsGallery/ControlPages/RepeatButtonPage.xaml
+++ b/XamlControlsGallery/ControlPages/RepeatButtonPage.xaml
@@ -39,10 +39,10 @@
                                                   Value= "IsEnabled=&quot;False&quot; "/>
             </local:ControlExample.Substitutions>
         </local:ControlExample>
-        <local:ControlExample HeaderText="A RepeatButton with Reveal style applied">
+        <local:ControlExample HeaderText="A RepeatButton with Reveal style applied.">
             <local:ControlExample.Example>
                 <StackPanel Orientation="Horizontal">
-                    <RepeatButton Style="{StaticResource RepeatButtonRevealStyle}" Content="Button" Click="RepeatButtonReveal_Click"/>
+                    <RepeatButton Style="{StaticResource RepeatButtonRevealStyle}" Content="Click and hold" Click="RepeatButtonReveal_Click"/>
                     <TextBlock x:Name="ControlRevealOutput" Margin="8,0,0,0" VerticalAlignment="Center" />
                 </StackPanel>
             </local:ControlExample.Example>

--- a/XamlControlsGallery/ControlPages/RepeatButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RepeatButtonPage.xaml.cs
@@ -25,10 +25,17 @@ namespace AppUIBasics.ControlPages
         }
 
         private static int _clicks = 0;
+        private static int _clickReveal = 0;
         private void RepeatButton_Click(object sender, RoutedEventArgs e)
         {
             _clicks += 1;
             Control1Output.Text = "Number of clicks: " + _clicks;
+        }
+
+        private void RepeatButtonReveal_Click(object sender, RoutedEventArgs e)
+        {
+            _clickReveal += 1;
+            ControlRevealOutput.Text = "Number of clicks: " + _clickReveal;
         }
     }
 }

--- a/XamlControlsGallery/ControlPages/ToggleButtonPage.xaml
+++ b/XamlControlsGallery/ControlPages/ToggleButtonPage.xaml
@@ -42,7 +42,7 @@
         </local:ControlExample>
         <local:ControlExample HeaderText="A ToggleButton with Reveal style applied.">
             <StackPanel Orientation="Horizontal" VerticalAlignment="Top">
-                <ToggleButton Content="ToggleButton"
+                <ToggleButton  x:Name="ToggleReveal" Content="ToggleButton"
                               Style="{StaticResource ToggleButtonRevealStyle}"
                               Checked="ToggleButtonReveal_Checked" Unchecked="ToggleButtonReveal_Unchecked" />
                 <TextBlock x:Name="ControlRevealOutput" Margin="8,0,0,0" VerticalAlignment="Center" />

--- a/XamlControlsGallery/ControlPages/ToggleButtonPage.xaml
+++ b/XamlControlsGallery/ControlPages/ToggleButtonPage.xaml
@@ -40,5 +40,18 @@
                                                   Value= "IsEnabled=&quot;False&quot; "/>
             </local:ControlExample.Substitutions>
         </local:ControlExample>
+        <local:ControlExample HeaderText="A ToggleButton with Reveal style applied.">
+            <StackPanel Orientation="Horizontal" VerticalAlignment="Top">
+                <ToggleButton Content="ToggleButton"
+                              Style="{StaticResource ToggleButtonRevealStyle}"
+                              Checked="ToggleButtonReveal_Checked" Unchecked="ToggleButtonReveal_Unchecked" />
+                <TextBlock x:Name="ControlRevealOutput" Margin="8,0,0,0" VerticalAlignment="Center" />
+            </StackPanel>
+            <local:ControlExample.Xaml>
+                <x:String>
+                    &lt;ToggleButton Content="ToggleButton" Style="{StaticResource ToggleButtonRevealStyle}"/&gt;
+                </x:String>
+            </local:ControlExample.Xaml>
+        </local:ControlExample>
     </StackPanel>
 </Page>

--- a/XamlControlsGallery/ControlPages/ToggleButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ToggleButtonPage.xaml.cs
@@ -25,6 +25,7 @@ namespace AppUIBasics.ControlPages
 
             // Set initial outpput value.
             Control1Output.Text = (bool)Toggle1.IsChecked ? "On" : "Off";
+            ControlRevealOutput.Text = (bool)ToggleReveal.IsChecked ? "On" : "Off";
         }
 
         private void ToggleButton_Checked(object sender, RoutedEventArgs e)

--- a/XamlControlsGallery/ControlPages/ToggleButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ToggleButtonPage.xaml.cs
@@ -36,5 +36,14 @@ namespace AppUIBasics.ControlPages
         {
             Control1Output.Text = "Off";
         }
+        private void ToggleButtonReveal_Checked(object sender, RoutedEventArgs e)
+        {
+            ControlRevealOutput.Text = "On";
+        }
+
+        private void ToggleButtonReveal_Unchecked(object sender, RoutedEventArgs e)
+        {
+            ControlRevealOutput.Text = "Off";
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added samples to component pages which have a RevealStyle which is not enabled by default (e.g. Button)
## Description
<!--- Describe your changes in detail -->
Added code samples to components
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Goal is to add the Reveal styles to the component where they are available for and show them on their sample page so users won't miss them. This PR is an effort towards #155.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by navigating through component pages and checking if Reveal style is displayed in a fashion that it is comprehensible for the user.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
