### PR TITLE
added full stop for MenuBar description

### DIFF
--- a/XamlControlsGallery/DataModel/ControlInfoData.json
+++ b/XamlControlsGallery/DataModel/ControlInfoData.json
@@ -202,7 +202,7 @@
           "Title": "MenuBar",
           "Subtitle": "A classic menu, allowing the display of MenuItems containing MenuFlyoutItems.",
           "ImagePath": "ms-appx:///Assets/MenuBar.png",
-          "Description": "The Menubar simplifies the creation of basic applications by providing a set of menus at the top of the app or window",
+          "Description": "The Menubar simplifies the creation of basic applications by providing a set of menus at the top of the app or window.",
           "Content": "",
           "IsUpdated": true,
           "Docs": [


### PR DESCRIPTION
There was a missing full stop for the MenuBar description
## Description
Added a fullstop to the ControlInfoData.json file

## Motivation and Context
Consistency with grammar.

## How Has This Been Tested?
Building the project

## Screenshots (if appropriate):
before:
![image](https://user-images.githubusercontent.com/32169182/67994131-a8656c80-fc3b-11e9-87fc-7164771b8eb7.png)
after:
![image](https://user-images.githubusercontent.com/32169182/67994152-c337e100-fc3b-11e9-8fbf-daa10d3c8522.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
