### PR TITLE
Fix bug where app would crash when opening MediaPlayerElement page

### DIFF
--- a/XamlControlsGallery/DataModel/ControlInfoData.json
+++ b/XamlControlsGallery/DataModel/ControlInfoData.json
@@ -1527,7 +1527,7 @@
           "UniqueId": "AnimatedVisualPlayer",
           "Title": "AnimatedVisualPlayer",
           "Subtitle": "An element to render and control playback of motion graphics.",
-          "ImagePath": "Assets/Animations.png",
+          "ImagePath": "ms-appx:///Assets/Animations.png",
           "Description": "An element to render and control playback of motion graphics.",
           "Content": "<p>Look at the <i>AnimatedVisualPlayerPage.xaml</i> and <i>AnimatedVisualPlayerPage.xaml.cs</i> files in Visual Studio to see the full code for this page.</p>",
           "IsNew": true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed the image link for the AnimatedVisualPlayer page, which was also needed the MediaPlayerElement page.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #211 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by starting application and navigating to MediaPlayeElement page.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
