### PR TITLE
344 is a better value since it scales well

### DIFF
--- a/XamlControlsGallery/ItemTemplates.xaml
+++ b/XamlControlsGallery/ItemTemplates.xaml
@@ -8,7 +8,7 @@
         <UserControl>
             <Grid
                 x:Name="controlRoot"
-                Width="345"
+                Width="344"
                 Height="140"
                 Padding="12"
                 Background="{ThemeResource SystemControlBackgroundListLowBrush}">


### PR DESCRIPTION
Just changed the width of the grid for the user control in ItemTemplates.xaml

## Description
345 * 1.25 = 431.25, which is not a whole number, therefore it will round the pixel down. Therefore not true scaling of 125%

## Motivation and Context
To make scaling better

## How Has This Been Tested?
Build and resized the window. It is one pixel different so can't really see it, but mathematically it will work since 344 * 1.25 = 430.

## Screenshots (if appropriate):
Still can fit controls horizontally two in a small window since the width was reduced
![image](https://user-images.githubusercontent.com/32169182/67994581-d9df3780-fc3d-11e9-9669-02484b1ddc37.png)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
