### PR TITLE
TabView: Mark handled keyboard accelerator events as handled

### DIFF
--- a/XamlControlsGallery/ControlPages/TabViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/TabViewPage.xaml.cs
@@ -133,6 +133,8 @@ namespace AppUIBasics.ControlPages
         {
             var senderTabView = args.Element as TabView;
             senderTabView.TabItems.Add(CreateNewTab(senderTabView.TabItems.Count));
+
+            args.Handled = true;
         }
 
         private void CloseSelectedTabKeyboardAccelerator_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
@@ -144,6 +146,8 @@ namespace AppUIBasics.ControlPages
             {
                 InvokedTabView.TabItems.Remove(InvokedTabView.SelectedItem);
             }
+
+            args.Handled = true;
         }
 
         private void NavigateToNumberedTabKeyboardAccelerator_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
@@ -189,6 +193,8 @@ namespace AppUIBasics.ControlPages
             {
                 InvokedTabView.SelectedIndex = tabToSelect;
             }
+
+            args.Handled = true;
         }
         #endregion
 

--- a/XamlControlsGallery/ControlPagesSampleCode/TabView/TabViewKeyboardAcceleratorSample_cs.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/TabView/TabViewKeyboardAcceleratorSample_cs.txt
@@ -2,6 +2,7 @@
 {
     var senderTabView = args.Element as TabView;
     senderTabView.TabItems.Add(CreateNewTab(senderTabView.TabItems.Count));
+    args.Handled = true;
 }
 
 private void CloseSelectedTabKeyboardAccelerator_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
@@ -13,6 +14,7 @@ private void CloseSelectedTabKeyboardAccelerator_Invoked(KeyboardAccelerator sen
     {
         InvokedTabView.TabItems.Remove(InvokedTabView.SelectedItem);
     }
+    args.Handled = true;
 }
 
 private void NavigateToNumberedTabKeyboardAccelerator_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
@@ -58,4 +60,5 @@ private void NavigateToNumberedTabKeyboardAccelerator_Invoked(KeyboardAccelerato
     {
         InvokedTabView.SelectedIndex = tabToSelect;
     }
+    args.Handled = true;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The TabView page uses KeyboardAccelerators to add/remove tabs via CTRL+T, CTRL+W. If we don't mark them as handled, they will occasionally "double fire" and open/close two tabs at a time. Since we are handling the event, we should mark the event as handled. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes an internal bug.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
