### PR TITLE
Switch from ToggleSwitch to radio buttons for pen tip in InkCanvas page

### DIFF
--- a/XamlControlsGallery/ControlPages/InkCanvasPage.xaml
+++ b/XamlControlsGallery/ControlPages/InkCanvasPage.xaml
@@ -21,8 +21,11 @@
                             ValueChanged="strokeSize_ValueChanged" Margin="0,12,0,0" IsFocusEngagementEnabled="False"/>
                     <CheckBox x:Name="drawAsHighlighter" Content="DrawAsHighlighter" IsChecked="False"
                             Checked="drawAsHighlighter_CheckedChanged" Unchecked="drawAsHighlighter_CheckedChanged" />
-                    <ToggleSwitch x:Name="penTipShape" Header="Pen tip" OnContent="Circle" OffContent="Rectangle" IsOn="True"
-                            Toggled="penTipShape_Toggled" Margin="0,8,0,0" />
+                    <StackPanel Margin="0,5,0,0">
+                        <TextBlock>Pen tip</TextBlock>
+                        <RadioButton x:Name="penTipShape" Checked="PenTip_Checked" Content="Circle" IsChecked="True"></RadioButton>
+                        <RadioButton Checked="PenTip_Checked" Content="Rectangle"></RadioButton>
+                    </StackPanel>
                     <Button x:Name="clearAll" Content="Clear All" Click="clearAll_Click" Margin="0,8,0,0" />
                 </StackPanel>
             </local:ControlExample.Options>

--- a/XamlControlsGallery/ControlPages/InkCanvasPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/InkCanvasPage.xaml.cs
@@ -54,12 +54,6 @@ namespace AppUIBasics.ControlPages
 
         }
 
-        private void penTipShape_Toggled(object sender, RoutedEventArgs e)
-        {
-            UpdatePen();
-
-        }
-
         private void UpdatePen()
         {
             if (_inkPresenter != null)
@@ -84,7 +78,7 @@ namespace AppUIBasics.ControlPages
 
                 defaultAttributes.Size = new Size(strokeSize.Value, strokeSize.Value);
                 defaultAttributes.DrawAsHighlighter = drawAsHighlighter.IsChecked.Value;
-                defaultAttributes.PenTip = penTipShape.IsOn ? PenTipShape.Circle : PenTipShape.Rectangle;
+                defaultAttributes.PenTip = (bool)penTipShape.IsChecked ? PenTipShape.Circle : PenTipShape.Rectangle;
 
                 _inkPresenter.UpdateDefaultDrawingAttributes(defaultAttributes);
             }
@@ -93,6 +87,11 @@ namespace AppUIBasics.ControlPages
         private void clearAll_Click(object sender, RoutedEventArgs e)
         {
             _inkPresenter.StrokeContainer.Clear();
+        }
+
+        private void PenTip_Checked(object sender, RoutedEventArgs e)
+        {
+            UpdatePen();
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replaced toggle switch for pen tip with radio buttons.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #219 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by navigating to InkCanvas page and testing if both pen tip options work correctly.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
