### PR TITLE
Fixing issue 232

### DIFF
--- a/XamlControlsGallery/ControlPages/SliderPage.xaml
+++ b/XamlControlsGallery/ControlPages/SliderPage.xaml
@@ -54,7 +54,7 @@
         </local:ControlExample>
         <local:ControlExample x:Name="Example4" HeaderText="A vertical slider with range and tick marks specified.">
             <StackPanel Orientation="Horizontal">
-                <Slider x:Name="Slider4" Width="100" Height="90" Orientation="Vertical" TickFrequency="10" TickPlacement="Outside"
+                <Slider x:Name="Slider4" Width="100" Height="100" Orientation="Vertical" TickFrequency="10" TickPlacement="Outside"
                         Maximum="50" Minimum="-50" AutomationProperties.Name="vertical slider"/>
                 <TextBlock Style="{StaticResource OutputTextBlockStyle}"
                         Text="{x:Bind Slider4.Value.ToString(), Mode=OneWay}" />

--- a/XamlControlsGallery/ControlPages/SliderPage.xaml
+++ b/XamlControlsGallery/ControlPages/SliderPage.xaml
@@ -54,7 +54,7 @@
         </local:ControlExample>
         <local:ControlExample x:Name="Example4" HeaderText="A vertical slider with range and tick marks specified.">
             <StackPanel Orientation="Horizontal">
-                <Slider x:Name="Slider4" Width="100" Orientation="Vertical" TickFrequency="10" TickPlacement="Outside"
+                <Slider x:Name="Slider4" Width="100" Height="90" Orientation="Vertical" TickFrequency="10" TickPlacement="Outside"
                         Maximum="50" Minimum="-50" AutomationProperties.Name="vertical slider"/>
                 <TextBlock Style="{StaticResource OutputTextBlockStyle}"
                         Text="{x:Bind Slider4.Value.ToString(), Mode=OneWay}" />


### PR DESCRIPTION

I added the height property, setting it to 90 for the vertical slider, effectively increasing the height of it.

## Motivation and Context
The issue is that there was not really any range for the vertical slider to be moved
https://github.com/microsoft/Xaml-Controls-Gallery/issues/232

## How Has This Been Tested?
Building the app on x86, Windows 10 1903 Build 18362. 10024
No other code was effected.

## Screenshots (if appropriate):
Looks like this now:
![image](https://user-images.githubusercontent.com/32169182/67820918-0e72b800-fab3-11e9-96f5-42f11e464096.png)

used to look like:
![image](https://user-images.githubusercontent.com/32169182/67821005-65788d00-fab3-11e9-81e9-ed3f07251caf.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
