### PR TITLE
Fix bug with changing focus and apply changes from #157 to SplitButton page, Closes #200

### DIFF
--- a/XamlControlsGallery/ControlPages/SplitButtonPage.xaml
+++ b/XamlControlsGallery/ControlPages/SplitButtonPage.xaml
@@ -88,7 +88,11 @@
                     </muxcontrols:SplitButton.Flyout>
                 </muxcontrols:SplitButton>
 
-                <RichEditBox x:Name="myRichEditBox" Grid.Column="1" MinWidth="240" MinHeight="96" PlaceholderText="Type something here" TextChanged="MyRichEditBox_TextChanged"/>
+                <RichEditBox x:Name="myRichEditBox" Grid.Column="1" MinWidth="240" MinHeight="96" 
+                             PlaceholderText="Type something here" 
+                             GotFocus="MyRichEditBox_GotFocus"
+                             LosingFocus="MyRichEditBox_LosingFocus"
+                             TextChanging="MyRichEditBox_TextChanging"/>
             </Grid>
         </local:ControlExample>
     </StackPanel>

--- a/XamlControlsGallery/ControlPages/SplitButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/SplitButtonPage.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using Windows.UI;
+using Windows.UI.Text;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
@@ -9,6 +10,11 @@ namespace AppUIBasics.ControlPages
     {
         private Color currentColor = Colors.Black;
 
+        // String used to restore the colors when the focus gets reenabled
+        // See #144 for more info https://github.com/microsoft/Xaml-Controls-Gallery/issues/144 
+        // (which also applies to this RichEditBox)
+        private string LastFormattedText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, " +
+                "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Tempor commodo ullamcorper a lacus.";
         public SplitButtonPage()
         {
             this.InitializeComponent();
@@ -41,9 +47,53 @@ namespace AppUIBasics.ControlPages
             currentColor = color;
         }
 
-        private void MyRichEditBox_TextChanged(object sender, RoutedEventArgs e)
+        private void MyRichEditBox_TextChanging(object sender, RichEditBoxTextChangingEventArgs e)
         {
+            // Hitting control+b and similiar commands my overwrite the color,
+            // which result to black text on black background when losing focus on dark theme.
+            // Solution: check if text actually changed
+            if (e.IsContentChanging)
+            {
+                myRichEditBox.Document.Selection.CharacterFormat.ForegroundColor = currentColor;
+            }
+        }
+
+
+        private void MyRichEditBox_GotFocus(object sender, RoutedEventArgs e)
+        {
+            // reset colors to correct defaults for Focused state
+            ITextRange documentRange = myRichEditBox.Document.GetRange(0, TextConstants.MaxUnitCount);
+            SolidColorBrush background = (SolidColorBrush)App.Current.Resources["TextControlBackgroundFocused"];
+            SolidColorBrush foreground = (SolidColorBrush)App.Current.Resources["TextControlForegroundFocused"];
+
+            myRichEditBox.Document.ApplyDisplayUpdates();
+
+            if (background != null && foreground != null)
+            {
+                documentRange.CharacterFormat.BackgroundColor = background.Color;
+            }
+            // saving selection span
+            var caretPosition = myRichEditBox.Document.Selection.GetIndex(TextRangeUnit.Character) - 1;
+            if (caretPosition <= 0)
+            {
+                // User has not entered text, prevent invalid values and just set index to 1
+                caretPosition = 1;
+            }
+            var selectionLength = myRichEditBox.Document.Selection.Length;
+            // restoring text styling, unintentionally sets caret position at beginning of text
+            myRichEditBox.Document.SetText(TextSetOptions.FormatRtf, LastFormattedText);
+            // restoring selection position
+            myRichEditBox.Document.Selection.SetIndex(TextRangeUnit.Character, caretPosition, false);
+            myRichEditBox.Document.Selection.SetRange(caretPosition, caretPosition + selectionLength);
+            // Editor might have gained focus because user changed color.
+            // Change selection color
+            // Note that only way to regain with selection containing text is using the change color button
             myRichEditBox.Document.Selection.CharacterFormat.ForegroundColor = currentColor;
+        }
+
+        private void MyRichEditBox_LosingFocus(object sender, RoutedEventArgs e)
+        {
+            myRichEditBox.Document.GetText(TextGetOptions.FormatRtf, out LastFormattedText);
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix a bug where hitting control+b and similar commands will result in navigating the app with focus becoming nearly impossible
## Description
<!--- Describe your changes in detail -->
Changed the event that was used since the previous event for text colorization would create an endless loop.

I also added the code that was introduced to the RichEditBox in #157 so that the same behavior does not occur in the SplitButton sample.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #200
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by starting application, visiting the RichEditBox on the SplitButton page and hitting control+b. After that I was able to successfully navigate to other commands using tab navigation.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
