### PR TITLE
Updated nuget version, remove fix for now fixed bug

### DIFF
--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml
@@ -71,7 +71,6 @@
             Header=" "
             HeaderTemplate="{StaticResource NavigationViewHeaderTemplate}"
             IsTabStop="False"
-            IsPaneOpen="False"
             PaneOpening="NavigationViewControl_PaneOpened"
             PaneClosing="NavigationViewControl_PaneClosing"
             DisplayModeChanged="NavigationViewControl_DisplayModeChanged"

--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿//*********************************************************
+//*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
 // THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF

--- a/XamlControlsGallery/XamlControlsGallery.csproj
+++ b/XamlControlsGallery/XamlControlsGallery.csproj
@@ -1077,7 +1077,7 @@
       <Version>6.1.9</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
-      <Version>2.2.190830001</Version>
+      <Version>2.2.190917002</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed">
       <Version>2.0.0</Version>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updated the WinUI package to the latest release.
Removed a small fixed for NavigationView, that is not needed anymore as it was fixed with latest version.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Updated the WinUI package to be able to samples for the new RevealStyles.
Removed a small fix to clean code base a bit.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by starting application.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Refactor (No change in behaviour)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Questions up for discussion
Since a bug with the TeachingTip was fixed with the latest WinUI package version, would it be better for TeachingTip samples to not add the TeachingTip to the PageHeader (which I assume was needed because otherwise TeachingTips were not closing upon navigating away). Instead we could add the TeachingTips to targets in the sample and by that have the sample code be a bit more explanatory.

@stmoy and @YuliKl What are your opinions on that?