### PR TITLE
Move PullToRefresh.xaml.cs inside its .xaml file in project view

### DIFF
--- a/XamlControlsGallery/XamlControlsGallery.csproj
+++ b/XamlControlsGallery/XamlControlsGallery.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -441,7 +441,9 @@
     <Compile Include="ControlPages\ProgressRingPage.xaml.cs">
       <DependentUpon>ProgressRingPage.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ControlPages\PullToRefreshPage.xaml.cs" />
+    <Compile Include="ControlPages\PullToRefreshPage.xaml.cs" >
+      <DependentUpon>PullToRefreshPage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="ControlPages\RadioButtonPage.xaml.cs">
       <DependentUpon>RadioButtonPage.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed the displaying of PullToRefreshPage.xaml(.cs) in project view
## Description
<!--- Describe your changes in detail -->
"Moved" the PullToRefreshPage.xaml.cs inside PullToRefreshPage.xaml file in project view
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Makes project view a bit more cleaner
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by starting Visual Studio and the XCG application.
## Screenshots (if appropriate):
Changed this:
![image](https://user-images.githubusercontent.com/16122379/64061657-32fb0280-cbde-11e9-84da-536a137c03a6.png) 
into this:
![image](https://user-images.githubusercontent.com/16122379/64061672-545bee80-cbde-11e9-9291-7fbf0903ab18.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
