### PR TITLE
added full stop to subtitle and description

### DIFF
--- a/XamlControlsGallery/DataModel/ControlInfoData.json
+++ b/XamlControlsGallery/DataModel/ControlInfoData.json
@@ -748,9 +748,9 @@
         {
           "UniqueId": "SplitButton",
           "Title": "SplitButton",
-          "Subtitle": "The splitbutton is a dropdown button, but with an addition execution hit target",
+          "Subtitle": "The splitbutton is a dropdown button, but with an addition execution hit target.",
           "ImagePath": "ms-appx:///Assets/SplitButton.png",
-          "Description": "The splitbutton is a dropdown button, but with an addition execution hit target",
+          "Description": "The splitbutton is a dropdown button, but with an addition execution hit target.",
           "Content": "",
           "IsUpdated": true,
           "Docs": [


### PR DESCRIPTION
Added full stop for splitbutton subtitle and description
## Description
Missing full stops 

## Motivation and Context
Consistent grammar

## How Has This Been Tested?
Shouldn't fail, I couldn't build the project for some other reason



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
