### PR TITLE
Fix crashing with acrylic page, Closes #107

### DIFF
--- a/XamlControlsGallery/ControlPages/AcrylicPage.xaml
+++ b/XamlControlsGallery/ControlPages/AcrylicPage.xaml
@@ -4,9 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:AppUIBasics"
     xmlns:media="using:Microsoft.UI.Xaml.Media"
-    xmlns:preview="using:Microsoft.UI.Xaml.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:contract8Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 8)"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     <Page.Resources>
@@ -200,8 +198,7 @@
             </local:ControlExample.Substitutions>
         </local:ControlExample>
 
-        <!-- Disable this sample until we find the root cause of the Luminosity slider crash. -->
-        <local:ControlExample x:Name="Example5" HeaderText="Luminosity with in-app Acrylic." MinimumUniversalAPIContract="8">
+        <local:ControlExample x:Name="Example5" HeaderText="Luminosity with in-app Acrylic.">
             <local:ControlExample.Example>
                 <Grid x:Name="Example5Grid" MinWidth="650" MinHeight="200">
                     <Grid.ColumnDefinitions>

--- a/XamlControlsGallery/ControlPages/AcrylicPage.xaml
+++ b/XamlControlsGallery/ControlPages/AcrylicPage.xaml
@@ -3,9 +3,10 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:AppUIBasics"
-    xmlns:media="using:Windows.UI.Xaml.Media"
+    xmlns:media="using:Microsoft.UI.Xaml.Media"
     xmlns:preview="using:Microsoft.UI.Xaml.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:contract8Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 8)"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     <Page.Resources>
@@ -14,7 +15,7 @@
                 <ResourceDictionary x:Key="Default">
                     <media:AcrylicBrush x:Key="CustomAcrylicInAppBrush" BackgroundSource="Backdrop" TintOpacity="0.8" TintColor="Black" FallbackColor="Green"/>
                     <media:AcrylicBrush x:Key="CustomAcrylicBackgroundBrush" BackgroundSource="HostBackdrop" TintOpacity="0.8" TintColor="Black" FallbackColor="Green"/>
-                    <media:AcrylicBrush x:Key="CustomAcrylicInAppLuminosity" BackgroundSource="Backdrop" TintLuminosityOpacity="0.8" TintOpacity="0.8" TintColor="SkyBlue" FallbackColor="SkyBlue"/>
+                    <media:AcrylicBrush x:Key="CustomAcrylicInAppLuminosity" BackgroundSource="Backdrop" TintOpacity="0.8" TintColor="SkyBlue" FallbackColor="SkyBlue"/>
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
 
@@ -198,10 +199,9 @@
                 <local:ControlExampleSubstitution Key="FallbackColor" Value="{x:Bind FallbackColorSelector.SelectedItem, Mode=OneWay}"/>
             </local:ControlExample.Substitutions>
         </local:ControlExample>
-        
+
         <!-- Disable this sample until we find the root cause of the Luminosity slider crash. -->
-        <local:ControlExample x:Name="Example5" HeaderText="Luminosity with in-app Acrylic." 
-                              Visibility="Collapsed">
+        <local:ControlExample x:Name="Example5" HeaderText="Luminosity with in-app Acrylic." MinimumUniversalAPIContract="8">
             <local:ControlExample.Example>
                 <Grid x:Name="Example5Grid" MinWidth="650" MinHeight="200">
                     <Grid.ColumnDefinitions>

--- a/XamlControlsGallery/ControlPages/AcrylicPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AcrylicPage.xaml.cs
@@ -35,25 +35,25 @@ namespace AppUIBasics.ControlPages
             if (sender == OpacitySliderLumin)
                 shape = CustomAcrylicShapeLumin;
 
-            ((AcrylicBrush)shape.Fill).TintOpacity = e.NewValue;
+            ((Microsoft.UI.Xaml.Media.AcrylicBrush)shape.Fill).TintOpacity = e.NewValue;
         }
 
         private void ColorSelector_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             Rectangle shape = (sender == ColorSelectorInApp) ? CustomAcrylicShapeInApp : CustomAcrylicShape;
-            ((AcrylicBrush)shape.Fill).TintColor = ((SolidColorBrush)e.AddedItems.First()).Color;
+            ((Microsoft.UI.Xaml.Media.AcrylicBrush)shape.Fill).TintColor = ((SolidColorBrush)e.AddedItems.First()).Color;
         }
 
         private void FallbackColorSelector_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             Rectangle shape = (sender == FallbackColorSelectorInApp) ? CustomAcrylicShapeInApp : CustomAcrylicShape;
-            ((AcrylicBrush)shape.Fill).FallbackColor = ((SolidColorBrush)e.AddedItems.First()).Color;
+            ((Microsoft.UI.Xaml.Media.AcrylicBrush)shape.Fill).FallbackColor = ((SolidColorBrush)e.AddedItems.First()).Color;
         }
 
         private void LuminositySlider_ValueChanged(object sender, RangeBaseValueChangedEventArgs e)
         {
             Rectangle shape = CustomAcrylicShapeLumin;
-            ((AcrylicBrush)shape.Fill).TintLuminosityOpacity = e.NewValue;
+            ((Microsoft.UI.Xaml.Media.AcrylicBrush)shape.Fill).TintLuminosityOpacity = e.NewValue;
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix the problem with the acrylic sample page crashing. Reenabled the TintLuminosityOpacity sample for Windows 10 Build 18362 users.
## Description
<!--- Describe your changes in detail -->
The problem for the crashing was that we casted an Microsoft.UI.Xaml.Media.AcrylicBrush to Windows.UI.Xaml.Media.AcrylicBrush which failed and crashed the app.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #107 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by starting application and navigating to Acrylic page.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
