### PR TITLE
added vertical alignments for boarderpage radio buttons

### DIFF
--- a/XamlControlsGallery/ControlPages/BorderPage.xaml
+++ b/XamlControlsGallery/ControlPages/BorderPage.xaml
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
     //*********************************************************
     //
     // Copyright (c) Microsoft. All rights reserved.
@@ -57,21 +57,25 @@
                             <RadioButton
                                 Checked="BGRadioButton_Checked"
                                 Content="Green"
+                                VerticalAlignment="Center" 
                                 GroupName="BGColor" />
 
                             <RadioButton
                                 Checked="BGRadioButton_Checked"
                                 Content="Yellow"
+                                VerticalAlignment="Center" 
                                 GroupName="BGColor" />
 
                             <RadioButton
                                 Checked="BGRadioButton_Checked"
                                 Content="Blue"
+                                VerticalAlignment="Center" 
                                 GroupName="BGColor" />
 
                             <RadioButton
                                 Checked="BGRadioButton_Checked"
                                 Content="White"
+                                VerticalAlignment="Center" 
                                 GroupName="BGColor"
                                 IsChecked="True" />
                         </StackPanel>
@@ -81,22 +85,26 @@
                             <RadioButton
                                 Checked="RadioButton_Checked"
                                 Content="Green"
+                                VerticalAlignment="Center" 
                                 GroupName="BorderBrush" />
 
                             <RadioButton
                                 Checked="RadioButton_Checked"
                                 Content="Yellow"
+                                VerticalAlignment="Center" 
                                 GroupName="BorderBrush"
                                 IsChecked="True" />
 
                             <RadioButton
                                 Checked="RadioButton_Checked"
                                 Content="Blue"
+                                VerticalAlignment="Center" 
                                 GroupName="BorderBrush" />
 
                             <RadioButton
                                 Checked="RadioButton_Checked"
                                 Content="White"
+                                VerticalAlignment="Center" 
                                 GroupName="BorderBrush" />
                         </StackPanel>
                     </Grid>


### PR DESCRIPTION
Alignments can be off due to scaling

## Description
https://github.com/microsoft/microsoft-ui-xaml/issues/1520

## Motivation and Context
Should stop any misalignment with radio buttons on this page


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
