### PR TITLE
Updated references to MUXC

### DIFF
--- a/XamlControlsGallery/ControlPages/AnimatedVisualPlayerPage.xaml
+++ b/XamlControlsGallery/ControlPages/AnimatedVisualPlayerPage.xaml
@@ -6,7 +6,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:animatedvisuals="using:AnimatedVisuals"
     xmlns:local="using:AppUIBasics"
-    xmlns:muxcontrols="using:Microsoft.UI.Xaml.Controls"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
@@ -35,19 +35,19 @@
                             Margin="0, 20, 0, 20">
 
                         <!--  AnimatedVisualPlayer  -->
-                        <muxcontrols:AnimatedVisualPlayer x:Name="Player"
+                        <muxc:AnimatedVisualPlayer x:Name="Player"
                                                           AutoPlay="False">
 
                             <!--  Codegen-ed Lottie animation source: /AnimatedVisuals/LottieLogo1.cs -->
                             <animatedvisuals:LottieLogo1/>
 
                             <!-- Fallback since Lottie-Windows is only supported on OS version 17763 and above -->
-                            <muxcontrols:AnimatedVisualPlayer.FallbackContent>
+                            <muxc:AnimatedVisualPlayer.FallbackContent>
                                 <DataTemplate>
                                     <Image Source="/Assets/LottieLogo1.png"/>
                                 </DataTemplate>
-                            </muxcontrols:AnimatedVisualPlayer.FallbackContent>
-                        </muxcontrols:AnimatedVisualPlayer>
+                            </muxc:AnimatedVisualPlayer.FallbackContent>
+                        </muxc:AnimatedVisualPlayer>
                     </Border>
 
                     <!--  Playback Buttons  -->
@@ -107,9 +107,9 @@
             </local:ControlExample.Example>
             <local:ControlExample.Xaml>
                 <x:String  xml:space="preserve">
-&lt;muxcontrols:AnimatedVisualPlayer x:Name="Player" AutoPlay="False"&gt;
+&lt;muxc:AnimatedVisualPlayer x:Name="Player" AutoPlay="False"&gt;
     &lt;animatedvisuals:LottieLogo1/&gt;
-&lt;/muxcontrols:AnimatedVisualPlayer&gt;
+&lt;/muxc:AnimatedVisualPlayer&gt;
                 </x:String>
             </local:ControlExample.Xaml>
         </local:ControlExample>

--- a/XamlControlsGallery/ControlPages/CommandBarFlyoutPage.xaml
+++ b/XamlControlsGallery/ControlPages/CommandBarFlyoutPage.xaml
@@ -4,19 +4,19 @@
       xmlns:local="using:AppUIBasics"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:muxcontrols="using:Microsoft.UI.Xaml.Controls"
+      xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
       mc:Ignorable="d">
     
     <Page.Resources>
-        <muxcontrols:CommandBarFlyout Placement="Right" x:Name="CommandBarFlyout1">
+        <muxc:CommandBarFlyout Placement="Right" x:Name="CommandBarFlyout1">
             <AppBarButton Label="Share" Icon="Share" ToolTipService.ToolTip="Share" Click="OnElementClicked" />
             <AppBarButton Label="Save" Icon="Save" ToolTipService.ToolTip="Save" Click="OnElementClicked" />
             <AppBarButton Label="Delete" Icon="Delete" ToolTipService.ToolTip="Delete" Click="OnElementClicked" />
-            <muxcontrols:CommandBarFlyout.SecondaryCommands>
+            <muxc:CommandBarFlyout.SecondaryCommands>
                 <AppBarButton Label="Resize" Click="OnElementClicked" />
                 <AppBarButton Label="Move" Click="OnElementClicked" />
-            </muxcontrols:CommandBarFlyout.SecondaryCommands>
-        </muxcontrols:CommandBarFlyout>
+            </muxc:CommandBarFlyout.SecondaryCommands>
+        </muxc:CommandBarFlyout>
     </Page.Resources>
     
     <StackPanel>

--- a/XamlControlsGallery/ControlPages/DropDownButtonPage.xaml
+++ b/XamlControlsGallery/ControlPages/DropDownButtonPage.xaml
@@ -2,36 +2,33 @@
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
       xmlns:local="using:AppUIBasics"
-      xmlns:controls="using:Windows.UI.Xaml.Controls" 
-      xmlns:common="using:AppUIBasics.Common"
-      xmlns:data="using:AppUIBasics.Data"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:muxcontrols="using:Microsoft.UI.Xaml.Controls"
+      xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
       mc:Ignorable="d">
     
     <StackPanel>
         <local:ControlExample HeaderText="Simple DropDownButton" XamlSource="Buttons/DropDown/DropDownButton_Simple.txt">
             <StackPanel x:Name="Control1" Orientation="Horizontal">
-            <muxcontrols:DropDownButton Content="Email">
-                <muxcontrols:DropDownButton.Flyout>
+            <muxc:DropDownButton Content="Email">
+                <muxc:DropDownButton.Flyout>
                     <MenuFlyout Placement="Bottom">
                         <MenuFlyoutItem Text="Send"/>
                         <MenuFlyoutItem Text="Reply"/>
                         <MenuFlyoutItem Text="Reply All"/>
                     </MenuFlyout>
-                </muxcontrols:DropDownButton.Flyout>
-            </muxcontrols:DropDownButton>
+                </muxc:DropDownButton.Flyout>
+            </muxc:DropDownButton>
             </StackPanel>
         </local:ControlExample>
 
         <local:ControlExample HeaderText="DropDownButton with Icons" XamlSource="Buttons/DropDown/DropDownButton_Icon.txt">
             <StackPanel x:Name="Control2" Orientation="Horizontal">
-            <muxcontrols:DropDownButton AutomationProperties.Name="Email">
-                <muxcontrols:DropDownButton.Content>
+            <muxc:DropDownButton AutomationProperties.Name="Email">
+                <muxc:DropDownButton.Content>
                     <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE715;"/>
-                </muxcontrols:DropDownButton.Content>
-                <muxcontrols:DropDownButton.Flyout>
+                </muxc:DropDownButton.Content>
+                <muxc:DropDownButton.Flyout>
                     <MenuFlyout Placement="Bottom">
                         <MenuFlyoutItem Text="Send">
                             <MenuFlyoutItem.Icon>
@@ -49,8 +46,8 @@
                             </MenuFlyoutItem.Icon>
                         </MenuFlyoutItem>
                     </MenuFlyout>
-                </muxcontrols:DropDownButton.Flyout>
-            </muxcontrols:DropDownButton>
+                </muxc:DropDownButton.Flyout>
+            </muxc:DropDownButton>
             </StackPanel>
         </local:ControlExample>
     </StackPanel>

--- a/XamlControlsGallery/ControlPages/DropDownButtonPage.xaml
+++ b/XamlControlsGallery/ControlPages/DropDownButtonPage.xaml
@@ -7,45 +7,45 @@
       xmlns:data="using:AppUIBasics.Data"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:muxcontrols="using:Microsoft.UI.Xaml.Controls"
+      xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
       mc:Ignorable="d">
     
     <StackPanel>
         <local:ControlExample HeaderText="Simple DropDownButton" XamlSource="Buttons/DropDown/DropDownButton_Simple.txt">
             <StackPanel x:Name="Control1" Orientation="Horizontal">
-                <muxcontrols:DropDownButton Content="Email">
-                    <muxcontrols:DropDownButton.Flyout>
+                <muxc:DropDownButton Content="Email">
+                    <muxc:DropDownButton.Flyout>
                         <MenuFlyout Placement="Bottom">
                             <MenuFlyoutItem Text="Send"/>
                             <MenuFlyoutItem Text="Reply"/>
                             <MenuFlyoutItem Text="Reply All"/>
                         </MenuFlyout>
-                    </muxcontrols:DropDownButton.Flyout>
-                </muxcontrols:DropDownButton>
+                    </muxc:DropDownButton.Flyout>
+                </muxc:DropDownButton>
             </StackPanel>
         </local:ControlExample>
         
         <local:ControlExample HeaderText="Reveal style applied to DropDownButton" XamlSource="Buttons/DropDown/DropDownButton_RevealStyle.txt">
             <StackPanel x:Name="ControlReveal" Orientation="Horizontal">
-                <muxcontrols:DropDownButton Content="Email" Style="{ThemeResource DropDownButtonRevealStyle}">
-                    <muxcontrols:DropDownButton.Flyout>
+                <muxc:DropDownButton Content="Email" Style="{ThemeResource DropDownButtonRevealStyle}">
+                    <muxc:DropDownButton.Flyout>
                         <MenuFlyout Placement="Bottom">
                             <MenuFlyoutItem Text="Send"/>
                             <MenuFlyoutItem Text="Reply"/>
                             <MenuFlyoutItem Text="Reply All"/>
                         </MenuFlyout>
-                    </muxcontrols:DropDownButton.Flyout>
-                </muxcontrols:DropDownButton>
+                    </muxc:DropDownButton.Flyout>
+                </muxc:DropDownButton>
             </StackPanel>
         </local:ControlExample>
 
         <local:ControlExample HeaderText="DropDownButton with Icons" XamlSource="Buttons/DropDown/DropDownButton_Icon.txt">
             <StackPanel x:Name="Control2" Orientation="Horizontal">
-            <muxcontrols:DropDownButton AutomationProperties.Name="Email">
-                <muxcontrols:DropDownButton.Content>
+            <muxc:DropDownButton AutomationProperties.Name="Email">
+                <muxc:DropDownButton.Content>
                     <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE715;"/>
-                </muxcontrols:DropDownButton.Content>
-                <muxcontrols:DropDownButton.Flyout>
+                </muxc:DropDownButton.Content>
+                <muxc:DropDownButton.Flyout>
                     <MenuFlyout Placement="Bottom">
                         <MenuFlyoutItem Text="Send">
                             <MenuFlyoutItem.Icon>
@@ -63,8 +63,8 @@
                             </MenuFlyoutItem.Icon>
                         </MenuFlyoutItem>
                     </MenuFlyout>
-                </muxcontrols:DropDownButton.Flyout>
-            </muxcontrols:DropDownButton>
+                </muxc:DropDownButton.Flyout>
+            </muxc:DropDownButton>
             </StackPanel>
         </local:ControlExample>
     </StackPanel>

--- a/XamlControlsGallery/ControlPages/ItemsRepeaterPage.xaml
+++ b/XamlControlsGallery/ControlPages/ItemsRepeaterPage.xaml
@@ -5,7 +5,7 @@
     xmlns:local="using:AppUIBasics"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:muxcontrols="using:Microsoft.UI.Xaml.Controls"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:l="using:AppUIBasics.ControlPages"
     xmlns:common="using:AppUIBasics.Common"
     mc:Ignorable="d" FontFamily="Segoe UI">
@@ -42,12 +42,12 @@
             </Button>
         </DataTemplate>
 
-        <muxcontrols:StackLayout x:Name="VerticalStackLayout" Orientation="Vertical" Spacing="8"/>
-        <muxcontrols:StackLayout x:Name="HorizontalStackLayout" Orientation="Horizontal" Spacing="8"/>
-        <muxcontrols:UniformGridLayout x:Name="UniformGridLayout" MinRowSpacing="8" MinColumnSpacing="8"/>
+        <muxc:StackLayout x:Name="VerticalStackLayout" Orientation="Vertical" Spacing="8"/>
+        <muxc:StackLayout x:Name="HorizontalStackLayout" Orientation="Horizontal" Spacing="8"/>
+        <muxc:UniformGridLayout x:Name="UniformGridLayout" MinRowSpacing="8" MinColumnSpacing="8"/>
 
         <common:ActivityFeedLayout x:Key="MyFeedLayout" ColumnSpacing="12" RowSpacing="12" MinItemSize="80, 108"/>
-        <muxcontrols:UniformGridLayout x:Key="UniformGridLayout2" MinItemWidth="108" MinItemHeight="108" MinRowSpacing="12" MinColumnSpacing="12"/>
+        <muxc:UniformGridLayout x:Key="UniformGridLayout2" MinItemWidth="108" MinItemHeight="108" MinRowSpacing="12" MinColumnSpacing="12"/>
 
         <l:MyDataTemplateSelector x:Key="MyDataTemplateSelector"
                                   Normal="{StaticResource NormalItemTemplate}"
@@ -60,7 +60,7 @@
                           HorizontalScrollMode="Auto" 
                           IsVerticalScrollChainingEnabled="False"
                           MaxHeight="500">
-                <muxcontrols:ItemsRepeater x:Name="repeater"
+                <muxc:ItemsRepeater x:Name="repeater"
                                Layout="{StaticResource VerticalStackLayout}"
                                ItemsSource="{x:Bind BarItems}"
                                ItemTemplate="{StaticResource HorizontalBarTemplate}"/>
@@ -92,7 +92,7 @@
 
             <local:ControlExample.Xaml>
                 <x:String xml:space="preserve">
-&lt;ItemsRepeater
+&lt;muxc:ItemsRepeater
         ItemsSource="{x:Bind BarItems}"
         Layout="{StaticResource $(Layout)}"
         ItemTemplate="{StaticResource $(ElementGenerator)}" /&gt;
@@ -109,18 +109,18 @@
 
             <!-- ItemsRepeaterScrollHost enables ItemsRepeater to coordinate with ScrollViewer down-level.
                  It's not needed on 17700+ builds. -->
-            <muxcontrols:ItemsRepeaterScrollHost>
+            <muxc:ItemsRepeaterScrollHost>
                 <ScrollViewer x:Name="scrollViewer"
                               Height="400"
                               IsVerticalScrollChainingEnabled="False"
                               Padding="0,0,16,0">
-                    <muxcontrols:ItemsRepeater x:Name="repeater2" 
+                    <muxc:ItemsRepeater x:Name="repeater2" 
                                        Margin="0,0,12,0"
                                        HorizontalAlignment="Stretch"
                                        Layout="{StaticResource MyFeedLayout}"
                                        ItemTemplate="{StaticResource MyDataTemplateSelector}"/>
                 </ScrollViewer>
-            </muxcontrols:ItemsRepeaterScrollHost>
+            </muxc:ItemsRepeaterScrollHost>
 
             <local:ControlExample.Options>
                 <StackPanel Spacing="12">
@@ -131,7 +131,7 @@
 
             <local:ControlExample.Xaml>
                 <x:String xml:space="preserve">
-&lt;ItemsRepeater
+&lt;muxc:ItemsRepeater
         ItemsSource="{x:Bind NumberedItems}"
         Layout="{StaticResource $(Layout)}"
         ItemTemplate="{StaticResource $(ItemTemplate)}" /&gt;

--- a/XamlControlsGallery/ControlPages/RatingsControlPage.xaml
+++ b/XamlControlsGallery/ControlPages/RatingsControlPage.xaml
@@ -2,13 +2,13 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:local="using:AppUIBasics"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:mux="using:Microsoft.UI.Xaml.Controls"
+        xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d">
     <StackPanel>
         <local:ControlExample x:Name="Example1" HeaderText="A simple RatingControl">
 
             <StackPanel VerticalAlignment="Top">
-                <mux:RatingControl x:Name="RatingControl1" AutomationProperties.Name="Simple RatingControl"
+                <muxc:RatingControl x:Name="RatingControl1" AutomationProperties.Name="Simple RatingControl"
                     IsClearEnabled="{x:Bind clearEnabledCheck.IsChecked.Value, Mode=OneWay}"
                     IsReadOnly="{x:Bind readOnlyCheck.IsChecked.Value, Mode=OneWay}" HorizontalAlignment="Left" />
 
@@ -28,7 +28,7 @@
 
             <local:ControlExample.Xaml>
                 <x:String>
-                    &lt;RatingControl AutomationProperties.Name="Simple RatingControl" IsClearEnabled="$(IsClearEnabled)" IsReadOnly="$(IsReadOnly)" /&gt;
+                    &lt;muxc:RatingControl AutomationProperties.Name="Simple RatingControl" IsClearEnabled="$(IsClearEnabled)" IsReadOnly="$(IsReadOnly)" /&gt;
                 </x:String>
             </local:ControlExample.Xaml>
             <local:ControlExample.Substitutions>
@@ -39,7 +39,7 @@
 
         <local:ControlExample x:Name="Example2" HeaderText="PlaceholderValue of RatingControl">
 
-            <mux:RatingControl x:Name="RatingControl2" HorizontalAlignment="Left" VerticalAlignment="Top"
+            <muxc:RatingControl x:Name="RatingControl2" HorizontalAlignment="Left" VerticalAlignment="Top"
                 PlaceholderValue="{x:Bind slider.Value, Mode=TwoWay}" AutomationProperties.Name="RatingControl with placeholder"/>
 
             <local:ControlExample.Options>
@@ -51,7 +51,7 @@
 
             <local:ControlExample.Xaml>
                 <x:String>
-                    &lt;RatingControl AutomationProperties.Name="RatingControl with placeholder" PlaceholderValue="$(Slider)" /&gt;
+                    &lt;muxc:RatingControl AutomationProperties.Name="RatingControl with placeholder" PlaceholderValue="$(Slider)" /&gt;
                 </x:String>
             </local:ControlExample.Xaml>
             <local:ControlExample.Substitutions>

--- a/XamlControlsGallery/ControlPages/RevealFocusPage.xaml
+++ b/XamlControlsGallery/ControlPages/RevealFocusPage.xaml
@@ -15,7 +15,7 @@
       xmlns:local2="using:AppUIBasics.ControlPages"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:mux="using:Microsoft.UI.Xaml.Controls"
+      xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
       mc:Ignorable="d">
 
     <StackPanel  XYFocusKeyboardNavigation="Enabled">
@@ -155,7 +155,7 @@
                     <ComboBoxItem>Strawberries</ComboBoxItem>
                 </ComboBox>
 
-                <mux:RatingControl Margin="5,16,0,0"
+                <muxc:RatingControl Margin="5,16,0,0"
                     AutomationProperties.Name="sample ratingControl"
                     FocusVisualMargin="{x:Bind local2:MyConverters.IntToThickness(marginSlider.Value), Mode=OneWay}"
                     FocusVisualPrimaryThickness="{x:Bind local2:MyConverters.IntToThickness(primarySlider.Value), Mode=OneWay}"

--- a/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml
+++ b/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml
@@ -16,7 +16,7 @@
     xmlns:local="using:AppUIBasics"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:muxcontrols="using:Microsoft.UI.Xaml.Controls"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:contract6Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 6)"
     mc:Ignorable="d">
 
@@ -79,14 +79,14 @@
                     </Button.Content>
                 </Button>
 
-                <muxcontrols:DropDownButton x:Name="fontColorButton"
+                <muxc:DropDownButton x:Name="fontColorButton"
                                             BorderThickness="0" 
                                             AutomationProperties.Name="Font color"
                                             ToolTipService.ToolTip="Font color"
                                             Background="Transparent" 
                                             RelativePanel.AlignRightWithPanel="True">
                     <SymbolIcon Symbol="FontColor"/>
-                    <muxcontrols:DropDownButton.Flyout>
+                    <muxc:DropDownButton.Flyout>
                         <Flyout Placement="Bottom">
                             <VariableSizedWrapGrid Orientation="Horizontal" MaximumRowsOrColumns="3">
                                 <VariableSizedWrapGrid.Resources>
@@ -148,8 +148,8 @@
                                 </Button>
                             </VariableSizedWrapGrid>
                         </Flyout>
-                    </muxcontrols:DropDownButton.Flyout>
-                </muxcontrols:DropDownButton>
+                    </muxc:DropDownButton.Flyout>
+                </muxc:DropDownButton>
 
                 <RichEditBox x:Name="editor" Height="200" AutomationProperties.Name="Custom editor"
                              RelativePanel.Below="openFileButton" 

--- a/XamlControlsGallery/ControlPages/SplitButtonPage.xaml
+++ b/XamlControlsGallery/ControlPages/SplitButtonPage.xaml
@@ -98,9 +98,9 @@
 
         <local:ControlExample HeaderText="A SplitButton with RevealStyle applied" XamlSource="Buttons\SplitButton\SplitButtonSample2.txt">
             <local:ControlExample.Example>
-                <muxcontrols:SplitButton AutomationProperties.Name="Font color with reveal" x:Name="myColorButtonReveal" Padding="5" MinHeight="0" MinWidth="0" VerticalAlignment="Top" Style="{ThemeResource SplitButtonRevealStyle}">
+                <muxc:SplitButton AutomationProperties.Name="Font color with reveal" x:Name="myColorButtonReveal" Padding="5" MinHeight="0" MinWidth="0" VerticalAlignment="Top" Style="{ThemeResource SplitButtonRevealStyle}">
                     Choose color
-                    <muxcontrols:SplitButton.Flyout>
+                    <muxc:SplitButton.Flyout>
                         <Flyout Placement="Bottom">
                             <VariableSizedWrapGrid Orientation="Horizontal" MaximumRowsOrColumns="3">
                                 <VariableSizedWrapGrid.Resources>
@@ -162,8 +162,8 @@
                                 </Button>
                             </VariableSizedWrapGrid>
                         </Flyout>
-                    </muxcontrols:SplitButton.Flyout>
-                </muxcontrols:SplitButton>
+                    </muxc:SplitButton.Flyout>
+                </muxc:SplitButton>
             </local:ControlExample.Example>
         </local:ControlExample>
     </StackPanel>

--- a/XamlControlsGallery/ControlPages/SplitButtonPage.xaml
+++ b/XamlControlsGallery/ControlPages/SplitButtonPage.xaml
@@ -4,7 +4,7 @@
       xmlns:local="using:AppUIBasics"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:muxcontrols="using:Microsoft.UI.Xaml.Controls"
+      xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
       mc:Ignorable="d">
 
     <Page.Resources>
@@ -21,9 +21,9 @@
                     <ColumnDefinition/>
                 </Grid.ColumnDefinitions>
 
-                <muxcontrols:SplitButton x:Name="myColorButton" AutomationProperties.Name="Font color" Padding="0" MinHeight="0" MinWidth="0" VerticalAlignment="Top" Click="myColorButton_Click">
+                <muxc:SplitButton x:Name="myColorButton" AutomationProperties.Name="Font color" Padding="0" MinHeight="0" MinWidth="0" VerticalAlignment="Top" Click="myColorButton_Click">
                     <Rectangle x:Name="CurrentColor" Width="{StaticResource SwatchSize}" Height="{StaticResource SwatchSize}" Fill="Black" Margin="0"/>
-                    <muxcontrols:SplitButton.Flyout>
+                    <muxc:SplitButton.Flyout>
                         <Flyout Placement="Bottom">
                             <VariableSizedWrapGrid Orientation="Horizontal" MaximumRowsOrColumns="3">
                                 <VariableSizedWrapGrid.Resources>
@@ -85,8 +85,8 @@
                                 </Button>
                             </VariableSizedWrapGrid>
                         </Flyout>
-                    </muxcontrols:SplitButton.Flyout>
-                </muxcontrols:SplitButton>
+                    </muxc:SplitButton.Flyout>
+                </muxc:SplitButton>
 
                 <RichEditBox x:Name="myRichEditBox" Grid.Column="1" MinWidth="240" MinHeight="96" 
                              PlaceholderText="Type something here" 

--- a/XamlControlsGallery/ControlPages/StandardUICommandPage.xaml
+++ b/XamlControlsGallery/ControlPages/StandardUICommandPage.xaml
@@ -5,7 +5,7 @@
       xmlns:local2="using:AppUIBasics.ControlPages"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:muxcontrols="using:Microsoft.UI.Xaml.Controls"
+      xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
       mc:Ignorable="d">
     <Page.Resources>
         <Style x:Key="HorizontalSwipe" TargetType="ListViewItem" BasedOn="{StaticResource ListViewItemRevealStyle}">
@@ -38,22 +38,22 @@
                     keyboard shortcut, and a description.
                 </TextBlock>
 
-                <muxcontrols:MenuBar Grid.Row="1">
-                    <muxcontrols:MenuBarItem Title="File">
+                <muxc:MenuBar Grid.Row="1">
+                    <muxc:MenuBarItem Title="File">
                         <MenuFlyoutItem Text="New"/>
                         <MenuFlyoutItem Text="Open..."/>
                         <MenuFlyoutItem Text="Save"/>
                         <MenuFlyoutItem Text="Exit"/>
-                    </muxcontrols:MenuBarItem>
+                    </muxc:MenuBarItem>
 
-                    <muxcontrols:MenuBarItem Title="Edit">
+                    <muxc:MenuBarItem Title="Edit">
                         <MenuFlyoutItem x:Name="DeleteFlyoutItem"/>
-                    </muxcontrols:MenuBarItem>
+                    </muxc:MenuBarItem>
 
-                    <muxcontrols:MenuBarItem Title="Help">
+                    <muxc:MenuBarItem Title="Help">
                         <MenuFlyoutItem Text="About"/>
-                    </muxcontrols:MenuBarItem>
-                </muxcontrols:MenuBar>
+                    </muxc:MenuBarItem>
+                </muxc:MenuBar>
 
                 <ListView x:Name="ListViewRight" Grid.Row="2" Height="500" Loaded="ListView_Loaded" ContainerContentChanging="ListViewRight_ContainerContentChanging" IsItemClickEnabled="True" SelectionMode="Single" SelectionChanged="ListView_SelectionChanged" ItemContainerStyle="{StaticResource HorizontalSwipe}">
                     <ListView.ItemTemplate>

--- a/XamlControlsGallery/ControlPages/TabViewPage.xaml
+++ b/XamlControlsGallery/ControlPages/TabViewPage.xaml
@@ -5,7 +5,7 @@
     xmlns:local="using:AppUIBasics"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:muxcontrols="using:Microsoft.UI.Xaml.Controls"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:samplepages="using:AppUIBasics.SamplePages"
     xmlns:local1="using:AppUIBasics.ControlPages"
     mc:Ignorable="d"
@@ -14,81 +14,81 @@
     <StackPanel>
         <local:ControlExample HeaderText="A TabView with support for adding, closing, and rearranging tabs" CSharpSource="TabView\TabViewBasicSample_cs.txt">
             <local:ControlExample.Example>
-                <muxcontrols:TabView x:Name="TabView1" SelectedIndex="0" Margin="-12" AddTabButtonClick="TabView_AddButtonClick" TabCloseRequested="TabView_TabCloseRequested" Loaded="TabView_Loaded" MinHeight="475"/>
+                <muxc:TabView x:Name="TabView1" SelectedIndex="0" Margin="-12" AddTabButtonClick="TabView_AddButtonClick" TabCloseRequested="TabView_TabCloseRequested" Loaded="TabView_Loaded" MinHeight="475"/>
             </local:ControlExample.Example>
             <local:ControlExample.Xaml>
                 <x:String>
-                    &lt;TabView AddTabButtonClick="TabView_AddButtonClick" TabCloseRequested="TabView_TabCloseRequested" Loaded="TabView_Loaded" /&gt;
+                    &lt;muxc:TabView AddTabButtonClick="TabView_AddButtonClick" TabCloseRequested="TabView_TabCloseRequested" Loaded="TabView_Loaded" /&gt;
                 </x:String>
             </local:ControlExample.Xaml>
         </local:ControlExample>
 
         <local:ControlExample HeaderText="A TabView with TabViewItems defined in markup">
             <local:ControlExample.Example>
-                <muxcontrols:TabView SelectedIndex="0" Margin="-12" MinHeight="475" AddTabButtonClick="TabView_AddButtonClick" TabCloseRequested="TabView_TabCloseRequested">
-                    <muxcontrols:TabView.TabItems>
-                        <muxcontrols:TabViewItem Header="Document 0">
-                            <muxcontrols:TabViewItem.IconSource>
-                                <muxcontrols:SymbolIconSource Symbol="Placeholder" />
-                            </muxcontrols:TabViewItem.IconSource>
+                <muxc:TabView SelectedIndex="0" Margin="-12" MinHeight="475" AddTabButtonClick="TabView_AddButtonClick" TabCloseRequested="TabView_TabCloseRequested">
+                    <muxc:TabView.TabItems>
+                        <muxc:TabViewItem Header="Document 0">
+                            <muxc:TabViewItem.IconSource>
+                                <muxc:SymbolIconSource Symbol="Placeholder" />
+                            </muxc:TabViewItem.IconSource>
                             <samplepages:SamplePage1 />
-                        </muxcontrols:TabViewItem>
-                        <muxcontrols:TabViewItem Header="Document 1">
-                            <muxcontrols:TabViewItem.IconSource>
-                                <muxcontrols:SymbolIconSource Symbol="Placeholder" />
-                            </muxcontrols:TabViewItem.IconSource>
+                        </muxc:TabViewItem>
+                        <muxc:TabViewItem Header="Document 1">
+                            <muxc:TabViewItem.IconSource>
+                                <muxc:SymbolIconSource Symbol="Placeholder" />
+                            </muxc:TabViewItem.IconSource>
                             <samplepages:SamplePage2 />
-                        </muxcontrols:TabViewItem>
-                        <muxcontrols:TabViewItem Header="Document 2">
-                            <muxcontrols:TabViewItem.IconSource>
-                                <muxcontrols:SymbolIconSource Symbol="Placeholder" />
-                            </muxcontrols:TabViewItem.IconSource>
+                        </muxc:TabViewItem>
+                        <muxc:TabViewItem Header="Document 2">
+                            <muxc:TabViewItem.IconSource>
+                                <muxc:SymbolIconSource Symbol="Placeholder" />
+                            </muxc:TabViewItem.IconSource>
                             <samplepages:SamplePage3 />
-                        </muxcontrols:TabViewItem>
-                    </muxcontrols:TabView.TabItems>
-                </muxcontrols:TabView>
+                        </muxc:TabViewItem>
+                    </muxc:TabView.TabItems>
+                </muxc:TabView>
             </local:ControlExample.Example>
             <local:ControlExample.Xaml>
                 <x:String xml:space="preserve">
-&lt;TabView AddTabButtonClick="TabView_AddButtonClick" TabCloseRequested="TabView_TabCloseRequested"&gt;
-    &lt;TabView.TabItems&gt;
-        &lt;TabViewItem Header="Document 0"&gt;
-            &lt;TabViewItem.IconSource&gt;
-                &lt;SymbolIconSource Symbol="Placeholder" /&gt;
-            &lt;/TabViewItem.IconSource&gt;
+&lt;muxc:TabView AddTabButtonClick="TabView_AddButtonClick" TabCloseRequested="TabView_TabCloseRequested"&gt;
+    &lt;muxc:TabView.TabItems&gt;
+        &lt;muxc:TabViewItem Header="Document 0"&gt;
+            &lt;muxc:TabViewItem.IconSource&gt;
+                &lt;muxc:SymbolIconSource Symbol="Placeholder" /&gt;
+            &lt;/muxc:TabViewItem.IconSource&gt;
             &lt;samplepages:SamplePage1 /&gt;
-        &lt;/TabViewItem&gt;
-        &lt;TabViewItem Header="Document 1"&gt;
-            &lt;TabViewItem.IconSource&gt;
-                &lt;SymbolIconSource Symbol="Placeholder" /&gt;
-            &lt;/TabViewItem.IconSource&gt;
+        &lt;/muxc:TabViewItem&gt;
+        &lt;muxc:TabViewItem Header="Document 1"&gt;
+            &lt;muxc:TabViewItem.IconSource&gt;
+                &lt;muxc:SymbolIconSource Symbol="Placeholder" /&gt;
+            &lt;/muxc:TabViewItem.IconSource&gt;
             &lt;samplepages:SamplePage2 /&gt;
-        &lt;/TabViewItem&gt;
-        &lt;TabViewItem Header="Document 2"&gt;
-            &lt;TabViewItem.IconSource&gt;
-                &lt;SymbolIconSource Symbol="Placeholder" /&gt;
-            &lt;/TabViewItem.IconSource&gt;
+        &lt;/muxc:TabViewItem&gt;
+        &lt;muxc:TabViewItem Header="Document 2"&gt;
+            &lt;muxc:TabViewItem.IconSource&gt;
+                &lt;muxc:SymbolIconSource Symbol="Placeholder" /&gt;
+            &lt;/muxc:TabViewItem.IconSource&gt;
             &lt;samplepages:SamplePage3 /&gt;
-        &lt;/TabViewItem&gt;
-    &lt;/TabView.TabItems&gt;
-&lt;/TabView&gt;
+        &lt;/muxc:TabViewItem&gt;
+    &lt;/muxc:TabView.TabItems&gt;
+&lt;/muxc:TabView&gt;
                 </x:String>
             </local:ControlExample.Xaml>
         </local:ControlExample>
 
         <local:ControlExample HeaderText="A TabView bound to a collection of MyData objects">
             <local:ControlExample.Example>
-                <muxcontrols:TabView x:Name="TabViewItemsSourceSample" SelectedIndex="0" Margin="-12" MinHeight="475" TabItemsSource="{x:Bind myDatas, Mode=OneWay}" AddTabButtonClick="TabViewItemsSourceSample_AddTabButtonClick" TabCloseRequested="TabViewItemsSourceSample_TabCloseRequested">
-                    <muxcontrols:TabView.TabItemTemplate>
+                <muxc:TabView x:Name="TabViewItemsSourceSample" SelectedIndex="0" Margin="-12" MinHeight="475" TabItemsSource="{x:Bind myDatas, Mode=OneWay}" AddTabButtonClick="TabViewItemsSourceSample_AddTabButtonClick" TabCloseRequested="TabViewItemsSourceSample_TabCloseRequested">
+                    <muxc:TabView.TabItemTemplate>
                         <DataTemplate x:DataType="local1:MyData">
-                            <muxcontrols:TabViewItem Header="{x:Bind DataHeader}" IconSource="{x:Bind DataIconSource}" Content="{x:Bind DataContent}" />
+                            <muxc:TabViewItem Header="{x:Bind DataHeader}" IconSource="{x:Bind DataIconSource}" Content="{x:Bind DataContent}" />
                         </DataTemplate>
-                    </muxcontrols:TabView.TabItemTemplate >
-                </muxcontrols:TabView>
+                    </muxc:TabView.TabItemTemplate >
+                </muxc:TabView>
             </local:ControlExample.Example>
             <local:ControlExample.Xaml>
                 <x:String>
-                    &lt;TabView TabItemsSource="{x:Bind myDatas, Mode=OneWay}" AddTabButtonClick="TabViewItemsSourceSample_AddTabButtonClick" TabCloseRequested="TabViewItemsSourceSample_TabCloseRequested" /&gt;
+                    &lt;muxc:TabView TabItemsSource="{x:Bind myDatas, Mode=OneWay}" AddTabButtonClick="TabViewItemsSourceSample_AddTabButtonClick" TabCloseRequested="TabViewItemsSourceSample_TabCloseRequested" /&gt;
                 </x:String>
             </local:ControlExample.Xaml>
         </local:ControlExample>
@@ -101,8 +101,8 @@
                     <TextBlock TextWrapping="WrapWholeWords" Margin="0,0,0,0" Text="- Ctrl+1 to Ctrl+8 selects that number tab" />
                     <TextBlock TextWrapping="WrapWholeWords" Margin="0,0,0,24" Text="- Ctrl+9 selects the last tab (regardless of the number of tabs)" />
 
-                    <muxcontrols:TabView x:Name="TabView2" SelectedIndex="0" Margin="-12" AddTabButtonClick="TabView_AddButtonClick" TabCloseRequested="TabView_TabCloseRequested" Loaded="TabView_Loaded" MinHeight="475">
-                        <muxcontrols:TabView.KeyboardAccelerators>
+                    <muxc:TabView x:Name="TabView2" SelectedIndex="0" Margin="-12" AddTabButtonClick="TabView_AddButtonClick" TabCloseRequested="TabView_TabCloseRequested" Loaded="TabView_Loaded" MinHeight="475">
+                        <muxc:TabView.KeyboardAccelerators>
                             <KeyboardAccelerator Key="T" Modifiers="Control" Invoked="NewTabKeyboardAccelerator_Invoked" />
                             <KeyboardAccelerator Key="W" Modifiers="Control" Invoked="CloseSelectedTabKeyboardAccelerator_Invoked" />
                             <KeyboardAccelerator Key="Number1" Modifiers="Control" Invoked="NavigateToNumberedTabKeyboardAccelerator_Invoked" />
@@ -114,14 +114,14 @@
                             <KeyboardAccelerator Key="Number7" Modifiers="Control" Invoked="NavigateToNumberedTabKeyboardAccelerator_Invoked" />
                             <KeyboardAccelerator Key="Number8" Modifiers="Control" Invoked="NavigateToNumberedTabKeyboardAccelerator_Invoked" />
                             <KeyboardAccelerator Key="Number9" Modifiers="Control" Invoked="NavigateToNumberedTabKeyboardAccelerator_Invoked" />
-                        </muxcontrols:TabView.KeyboardAccelerators>
-                    </muxcontrols:TabView>
+                        </muxc:TabView.KeyboardAccelerators>
+                    </muxc:TabView>
                 </StackPanel>
             </local:ControlExample.Example>
             <local:ControlExample.Xaml>
                 <x:String xml:space="preserve">
-&lt;TabView AddTabButtonClick="TabView_AddButtonClick" TabCloseRequested="TabView_TabCloseRequested" Loaded="TabView_Loaded"&gt;
-    &lt;TabView.KeyboardAccelerators&gt;
+&lt;muxc:TabView AddTabButtonClick="TabView_AddButtonClick" TabCloseRequested="TabView_TabCloseRequested" Loaded="TabView_Loaded"&gt;
+    &lt;muxc:TabView.KeyboardAccelerators&gt;
         &lt;KeyboardAccelerator Key="T" Modifiers="Control" Invoked="NewTabKeyboardAccelerator_Invoked" /&gt;
         &lt;KeyboardAccelerator Key="W" Modifiers="Control" Invoked="CloseSelectedTabKeyboardAccelerator_Invoked" /&gt;
         &lt;KeyboardAccelerator Key="Number1" Modifiers="Control" Invoked="NavigateToNumberedTabKeyboardAccelerator_Invoked" /&gt;
@@ -133,8 +133,8 @@
         &lt;KeyboardAccelerator Key="Number7" Modifiers="Control" Invoked="NavigateToNumberedTabKeyboardAccelerator_Invoked" /&gt;
         &lt;KeyboardAccelerator Key="Number8" Modifiers="Control" Invoked="NavigateToNumberedTabKeyboardAccelerator_Invoked" /&gt;
         &lt;KeyboardAccelerator Key="Number9" Modifiers="Control" Invoked="NavigateToNumberedTabKeyboardAccelerator_Invoked" /&gt;
-    &lt;/TabView.KeyboardAccelerators&gt;
-&lt;/TabView&gt;
+    &lt;/muxc:TabView.KeyboardAccelerators&gt;
+&lt;/muxc:TabView&gt;
                 </x:String>
             </local:ControlExample.Xaml>
         </local:ControlExample>
@@ -146,54 +146,54 @@
                     <TextBlock TextWrapping="WrapWholeWords" Margin="0,0,0,12" Text="If your TabView is used inside the app's titlebar area, use the TabStripFooter to specify a custom drag region" />
                     <TextBlock TextWrapping="WrapWholeWords" Margin="0,0,0,24" Text="See TabViewWindowingSamplePage.xaml and *.cs files to see the complete code" />
 
-                    <muxcontrols:TabView SelectedIndex="0" Margin="-12" AddTabButtonClick="TabView_AddButtonClick" TabCloseRequested="TabView_TabCloseRequested" Loaded="TabView_Loaded" MinHeight="475" TabWidthMode="SizeToContent">
-                        <muxcontrols:TabView.TabStripHeader>
+                    <muxc:TabView SelectedIndex="0" Margin="-12" AddTabButtonClick="TabView_AddButtonClick" TabCloseRequested="TabView_TabCloseRequested" Loaded="TabView_Loaded" MinHeight="475" TabWidthMode="SizeToContent">
+                        <muxc:TabView.TabStripHeader>
                             <TextBlock Text="TabStripHeader Content" VerticalAlignment="Center" Margin="8,6" Style="{ThemeResource BaseTextBlockStyle}" />
-                        </muxcontrols:TabView.TabStripHeader>
-                        <muxcontrols:TabView.TabStripFooter>
+                        </muxc:TabView.TabStripHeader>
+                        <muxc:TabView.TabStripFooter>
                             <TextBlock Text="TabStripFooter Content" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="6" Style="{ThemeResource BaseTextBlockStyle}" />
-                        </muxcontrols:TabView.TabStripFooter>
-                    </muxcontrols:TabView>
+                        </muxc:TabView.TabStripFooter>
+                    </muxc:TabView>
                 </StackPanel>
             </local:ControlExample.Example>
             <local:ControlExample.Xaml>
                 <x:String xml:space="preserve">
-&lt;TabView&gt;
-    &lt;TabView.TabStripHeader&gt;
+&lt;muxc:TabView&gt;
+    &lt;muxc:TabView.TabStripHeader&gt;
         &lt;TextBlock Text="TabStripHeader Content" VerticalAlignment="Center" Margin="8,6" Style="{ThemeResource BaseTextBlockStyle}" /&gt;
-    &lt;/TabView.TabStripHeader&gt;
-    &lt;TabView.TabStripFooter&gt;
+    &lt;/muxc:TabView.TabStripHeader&gt;
+    &lt;muxc:TabView.TabStripFooter&gt;
         &lt;TextBlock Text="TabStripFooter Content" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="6" Style="{ThemeResource BaseTextBlockStyle}" /&gt;
-    &lt;/TabView.TabStripFooter&gt;
-&lt;/TabView&gt;
+    &lt;/muxc:TabView.TabStripFooter&gt;
+&lt;/muxc:TabView&gt;
                 </x:String>
             </local:ControlExample.Xaml>
         </local:ControlExample>
 
         <local:ControlExample HeaderText="Tab widths can either be equally sized or sized to the content of the tab">
             <local:ControlExample.Example>
-                <muxcontrols:TabView x:Name="TabView3" SelectedIndex="0" Margin="-12" IsAddTabButtonVisible="False" MinHeight="475">
-                    <muxcontrols:TabView.TabItems>
-                        <muxcontrols:TabViewItem  Header="Home" IsClosable="False">
-                            <muxcontrols:TabViewItem.IconSource>
-                                <muxcontrols:SymbolIconSource Symbol="Home" />
-                            </muxcontrols:TabViewItem.IconSource>
+                <muxc:TabView x:Name="TabView3" SelectedIndex="0" Margin="-12" IsAddTabButtonVisible="False" MinHeight="475">
+                    <muxc:TabView.TabItems>
+                        <muxc:TabViewItem  Header="Home" IsClosable="False">
+                            <muxc:TabViewItem.IconSource>
+                                <muxc:SymbolIconSource Symbol="Home" />
+                            </muxc:TabViewItem.IconSource>
                             <samplepages:SamplePage1 />
-                        </muxcontrols:TabViewItem>
-                        <muxcontrols:TabViewItem  Header="Tab 2 Has Longer Text" IsClosable="False">
-                            <muxcontrols:TabViewItem.IconSource>
-                                <muxcontrols:SymbolIconSource Symbol="MusicInfo" />
-                            </muxcontrols:TabViewItem.IconSource>
+                        </muxc:TabViewItem>
+                        <muxc:TabViewItem  Header="Tab 2 Has Longer Text" IsClosable="False">
+                            <muxc:TabViewItem.IconSource>
+                                <muxc:SymbolIconSource Symbol="MusicInfo" />
+                            </muxc:TabViewItem.IconSource>
                             <samplepages:SamplePage2 />
-                        </muxcontrols:TabViewItem>
-                        <muxcontrols:TabViewItem  Header="Third Tab" IsClosable="False">
-                            <muxcontrols:TabViewItem.IconSource>
-                                <muxcontrols:SymbolIconSource Symbol="Placeholder" />
-                            </muxcontrols:TabViewItem.IconSource>
+                        </muxc:TabViewItem>
+                        <muxc:TabViewItem  Header="Third Tab" IsClosable="False">
+                            <muxc:TabViewItem.IconSource>
+                                <muxc:SymbolIconSource Symbol="Placeholder" />
+                            </muxc:TabViewItem.IconSource>
                             <samplepages:SamplePage3 />
-                        </muxcontrols:TabViewItem>
-                    </muxcontrols:TabView.TabItems>
-                </muxcontrols:TabView>
+                        </muxc:TabViewItem>
+                    </muxc:TabView.TabItems>
+                </muxc:TabView>
             </local:ControlExample.Example>
             <local:ControlExample.Options>
                 <ComboBox Header="TabWidthBehavior" SelectedIndex="0" SelectionChanged="TabWidthBehaviorComboBox_SelectionChanged" Width="150">
@@ -203,7 +203,7 @@
             </local:ControlExample.Options>
             <local:ControlExample.Xaml>
                 <x:String>
-                    &lt;TabView TabWidthMode="$(TabWidthMode)" /&gt;
+                    &lt;muxc:TabView TabWidthMode="$(TabWidthMode)" /&gt;
                 </x:String>
             </local:ControlExample.Xaml>
             <local:ControlExample.Substitutions>
@@ -216,57 +216,57 @@
                 <StackPanel>
                     <TextBlock TextWrapping="WrapWholeWords" Margin="0,0,0,12" Text="Use BitmapIcon.ShowAsMonochrome=&quot;False&quot; to display full color icons in the TabViewItem" />
 
-                    <muxcontrols:TabView x:Name="TabView4" SelectedIndex="0" IsAddTabButtonVisible="False" MinWidth="490" TabWidthMode="SizeToContent">
-                        <muxcontrols:TabView.TabItems>
-                            <muxcontrols:TabViewItem Header="CMD Prompt" IsClosable="False">
-                                <muxcontrols:TabViewItem.IconSource>
-                                    <muxcontrols:BitmapIconSource UriSource="/Assets/TabViewIcons/cmd.png" ShowAsMonochrome="False" />
-                                </muxcontrols:TabViewItem.IconSource>
-                            </muxcontrols:TabViewItem>
-                            <muxcontrols:TabViewItem Header="Powershell" IsClosable="False">
-                                <muxcontrols:TabViewItem.IconSource>
-                                    <muxcontrols:BitmapIconSource UriSource="/Assets/TabViewIcons/powershell.png" ShowAsMonochrome="False" />
-                                </muxcontrols:TabViewItem.IconSource>
-                            </muxcontrols:TabViewItem>
-                            <muxcontrols:TabViewItem Header="Windows Subsystem for Linux" IsClosable="False">
-                                <muxcontrols:TabViewItem.IconSource>
-                                    <muxcontrols:BitmapIconSource UriSource="/Assets/TabViewIcons/linux.png" ShowAsMonochrome="False" />
-                                </muxcontrols:TabViewItem.IconSource>
-                            </muxcontrols:TabViewItem>
-                        </muxcontrols:TabView.TabItems>
-                    </muxcontrols:TabView>
+                    <muxc:TabView x:Name="TabView4" SelectedIndex="0" IsAddTabButtonVisible="False" MinWidth="490" TabWidthMode="SizeToContent">
+                        <muxc:TabView.TabItems>
+                            <muxc:TabViewItem Header="CMD Prompt" IsClosable="False">
+                                <muxc:TabViewItem.IconSource>
+                                    <muxc:BitmapIconSource UriSource="/Assets/TabViewIcons/cmd.png" ShowAsMonochrome="False" />
+                                </muxc:TabViewItem.IconSource>
+                            </muxc:TabViewItem>
+                            <muxc:TabViewItem Header="Powershell" IsClosable="False">
+                                <muxc:TabViewItem.IconSource>
+                                    <muxc:BitmapIconSource UriSource="/Assets/TabViewIcons/powershell.png" ShowAsMonochrome="False" />
+                                </muxc:TabViewItem.IconSource>
+                            </muxc:TabViewItem>
+                            <muxc:TabViewItem Header="Windows Subsystem for Linux" IsClosable="False">
+                                <muxc:TabViewItem.IconSource>
+                                    <muxc:BitmapIconSource UriSource="/Assets/TabViewIcons/linux.png" ShowAsMonochrome="False" />
+                                </muxc:TabViewItem.IconSource>
+                            </muxc:TabViewItem>
+                        </muxc:TabView.TabItems>
+                    </muxc:TabView>
                 </StackPanel>
             </local:ControlExample.Example>
 
             <local:ControlExample.Xaml>
                 <x:String xml:space="preserve">
-&lt;TabView&gt;
-    &lt;TabView.TabItems&gt;
-        &lt;TabViewItem Header="CMD Prompt"&gt;
-            &lt;TabViewItem.IconSource&gt;
-                &lt;BitmapIconSource UriSource="/Assets/TabViewIcons/cmd.png" ShowAsMonochrome="False" /&gt;
-            &lt;/TabViewItem.IconSource&gt;
-        &lt;/TabViewItem&gt;
-        &lt;TabViewItem Header="Powershell"&gt;
-            &lt;TabViewItem.IconSource&gt;
-                &lt;BitmapIconSource UriSource="/Assets/TabViewIcons/powershell.png" ShowAsMonochrome="False" /&gt;
-            &lt;/TabViewItem.IconSource&gt;
-        &lt;/TabViewItem&gt;
-        &lt;TabViewItem Header="Windows Subsystem for Linux"&gt;
-            &lt;TabViewItem.IconSource&gt;
-                &lt;BitmapIconSource UriSource="/Assets/TabViewIcons/linux.png" ShowAsMonochrome="False" /&gt;
-            &lt;/TabViewItem.IconSource&gt;
-        &lt;/TabViewItem&gt;
-    &lt;/TabView.TabItems&gt;
-&lt;/TabView&gt;
+&lt;muxc:TabView&gt;
+    &lt;muxc:TabView.TabItems&gt;
+        &lt;muxc:TabViewItem Header="CMD Prompt"&gt;
+            &lt;muxc:TabViewItem.IconSource&gt;
+                &lt;muxc:BitmapIconSource UriSource="/Assets/TabViewIcons/cmd.png" ShowAsMonochrome="False" /&gt;
+            &lt;/muxc:TabViewItem.IconSource&gt;
+        &lt;/muxc:TabViewItem&gt;
+        &lt;muxc:TabViewItem Header="Powershell"&gt;
+            &lt;muxc:TabViewItem.IconSource&gt;
+                &lt;muxc:BitmapIconSource UriSource="/Assets/TabViewIcons/powershell.png" ShowAsMonochrome="False" /&gt;
+            &lt;/muxc:TabViewItem.IconSource&gt;
+        &lt;/muxc:TabViewItem&gt;
+        &lt;muxc:TabViewItem Header="Windows Subsystem for Linux"&gt;
+            &lt;muxc:TabViewItem.IconSource&gt;
+                &lt;muxc:BitmapIconSource UriSource="/Assets/TabViewIcons/linux.png" ShowAsMonochrome="False" /&gt;
+            &lt;/muxc:TabViewItem.IconSource&gt;
+        &lt;/muxc:TabViewItem&gt;
+    &lt;/muxc:TabView.TabItems&gt;
+&lt;/muxc:TabView&gt;
                 </x:String>
             </local:ControlExample.Xaml>
         </local:ControlExample>
 
         <local:ControlExample HeaderText="A TabView with accent colored TabStrip background">
             <local:ControlExample.Example>
-                <muxcontrols:TabView x:Name="TabView5" SelectedIndex="0" Margin="-12" AddTabButtonClick="TabView_AddButtonClick" TabCloseRequested="TabView_TabCloseRequested" Loaded="TabView_Loaded" MinHeight="475">
-                    <muxcontrols:TabView.Resources>
+                <muxc:TabView x:Name="TabView5" SelectedIndex="0" Margin="-12" AddTabButtonClick="TabView_AddButtonClick" TabCloseRequested="TabView_TabCloseRequested" Loaded="TabView_Loaded" MinHeight="475">
+                    <muxc:TabView.Resources>
                         <ResourceDictionary>
                             <ResourceDictionary.ThemeDictionaries>
                                 <ResourceDictionary x:Key="Light">
@@ -277,13 +277,13 @@
                                 </ResourceDictionary>
                             </ResourceDictionary.ThemeDictionaries>
                         </ResourceDictionary>
-                    </muxcontrols:TabView.Resources>
-                </muxcontrols:TabView>
+                    </muxc:TabView.Resources>
+                </muxc:TabView>
             </local:ControlExample.Example>
             <local:ControlExample.Xaml>
                 <x:String xml:space="preserve">
-&lt;TabView&gt;
-    &lt;TabView.Resources&gt;
+&lt;muxc:TabView&gt;
+    &lt;muxc:TabView.Resources&gt;
         &lt;ResourceDictionary&gt;
             &lt;ResourceDictionary.ThemeDictionaries&gt;
                 &lt;ResourceDictionary x:Key="Light"&gt;
@@ -294,8 +294,8 @@
                 &lt;/ResourceDictionary&gt;
             &lt;/ResourceDictionary.ThemeDictionaries&gt;
         &lt;/ResourceDictionary&gt;
-    &lt;/TabView.Resources&gt;
-&lt;/TabView&gt;
+    &lt;/muxc:TabView.Resources&gt;
+&lt;/muxc:TabView&gt;
                 </x:String>
             </local:ControlExample.Xaml>
         </local:ControlExample>

--- a/XamlControlsGallery/ControlPages/ToggleSplitButtonPage.xaml
+++ b/XamlControlsGallery/ControlPages/ToggleSplitButtonPage.xaml
@@ -4,7 +4,7 @@
       xmlns:local="using:AppUIBasics"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:muxcontrols="using:Microsoft.UI.Xaml.Controls"
+      xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
       mc:Ignorable="d">
     <StackPanel>
         <local:ControlExample x:Name="Example1" HeaderText="Using ToggleSplitButton to control bulleted list functionality in RichEditBox" 
@@ -16,9 +16,9 @@
                     <ColumnDefinition/>
                 </Grid.ColumnDefinitions>
 
-                <muxcontrols:ToggleSplitButton x:Name="myListButton" AutomationProperties.Name="Bullets" VerticalAlignment="Top" IsCheckedChanged="MyListButton_IsCheckedChanged">
+                <muxc:ToggleSplitButton x:Name="myListButton" AutomationProperties.Name="Bullets" VerticalAlignment="Top" IsCheckedChanged="MyListButton_IsCheckedChanged">
                     <SymbolIcon x:Name="mySymbolIcon" Symbol="List"/>
-                    <muxcontrols:ToggleSplitButton.Flyout>
+                    <muxc:ToggleSplitButton.Flyout>
                         <Flyout Placement="Bottom">
                             <StackPanel Orientation="Horizontal">
                                 <StackPanel.Resources>
@@ -37,8 +37,8 @@
                                 </Button>
                             </StackPanel>
                         </Flyout>
-                    </muxcontrols:ToggleSplitButton.Flyout>
-                </muxcontrols:ToggleSplitButton>
+                    </muxc:ToggleSplitButton.Flyout>
+                </muxc:ToggleSplitButton>
 
                 <RichEditBox x:Name="myRichEditBox" Grid.Column="1" MinWidth="240" MinHeight="96" AutomationProperties.Name="Text entry"/>
             </Grid>

--- a/XamlControlsGallery/ControlPages/TreeViewPage.xaml
+++ b/XamlControlsGallery/ControlPages/TreeViewPage.xaml
@@ -1,7 +1,7 @@
 ﻿<Page x:Class="AppUIBasics.ControlPages.TreeViewPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:muxcontrols="using:Microsoft.UI.Xaml.Controls"
+      xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
       xmlns:local="using:AppUIBasics"
       xmlns:controlpages="using:AppUIBasics.ControlPages"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -11,7 +11,7 @@
     <Page.Resources>
         <DataTemplate x:Key="FolderTemplate"
                       x:DataType="controlpages:ExplorerItem">
-            <muxcontrols:TreeViewItem AutomationProperties.Name="{x:Bind Name}"
+            <muxc:TreeViewItem AutomationProperties.Name="{x:Bind Name}"
                 ItemsSource="{x:Bind Children}" IsExpanded="True">
 
                 <StackPanel Orientation="Horizontal">
@@ -19,19 +19,19 @@
                     <TextBlock Margin="0,0,10,0"/>
                     <TextBlock Text="{x:Bind Name}" />
                 </StackPanel>
-            </muxcontrols:TreeViewItem>
+            </muxc:TreeViewItem>
         </DataTemplate>
 
         <DataTemplate x:Key="FileTemplate"
                       x:DataType="controlpages:ExplorerItem">
-            <muxcontrols:TreeViewItem AutomationProperties.Name="{x:Bind Name}">
+            <muxc:TreeViewItem AutomationProperties.Name="{x:Bind Name}">
 
                 <StackPanel Orientation="Horizontal">
                     <Image Width="20" Source="../Assets/file.png"/>
                     <TextBlock Margin="0,0,10,0"/>
                     <TextBlock Text="{x:Bind Name}"/>
                 </StackPanel>
-            </muxcontrols:TreeViewItem>
+            </muxc:TreeViewItem>
         </DataTemplate>
 
         <controlpages:ExplorerItemTemplateSelector 
@@ -44,13 +44,13 @@
         <local:ControlExample HeaderText="A simple TreeView with drag and drop support">
             <local:ControlExample.Example>
                 <Grid Height="400" BorderBrush="{ThemeResource TextControlBorderBrush}" BorderThickness="1">
-                    <muxcontrols:TreeView x:Name="sampleTreeView" MinWidth="345" MaxHeight="400" Margin="0,12,0,0"
+                    <muxc:TreeView x:Name="sampleTreeView" MinWidth="345" MaxHeight="400" Margin="0,12,0,0"
                             HorizontalAlignment="Center" VerticalAlignment="Top" ItemInvoked="sampleTreeView_ItemInvoked" CanDragItems="True" AllowDrop="True" />
                 </Grid>
             </local:ControlExample.Example>
             <local:ControlExample.Xaml>
                 <x:String>
-                    &lt;controls:TreeView  CanDragItems="True"  AllowDrop="True"/&gt;
+                    &lt;muxc:TreeView  CanDragItems="True"  AllowDrop="True"/&gt;
                 </x:String>
             </local:ControlExample.Xaml>
         </local:ControlExample>
@@ -58,13 +58,13 @@
         <local:ControlExample HeaderText="A TreeView with Multi-selection enabled">
             <local:ControlExample.Example>
                 <Grid Height="400" BorderBrush="{ThemeResource TextControlBorderBrush}" BorderThickness="1">
-                    <muxcontrols:TreeView x:Name="sampleTreeView2" MinWidth="345" MaxHeight="400" Margin="0,12,0,0"
+                    <muxc:TreeView x:Name="sampleTreeView2" MinWidth="345" MaxHeight="400" Margin="0,12,0,0"
                             HorizontalAlignment="Center" VerticalAlignment="Top" SelectionMode="Multiple"/>
                 </Grid>
             </local:ControlExample.Example>
             <local:ControlExample.Xaml>
                 <x:String>
-                    &lt;controls:TreeView SelectionMode="Multiple" /&gt;
+                    &lt;muxc:TreeView SelectionMode="Multiple" /&gt;
                 </x:String>
             </local:ControlExample.Xaml>
         </local:ControlExample>
@@ -72,19 +72,19 @@
         <local:ControlExample HeaderText="A TreeView with DataBinding Using ItemSource" XamlSource="TreeView\TreeViewDataBindingSample_xaml.txt">
             <local:ControlExample.Example>
                 <Grid Height="400" BorderBrush="{ThemeResource TextControlBorderBrush}" BorderThickness="1">
-                    <muxcontrols:TreeView Name="TreeView1" 
+                    <muxc:TreeView Name="TreeView1" 
                                           MinWidth="345" 
                                           MaxHeight="400" 
                                           Margin="0,12,0,0"
                                           HorizontalAlignment="Center" 
                                           VerticalAlignment="Top" 
                                           ItemsSource="{x:Bind DataSource}">
-                        <muxcontrols:TreeView.ItemTemplate>
+                        <muxc:TreeView.ItemTemplate>
                             <DataTemplate x:DataType="controlpages:ExplorerItem">
-                                <muxcontrols:TreeViewItem ItemsSource="{x:Bind Children}" Content="{x:Bind Name}" IsExpanded="True"/>
+                                <muxc:TreeViewItem ItemsSource="{x:Bind Children}" Content="{x:Bind Name}" IsExpanded="True"/>
                             </DataTemplate>
-                        </muxcontrols:TreeView.ItemTemplate>
-                    </muxcontrols:TreeView>
+                        </muxc:TreeView.ItemTemplate>
+                    </muxc:TreeView>
                 </Grid>
             </local:ControlExample.Example>
         </local:ControlExample>
@@ -92,7 +92,7 @@
         <local:ControlExample HeaderText="A TreeView with ItemTemplateSelector" XamlSource="TreeView\TreeViewTemplateSelectorSample_xaml.txt">
             <local:ControlExample.Example>
                 <Grid Height="400" BorderBrush="{ThemeResource TextControlBorderBrush}" BorderThickness="1">
-                    <muxcontrols:TreeView Name="FileTree" Grid.Column="2" MinWidth="345" MaxHeight="400" Margin="0,12,0,0"
+                    <muxc:TreeView Name="FileTree" Grid.Column="2" MinWidth="345" MaxHeight="400" Margin="0,12,0,0"
                             HorizontalAlignment="Center" VerticalAlignment="Top" ItemsSource="{x:Bind DataSource}" 
                             ItemTemplateSelector="{StaticResource ExplorerItemTemplateSelector}" />
                 </Grid>

--- a/XamlControlsGallery/ControlPages/XamlUICommandPage.xaml
+++ b/XamlControlsGallery/ControlPages/XamlUICommandPage.xaml
@@ -2,10 +2,8 @@
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
       xmlns:local="using:AppUIBasics"
-      xmlns:local2="using:AppUIBasics.ControlPages"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:muxcontrols="using:Microsoft.UI.Xaml.Controls"
       mc:Ignorable="d">
     <Page.Resources>
         <Style x:Key="HorizontalSwipe" TargetType="ListViewItem" BasedOn="{StaticResource ListViewItemRevealStyle}">

--- a/XamlControlsGallery/ControlPagesSampleCode/Buttons/DropDown/DropDownButton_Icon.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/Buttons/DropDown/DropDownButton_Icon.txt
@@ -1,8 +1,8 @@
-﻿<DropDownButton AutomationProperties.Name="Email">
-    <DropDownButton.Content>
+﻿<muxc:DropDownButton AutomationProperties.Name="Email">
+    <muxc:DropDownButton.Content>
         <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE715;"/>
-    </DropDownButton.Content>
-    <DropDownButton.Flyout>
+    </muxc:DropDownButton.Content>
+    <muxc:DropDownButton.Flyout>
         <MenuFlyout Placement="Bottom">
             <MenuFlyoutItem Text="Send">
                 <MenuFlyoutItem.Icon>
@@ -20,5 +20,5 @@
                 </MenuFlyoutItem.Icon>
             </MenuFlyoutItem>
         </MenuFlyout>
-    </DropDownButton.Flyout>
-</DropDownButton>
+    </muxc:DropDownButton.Flyout>
+</muxc:DropDownButton>

--- a/XamlControlsGallery/ControlPagesSampleCode/Buttons/DropDown/DropDownButton_RevealStyle.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/Buttons/DropDown/DropDownButton_RevealStyle.txt
@@ -1,9 +1,9 @@
-﻿<DropDownButton Content="Email" Style="{ThemeResource DropDownButtonRevealStyle}">
-    <DropDownButton.Flyout>
+﻿<muxc:DropDownButton Content="Email" Style="{ThemeResource DropDownButtonRevealStyle}">
+    <muxc:DropDownButton.Flyout>
         <MenuFlyout Placement="Bottom">
             <MenuFlyoutItem Text="Send"/>
             <MenuFlyoutItem Text="Reply"/>
             <MenuFlyoutItem Text="Reply All"/>
         </MenuFlyout>
-    </DropDownButton.Flyout>
-</DropDownButton>
+    </muxc:DropDownButton.Flyout>
+</muxc:DropDownButton>

--- a/XamlControlsGallery/ControlPagesSampleCode/Buttons/DropDown/DropDownButton_Simple.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/Buttons/DropDown/DropDownButton_Simple.txt
@@ -1,9 +1,9 @@
-﻿<DropDownButton Content="Email">
-    <DropDownButton.Flyout>
+﻿<muxc:DropDownButton Content="Email">
+    <muxc:DropDownButton.Flyout>
         <MenuFlyout Placement="Bottom">
             <MenuFlyoutItem Text="Send"/>
             <MenuFlyoutItem Text="Reply"/>
             <MenuFlyoutItem Text="Reply All"/>
         </MenuFlyout>
-    </DropDownButton.Flyout>
-</DropDownButton>
+    </muxc:DropDownButton.Flyout>
+</muxc:DropDownButton>

--- a/XamlControlsGallery/ControlPagesSampleCode/Buttons/SplitButton/SplitButtonSample1.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/Buttons/SplitButton/SplitButtonSample1.txt
@@ -1,8 +1,8 @@
-﻿<SplitButton x:Name="myColorButton" Click="myColorButton_Click">
+﻿<muxc:SplitButton x:Name="myColorButton" Click="myColorButton_Click">
     <Rectangle x:Name="CurrentColor" Width="32" Height="32" Fill="Black"/>
-    <SplitButton.Flyout>
+    <muxc:SplitButton.Flyout>
         <Flyout Placement="Bottom">
             <!-- flyout content -->
         </Flyout>
-    </SplitButton.Flyout>
-</SplitButton>
+    </muxc:SplitButton.Flyout>
+</muxc:SplitButton>

--- a/XamlControlsGallery/ControlPagesSampleCode/Buttons/SplitButton/SplitButtonSample2.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/Buttons/SplitButton/SplitButtonSample2.txt
@@ -1,8 +1,8 @@
-﻿<SplitButton x:Name="myColorButton" Style="{ThemeResource SplitButtonRevealStyle}" >
+﻿<muxc:SplitButton x:Name="myColorButton" Style="{ThemeResource SplitButtonRevealStyle}" >
     Choose color
-    <SplitButton.Flyout>
+    <muxc:SplitButton.Flyout>
         <Flyout Placement="Bottom">
             <!-- flyout content -->
         </Flyout>
-    </SplitButton.Flyout>
-</SplitButton>
+    </muxc:SplitButton.Flyout>
+</muxc:SplitButton>

--- a/XamlControlsGallery/ControlPagesSampleCode/Buttons/ToggleSplitButton/ToggleSplitButtonSample1.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/Buttons/ToggleSplitButton/ToggleSplitButtonSample1.txt
@@ -1,8 +1,8 @@
-﻿<ToggleSplitButton x:Name="myListButton" VerticalAlignment="Top" Click="myListButton_Click">
+﻿<muxc:ToggleSplitButton x:Name="myListButton" VerticalAlignment="Top" Click="myListButton_Click">
     <SymbolIcon x:Name="mySymbolIcon" Symbol="List"/>
-    <ToggleSplitButton.Flyout>
+    <muxc:ToggleSplitButton.Flyout>
         <Flyout Placement="Bottom">
             <!-- flyout content -->
         </Flyout>
-    </ToggleSplitButton.Flyout>
-</ToggleSplitButton>
+    </muxc:ToggleSplitButton.Flyout>
+</muxc:ToggleSplitButton>

--- a/XamlControlsGallery/ControlPagesSampleCode/CommandBarFlyout/CommandBarFlyoutSample1_xaml.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/CommandBarFlyout/CommandBarFlyoutSample1_xaml.txt
@@ -1,13 +1,13 @@
 ﻿<Page.Resources>
-    <muxcontrols:CommandBarFlyout Placement="Right" x:Name="CommandBarFlyout1">
+    <muxc:CommandBarFlyout Placement="Right" x:Name="CommandBarFlyout1">
         <AppBarButton Label="Share" Icon="Share" ToolTipService.ToolTip="Share" Click="OnElementClicked" />
         <AppBarButton Label="Save" Icon="Save" ToolTipService.ToolTip="Save" Click="OnElementClicked" />
         <AppBarButton Label="Delete" Icon="Delete" ToolTipService.ToolTip="Delete" Click="OnElementClicked" />
-        <muxcontrols:CommandBarFlyout.SecondaryCommands>
+        <muxc:CommandBarFlyout.SecondaryCommands>
             <AppBarButton x:Name="ResizeButton1" Label="Resize" Click="OnElementClicked" />
             <AppBarButton x:Name="MoveButton1" Label="Move" Click="OnElementClicked" />
-        </muxcontrols:CommandBarFlyout.SecondaryCommands>
-    </muxcontrols:CommandBarFlyout>
+        </muxc:CommandBarFlyout.SecondaryCommands>
+    </muxc:CommandBarFlyout>
 </Page.Resources>
 
 <Button x:Name="myImageButton" AutomationProperties.Name="mountain" Padding="0"

--- a/XamlControlsGallery/ControlPagesSampleCode/NavigationView/NavigationViewSample1.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/NavigationView/NavigationViewSample1.txt
@@ -1,9 +1,9 @@
-﻿<NavigationView x:Name="nvSample">
-    <NavigationView.MenuItems>
-        <NavigationViewItem Icon="Play" Content="Menu Item1" Tag="SamplePage1" />
-        <NavigationViewItem Icon="Save" Content="Menu Item2" Tag="SamplePage2" />
-        <NavigationViewItem Icon="Refresh" Content="Menu Item3" Tag="SamplePage3" />
-        <NavigationViewItem Icon="Download" Content="Menu Item4" Tag="SamplePage4" />
-    </NavigationView.MenuItems>
+﻿<muxc:NavigationView x:Name="nvSample">
+    <muxc:NavigationView.MenuItems>
+        <muxc:NavigationViewItem Icon="Play" Content="Menu Item1" Tag="SamplePage1" />
+        <muxc:NavigationViewItem Icon="Save" Content="Menu Item2" Tag="SamplePage2" />
+        <muxc:NavigationViewItem Icon="Refresh" Content="Menu Item3" Tag="SamplePage3" />
+        <muxc:NavigationViewItem Icon="Download" Content="Menu Item4" Tag="SamplePage4" />
+    </muxc:NavigationView.MenuItems>
     <Frame x:Name="contentFrame"/>
-</NavigationView>
+</muxc:NavigationView>

--- a/XamlControlsGallery/ControlPagesSampleCode/NavigationView/NavigationViewSample2.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/NavigationView/NavigationViewSample2.txt
@@ -1,9 +1,9 @@
-﻿<NavigationView x:Name="nvSample" Header="This is Header Text" PaneDisplayMode="Top">
-    <NavigationView.MenuItems>
-        <NavigationViewItem  Content="Menu Item1" Tag="SamplePage1" />
-        <NavigationViewItem  Content="Menu Item2" Tag="SamplePage2" />
-        <NavigationViewItem  Content="Menu Item3" Tag="SamplePage3" />
-        <NavigationViewItem  Content="Menu Item4" Tag="SamplePage4" />
-    </NavigationView.MenuItems>
+﻿<muxc:NavigationView x:Name="nvSample" Header="This is Header Text" PaneDisplayMode="Top">
+    <muxc:NavigationView.MenuItems>
+        <muxc:NavigationViewItem  Content="Menu Item1" Tag="SamplePage1" />
+        <muxc:NavigationViewItem  Content="Menu Item2" Tag="SamplePage2" />
+        <muxc:NavigationViewItem  Content="Menu Item3" Tag="SamplePage3" />
+        <muxc:NavigationViewItem  Content="Menu Item4" Tag="SamplePage4" />
+    </muxc:NavigationView.MenuItems>
     <Frame x:Name="contentFrame"/>
-</NavigationView>
+</muxc:NavigationView>

--- a/XamlControlsGallery/ControlPagesSampleCode/NavigationView/NavigationViewSample3.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/NavigationView/NavigationViewSample3.txt
@@ -11,12 +11,12 @@
     </VisualStateGroup>
 </VisualStateManager.VisualStateGroups >
 
-<NavigationView x:Name="nvSample">
-    <NavigationView.MenuItems>
-        <NavigationViewItem Content="Menu Item1" Tag="SamplePage1" />
-        <NavigationViewItem Content="Menu Item2" Tag="SamplePage2" />
-        <NavigationViewItem Content="Menu Item3" Tag="SamplePage3" />
-        <NavigationViewItem Content="Menu Item4" Tag="SamplePage4" />
-    </NavigationView.MenuItems>
+<muxc:NavigationView x:Name="nvSample">
+    <muxc:NavigationView.MenuItems>
+        <muxc:NavigationViewItem Content="Menu Item1" Tag="SamplePage1" />
+        <muxc:NavigationViewItem Content="Menu Item2" Tag="SamplePage2" />
+        <muxc:NavigationViewItem Content="Menu Item3" Tag="SamplePage3" />
+        <muxc:NavigationViewItem Content="Menu Item4" Tag="SamplePage4" />
+    </muxc:NavigationView.MenuItems>
     <Frame x:Name="contentFrame"/>
-</NavigationView>
+</muxc:NavigationView>

--- a/XamlControlsGallery/ControlPagesSampleCode/NavigationView/NavigationViewSample4_xaml.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/NavigationView/NavigationViewSample4_xaml.txt
@@ -1,10 +1,10 @@
-﻿<NavigationView x:Name="nvSample" PaneDisplayMode="Top" 
+﻿<muxc:NavigationView x:Name="nvSample" PaneDisplayMode="Top" 
     SelectionFollowsFocus="Enabled" BackButtonVisibility="Collapsed">
-    <NavigationView.MenuItems>
-        <NavigationViewItem Icon="Play" Content="Item1" x:Name="SamplePage1Item" />
-        <NavigationViewItem Icon="Save" Content="Item2" x:Name="SamplePage2Item" />
-        <NavigationViewItem Icon="Refresh" Content="Item3" x:Name="SamplePage3Item" />
-        <NavigationViewItem Icon="Download" Content="Item4" x:Name="SamplePage4Item" />
-    </NavigationView.MenuItems>
+    <muxc:NavigationView.MenuItems>
+        <muxc:NavigationViewItem Icon="Play" Content="Item1" x:Name="SamplePage1Item" />
+        <muxc:NavigationViewItem Icon="Save" Content="Item2" x:Name="SamplePage2Item" />
+        <muxc:NavigationViewItem Icon="Refresh" Content="Item3" x:Name="SamplePage3Item" />
+        <muxc:NavigationViewItem Icon="Download" Content="Item4" x:Name="SamplePage4Item" />
+    </muxc:NavigationView.MenuItems>
     <Frame x:Name="contentFrame"/>
-</NavigationView>
+</muxc:NavigationView>

--- a/XamlControlsGallery/ControlPagesSampleCode/NavigationView/NavigationViewSample5_xaml.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/NavigationView/NavigationViewSample5_xaml.txt
@@ -1,15 +1,15 @@
-﻿<NavigationView x:Name="nvSample" 
+﻿<muxc:NavigationView x:Name="nvSample" 
                 MenuItemTemplateSelector="{StaticResource selector}" 
                 MenuItemSource="{x:Bind Categories, Mode=OneWay}" />
  
 <local:MenuItemTemplateSelector x:Key="selector"> 
     <local:MenuItemTemplateSelector.ItemTemplate> 
         <DataTemplate x:DataType="local:Category" > 
-            <muxcontrols:NavigationViewItem Content="{x:Bind Name}" TooltipService.ToolTip="{x:Bind Tooltip}"> 
-                <muxcontrols:NavigationViewItem.Icon> 
+            <muxc:NavigationViewItem Content="{x:Bind Name}" TooltipService.ToolTip="{x:Bind Tooltip}"> 
+                <muxc:NavigationViewItem.Icon> 
                     <SymbolIcon Symbol="{x:Bind Glyph}" /> 
-                </muxcontrols:NavigationViewItem.Icon> 
-            </muxcontrols:NavigationViewItem>
+                </muxc:NavigationViewItem.Icon> 
+            </muxc:NavigationViewItem>
         </DataTemplate> 
     </local:MenuItemTemplateSelector.ItemTemplate > 
 </local:MenuItemTemplateSelector> 

--- a/XamlControlsGallery/ControlPagesSampleCode/Text/RichEditBox/RichEditBoxSample3_xaml.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/Text/RichEditBox/RichEditBoxSample3_xaml.txt
@@ -30,12 +30,12 @@
         </Button.Content>
     </Button>
 
-    <muxcontrols:DropDownButton x:Name="fontColorButton" AutomationProperties.Name="Font color"
+    <muxc:DropDownButton x:Name="fontColorButton" AutomationProperties.Name="Font color"
                                 BorderThickness="0" ToolTipService.ToolTip="Font color"
                                 Background="Transparent" 
                                 RelativePanel.AlignRightWithPanel="True">
         <SymbolIcon Symbol="FontColor"/>
-        <muxcontrols:DropDownButton.Flyout>
+        <muxc:DropDownButton.Flyout>
             <Flyout Placement="Bottom">
                 <VariableSizedWrapGrid Orientation="Horizontal" MaximumRowsOrColumns="3">
                     <VariableSizedWrapGrid.Resources>
@@ -97,8 +97,8 @@
                     </Button>
                 </VariableSizedWrapGrid>
             </Flyout>
-        </muxcontrols:DropDownButton.Flyout>
-    </muxcontrols:DropDownButton>
+        </muxc:DropDownButton.Flyout>
+    </muxc:DropDownButton>
 
     <RichEditBox x:Name="editor" Height="200" 
                  RelativePanel.Below="openFileButton" 

--- a/XamlControlsGallery/ControlPagesSampleCode/TreeView/TreeViewDataBindingSample_xaml.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/TreeView/TreeViewDataBindingSample_xaml.txt
@@ -1,7 +1,7 @@
-﻿<controls:TreeView ItemsSource="{x:Bind DataSource}">
-   <controls:TreeView.ItemTemplate>
+﻿<muxc:TreeView ItemsSource="{x:Bind DataSource}">
+   <muxc:TreeView.ItemTemplate>
       <DataTemplate x:DataType="local:ExplorerItem">
-         <controls:TreeViewItem ItemsSource="{x:Bind Children}" Content="{x:Bind Name}"/>
+         <muxc:TreeViewItem ItemsSource="{x:Bind Children}" Content="{x:Bind Name}"/>
       </DataTemplate>
-   </controls:TreeView.ItemTemplate>
-</controls:TreeView>
+   </muxc:TreeView.ItemTemplate>
+</muxc:TreeView>

--- a/XamlControlsGallery/ControlPagesSampleCode/TreeView/TreeViewTemplateSelectorSample_xaml.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/TreeView/TreeViewTemplateSelectorSample_xaml.txt
@@ -1,30 +1,30 @@
 ﻿<Page.Resources>
     <DataTemplate x:Key="FolderTemplate" x:DataType="controlpages:ExplorerItem">
-        <controls:TreeViewItem AutomationProperties.Name="{x:Bind Name}"
+        <muxc:TreeViewItem AutomationProperties.Name="{x:Bind Name}"
             ItemsSource="{x:Bind Children}" IsExpanded="True">
             <StackPanel Orientation="Horizontal">
                 <Image Width="20" Source="../Assets/folder.png"/>
                 <TextBlock Margin="0,0,10,0"/>
                 <TextBlock Text="{x:Bind Name}" />
             </StackPanel>
-        </controls:TreeViewItem>
+        </muxc:TreeViewItem>
     </DataTemplate>
 
     <DataTemplate x:Key="FileTemplate" x:DataType="controlpages:ExplorerItem">
-        <controls:TreeViewItem AutomationProperties.Name="{x:Bind Name}">
+        <muxc:TreeViewItem AutomationProperties.Name="{x:Bind Name}">
             <StackPanel Orientation="Horizontal">
                 <Image Width="20" Source="../Assets/file.png"/>
                 <TextBlock Margin="0,0,10,0"/>
                 <TextBlock Text="{x:Bind Name}"/>
             </StackPanel>
-        </controls:TreeViewItem>
+        </muxc:TreeViewItem>
     </DataTemplate>
 
-    <local:ExplorerItemTemplateSelector x:Key="ExpolrerItemTemplateSelector"
+    <controlpages:ExplorerItemTemplateSelector x:Key="ExpolrerItemTemplateSelector"
         FolderTemplate="{StaticResource FolderTemplate}"
         FileTemplate="{StaticResource FileTemplate}" />
 </Page.Resources>
 
-<controls:TreeView ItemsSource="{x:Bind DataSource}" 
+<muxc:TreeView ItemsSource="{x:Bind DataSource}" 
                    ItemTemplateSelector="{StaticResource ExpolrerItemTemplateSelector}" />
 

--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml
@@ -13,7 +13,7 @@
     x:Class="AppUIBasics.NavigationRootPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:mux="using:Microsoft.UI.Xaml.Controls"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:local="using:AppUIBasics">
 
     <Page.Resources>
@@ -64,7 +64,7 @@
                        Style="{StaticResource CaptionTextBlockStyle}" />
         </Border>
 
-        <mux:NavigationView
+        <muxc:NavigationView
             Canvas.ZIndex="0"
             x:Name="NavigationViewControl"
             Grid.Column="1"
@@ -77,7 +77,7 @@
             PaneClosing="NavigationViewControl_PaneClosing"
             DisplayModeChanged="NavigationViewControl_DisplayModeChanged"
             ItemInvoked="OnNavigationViewItemInvoked">
-            <mux:NavigationView.AutoSuggestBox>
+            <muxc:NavigationView.AutoSuggestBox>
                 <AutoSuggestBox
                     x:Name="controlsSearchBox"
                     VerticalAlignment="Center"
@@ -87,9 +87,9 @@
                     QuerySubmitted="OnControlsSearchBoxQuerySubmitted"
                     TextChanged="OnControlsSearchBoxTextChanged">
                 </AutoSuggestBox>
-            </mux:NavigationView.AutoSuggestBox>
+            </muxc:NavigationView.AutoSuggestBox>
 
             <Frame x:Name="rootFrame" Navigated="OnRootFrameNavigated" />
-        </mux:NavigationView>
+        </muxc:NavigationView>
     </Grid>
 </Page>

--- a/XamlControlsGallery/PageHeader.xaml
+++ b/XamlControlsGallery/PageHeader.xaml
@@ -2,7 +2,7 @@
     x:Class="AppUIBasics.PageHeader"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="using:Microsoft.UI.Xaml.Controls"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:local="using:AppUIBasics"
     x:Name="headerControl"
     Padding="12,0,12,0"
@@ -81,15 +81,15 @@
                             <FontIcon Glyph="&#xE771;" Margin="0,-2,0,0" />
                         </AppBarButton.Icon>
                         <AppBarButton.Resources>
-                            <controls:TeachingTip x:Name="ToggleThemeTeachingTip1"                   
+                            <muxc:TeachingTip x:Name="ToggleThemeTeachingTip1"                   
                                 Target="{x:Bind ThemeButton}"
                                 Title="Change themes without hassle"                                        
                                 Subtitle="It's easier than ever to see control samples in both light and dark theme!">
-                                <controls:TeachingTip.IconSource>
-                                    <controls:SymbolIconSource Symbol="Refresh" />
-                                </controls:TeachingTip.IconSource>
-                            </controls:TeachingTip>
-                            <controls:TeachingTip x:Name="ToggleThemeTeachingTip2"                   
+                                <muxc:TeachingTip.IconSource>
+                                    <muxc:SymbolIconSource Symbol="Refresh" />
+                                </muxc:TeachingTip.IconSource>
+                            </muxc:TeachingTip>
+                            <muxc:TeachingTip x:Name="ToggleThemeTeachingTip2"                   
                                 Title="Change themes without hassle"
                                 Subtitle="It's easier than ever to see control samples in both light and dark theme!"
                                 PreferredPlacement="Auto"                                              
@@ -98,19 +98,19 @@
                                 ActionButtonClick="ToggleThemeTeachingTip2_ActionButtonClick"
                                 ActionButtonContent="Toggle theme now"
                                 CloseButtonContent="Got it!">
-                            </controls:TeachingTip>
-                            <controls:TeachingTip x:Name="ToggleThemeTeachingTip3" 
+                            </muxc:TeachingTip>
+                            <muxc:TeachingTip x:Name="ToggleThemeTeachingTip3" 
                                 Target="{x:Bind ThemeButton}"
                                 Title="Change themes without hassle"
                                 Subtitle="It's easier than ever to see control samples in both light and dark theme!"
                                 PreferredPlacement="LeftBottom">
-                                <controls:TeachingTip.HeroContent>
+                                <muxc:TeachingTip.HeroContent>
                                     <Image Source="/Assets/SampleMedia/sunset.jpg" AutomationProperties.Name="Sunset" />
-                                </controls:TeachingTip.HeroContent>
-                                <controls:TeachingTip.Content>
+                                </muxc:TeachingTip.HeroContent>
+                                <muxc:TeachingTip.Content>
                                     <TextBlock TextWrapping="WrapWholeWords" Margin="0,16,0,0">To change your desktop theme visit the <Hyperlink NavigateUri="ms-settings:colors">Settings app</Hyperlink>.</TextBlock>
-                                </controls:TeachingTip.Content>
-                            </controls:TeachingTip>
+                                </muxc:TeachingTip.Content>
+                            </muxc:TeachingTip>
                         </AppBarButton.Resources>
                     </AppBarButton>
                 </CommandBar>

--- a/XamlControlsGallery/TabViewPages/TabViewWindowingSamplePage.xaml
+++ b/XamlControlsGallery/TabViewPages/TabViewWindowingSamplePage.xaml
@@ -6,11 +6,11 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    xmlns:muxcontrols="using:Microsoft.UI.Xaml.Controls"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-        <muxcontrols:TabView x:Name="Tabs" 
+        <muxc:TabView x:Name="Tabs" 
                              VerticalAlignment="Stretch"
                              AddTabButtonClick="Tabs_AddTabButtonClick"
                              TabCloseRequested="Tabs_TabCloseRequested"
@@ -21,12 +21,12 @@
                              TabStripDragOver="Tabs_TabStripDragOver"
                              TabStripDrop="Tabs_TabStripDrop"
                              TabDragStarting="Tabs_TabDragStarting" >
-            <muxcontrols:TabView.TabStripHeader>
+            <muxc:TabView.TabStripHeader>
                 <Grid x:Name="ShellTitlebarInset" Background="Transparent" />
-            </muxcontrols:TabView.TabStripHeader>
-            <muxcontrols:TabView.TabStripFooter>
+            </muxc:TabView.TabStripHeader>
+            <muxc:TabView.TabStripFooter>
                 <Grid x:Name="CustomDragRegion" Background="Transparent" />
-            </muxcontrols:TabView.TabStripFooter>
-        </muxcontrols:TabView>
+            </muxc:TabView.TabStripFooter>
+        </muxc:TabView>
     </Grid>
 </Page>


### PR DESCRIPTION
Updated all instances of using:Microsoft.UI.Xaml.Controls to use mux prefix

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Searched for all instances of using:Microsoft.UI.Xaml.Controls, ensured they all use the same xmlns:muxc prefix. Updated sample code to also use "muxc".

I anticipated merge conflicts with #208 but they haven't materialized. Perhaps I just haven't waited long enough for the PR to propagate...? 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manually verified

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
