### PR TITLE
Alignments for radiocontrols and checkboxes on NavigationViewPage

### DIFF
--- a/XamlControlsGallery/ControlPages/NavigationViewPage.xaml
+++ b/XamlControlsGallery/ControlPages/NavigationViewPage.xaml
@@ -7,7 +7,7 @@
         xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
         x:Class="AppUIBasics.ControlPages.NavigationViewPage"
         mc:Ignorable="d">
-    
+
     <Page.Resources>
         <converters:MenuItemTemplateSelector x:Key="selector" >
             <converters:MenuItemTemplateSelector.ItemTemplate>
@@ -244,25 +244,25 @@
                               WebViewHeight="250" >
             <local:ControlExample.Options>
                 <StackPanel>
-                    <CheckBox x:Name="settingsCheck" Content="Settings item visible" IsChecked="True" Click="settingsCheck_Click"/>
-                    <CheckBox x:Name="visibleCheck" Content="Back button visible" IsChecked="True" Click="visibleCheck_Click"/>
-                    <CheckBox x:Name="enableCheck" Content="Back button enabled" IsChecked="False" Click="enableCheck_Click"/>
-                    <CheckBox x:Name="autoSuggestCheck" Content="AutoSuggestBox visible" IsChecked="True" Click="autoSuggestCheck_Click"/>
+                    <CheckBox x:Name="settingsCheck" VerticalAlignment="Center" Content="Settings item visible" IsChecked="True" Click="settingsCheck_Click"/>
+                    <CheckBox x:Name="visibleCheck" VerticalAlignment="Center" Content="Back button visible" IsChecked="True" Click="visibleCheck_Click"/>
+                    <CheckBox x:Name="enableCheck" VerticalAlignment="Center" Content="Back button enabled" IsChecked="False" Click="enableCheck_Click"/>
+                    <CheckBox x:Name="autoSuggestCheck" VerticalAlignment="Center" Content="AutoSuggestBox visible" IsChecked="True" Click="autoSuggestCheck_Click"/>
 
                     <TextBlock Text="Header:" Margin="0,12,0,0"/>
                     <TextBox x:Name="headerText" Text="Header" AutomationProperties.Name="Header property"/>
-                    <CheckBox x:Name="headerCheck" Content="Always show header" IsChecked="True" Click="headerCheck_Click"/>
+                    <CheckBox x:Name="headerCheck" VerticalAlignment="Center" Content="Always show header" IsChecked="True" Click="headerCheck_Click"/>
                     <TextBlock Text="PaneTitle:" Margin="0,12,0,0"/>
-                    <TextBox x:Name="paneText" Text="Pane Title" AutomationProperties.Name="PaneTitle property"/>
-                    <CheckBox x:Name="panemc_Check" Content="PaneCustomContent visible" IsChecked="False" Click="panemc_Check_Click"/>
-                    <CheckBox x:Name="paneFooterCheck" Content="PaneFooter visible" IsChecked="False" Click="paneFooterCheck_Click"/>
+                    <TextBox x:Name="paneText" VerticalAlignment="Center" Text="Pane Title" AutomationProperties.Name="PaneTitle property"/>
+                    <CheckBox x:Name="panemc_Check" VerticalAlignment="Center" Content="PaneCustomContent visible" IsChecked="False" Click="panemc_Check_Click"/>
+                    <CheckBox x:Name="paneFooterCheck" VerticalAlignment="Center" Content="PaneFooter visible" IsChecked="False" Click="paneFooterCheck_Click"/>
 
                     <TextBlock Text="PanePosition:" Margin="0,12,0,0"/>
                     <RadioButton Content="Left" IsChecked="True" Checked="panePositionLeft_Checked"/>
-                    <RadioButton Content="Top" Checked="panePositionTop_Checked" Margin="0,0,0,12"/>
+                    <RadioButton Content="Top" VerticalAlignment="Center" Checked="panePositionTop_Checked" Margin="0,0,0,12"/>
 
-                    <CheckBox x:Name="sffCheck" Content="Keyboard SelectionFollowsFocus" IsChecked="False" Click="sffCheck_Click"/>
-                    <CheckBox x:Name="suppressselectionCheck_Checked" Content="Selection of Menu Item2 suppressed" IsChecked="False" Click="suppressselectionCheck_Checked_Click"/>
+                    <CheckBox x:Name="sffCheck" VerticalAlignment="Center" Content="Keyboard SelectionFollowsFocus" IsChecked="False" Click="sffCheck_Click"/>
+                    <CheckBox x:Name="suppressselectionCheck_Checked" VerticalAlignment="Center" Content="Selection of Menu Item2 suppressed" IsChecked="False" Click="suppressselectionCheck_Checked_Click"/>
 
                 </StackPanel>
 

--- a/XamlControlsGallery/ControlPages/NavigationViewPage.xaml
+++ b/XamlControlsGallery/ControlPages/NavigationViewPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page
+<Page
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:local="using:AppUIBasics"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -7,7 +7,7 @@
         xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
         x:Class="AppUIBasics.ControlPages.NavigationViewPage"
         mc:Ignorable="d">
-
+    
     <Page.Resources>
         <converters:MenuItemTemplateSelector x:Key="selector" >
             <converters:MenuItemTemplateSelector.ItemTemplate>
@@ -258,7 +258,7 @@
                     <CheckBox x:Name="paneFooterCheck" VerticalAlignment="Center" Content="PaneFooter visible" IsChecked="False" Click="paneFooterCheck_Click"/>
 
                     <TextBlock Text="PanePosition:" Margin="0,12,0,0"/>
-                    <RadioButton Content="Left" IsChecked="True" Checked="panePositionLeft_Checked"/>
+                    <RadioButton Content="Left" VerticalAlignment="Center" IsChecked="True" Checked="panePositionLeft_Checked"/>
                     <RadioButton Content="Top" VerticalAlignment="Center" Checked="panePositionTop_Checked" Margin="0,0,0,12"/>
 
                     <CheckBox x:Name="sffCheck" VerticalAlignment="Center" Content="Keyboard SelectionFollowsFocus" IsChecked="False" Click="sffCheck_Click"/>


### PR DESCRIPTION
Added alignments for all the Radiocontrols and checkboxes on each page in case they don't align when scaling fails
## Description
Just set the VerticalAlignment property for each to center

## Motivation and Context
To have consistent scaling.
https://github.com/microsoft/microsoft-ui-xaml/issues/1520

## How Has This Been Tested?
Building

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
