### PR TITLE
Update WinUI package to 2.2 release

### DIFF
--- a/XamlControlsGallery/DataModel/ControlInfoData.json
+++ b/XamlControlsGallery/DataModel/ControlInfoData.json
@@ -1165,33 +1165,6 @@
           ]
         },
         {
-          "UniqueId": "ScrollViewer2",
-          "Title": "ScrollViewer (preview)",
-          "Subtitle": "A container control that lets the user pan and zoom its content.",
-          "ImagePath": "ms-appx:///Assets/ScrollViewer.png",
-          "Description": "The new ScrollViewer lets a user scroll, pan, and zoom to see content that's larger than the viewable area. Many content controls, like ListView, have ScrollViewers built into their control templates to provide automatic scrolling.",
-          "Content": "<p>Look at the <i>ScrollViewer2Page.xaml</i> file in Visual Studio to see the full code for this page.</p>",
-          "IsPreview": true,
-          "Docs": [
-            {
-              "Title": "ScrollViewer - API",
-              "Uri": "https://docs.microsoft.com/uwp/api/microsoft.ui.xaml.controls.scrollviewer"
-            },
-            {
-              "Title": "Guidance",
-              "Uri": "https://docs.microsoft.com/windows/uwp/design/controls-and-patterns/scroll-controls"
-            }
-          ],
-          "RelatedControls": [
-            "ViewBox",
-            "Canvas",
-            "Grid",
-            "StackPanel",
-            "RelativePanel",
-            "ParallaxView"
-          ]
-        },
-        {
           "UniqueId": "SemanticZoom",
           "Title": "SemanticZoom",
           "Subtitle": "Lets the user zoom between two different views of a collection, making it easier to navigate through large collections of items.",

--- a/XamlControlsGallery/XamlControlsGallery.csproj
+++ b/XamlControlsGallery/XamlControlsGallery.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -414,9 +414,6 @@
     <Compile Include="ControlPages\PageTransitionPage.xaml.cs">
       <DependentUpon>PageTransitionPage.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ControlPages\ScrollViewer2Page.xaml.cs">
-      <DependentUpon>ScrollViewer2Page.xaml</DependentUpon>
-    </Compile>
     <Compile Include="ControlPages\TeachingTipPage.xaml.cs">
       <DependentUpon>TeachingTipPage.xaml</DependentUpon>
     </Compile>
@@ -441,7 +438,7 @@
     <Compile Include="ControlPages\ProgressRingPage.xaml.cs">
       <DependentUpon>ProgressRingPage.xaml</DependentUpon>
     </Compile>
-    <Compile Include="ControlPages\PullToRefreshPage.xaml.cs" >
+    <Compile Include="ControlPages\PullToRefreshPage.xaml.cs">
       <DependentUpon>PullToRefreshPage.xaml</DependentUpon>
     </Compile>
     <Compile Include="ControlPages\RadioButtonPage.xaml.cs">
@@ -692,10 +689,6 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="ControlPages\TeachingTipPage.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </Page>
-    <Page Include="ControlPages\ScrollViewer2Page.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
@@ -1084,7 +1077,7 @@
       <Version>6.1.9</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
-      <Version>2.2.190611001-prerelease</Version>
+      <Version>2.2.190830001</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed">
       <Version>2.0.0</Version>


### PR DESCRIPTION
Update WinUI package to 2.2 release and remove experimental scrollviewer2 sample. (The code is still there but not compiled)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updates to the latest 2.2 release package. Since the release package does not contain preview features (like ScrollViewer2) removed that sample from the compile step and from the landing page. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This step is required before updating the Gallery to include the release version of TabView & other 2.2 features. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Clean rebuild, manual verification across several pages.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
