### PR TITLE
Fix system caption buttons not updating colors when system theme changes

### DIFF
--- a/XamlControlsGallery/App.xaml.cs
+++ b/XamlControlsGallery/App.xaml.cs
@@ -33,53 +33,7 @@ namespace AppUIBasics
     /// </summary>
     sealed partial class App : Application
     {
-        private const string SelectedAppThemeKey = "SelectedAppTheme";
-
-        /// <summary>
-        /// Gets the current actual theme of the app based on the requested theme of the
-        /// root element, or if that value is Default, the requested theme of the Application.
-        /// </summary>
-        public static ElementTheme ActualTheme
-        {
-            get
-            {
-                if (Window.Current.Content is FrameworkElement rootElement)
-                {
-                    if (rootElement.RequestedTheme != ElementTheme.Default)
-                    {
-                        return rootElement.RequestedTheme;
-                    }
-                }
-
-                return GetEnum<ElementTheme>(Current.RequestedTheme.ToString());
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets (with LocalSettings persistence) the RequestedTheme of the root element.
-        /// </summary>
-        public static ElementTheme RootTheme
-        {
-            get
-            {
-                if (Window.Current.Content is FrameworkElement rootElement)
-                {
-                    return rootElement.RequestedTheme;
-                }
-
-                return ElementTheme.Default;
-            }
-            set
-            {
-                if (Window.Current.Content is FrameworkElement rootElement)
-                {
-                    rootElement.RequestedTheme = value;
-                }
-
-                ApplicationData.Current.LocalSettings.Values[SelectedAppThemeKey] = value.ToString();
-            }
-        }
-
+        
         /// <summary>
         /// Initializes the singleton Application object.  This is the first line of authored code
         /// executed, and as such is the logical equivalent of main() or WinMain().
@@ -174,12 +128,7 @@ namespace AppUIBasics
 
             Frame rootFrame = GetRootFrame();
 
-            string savedTheme = ApplicationData.Current.LocalSettings.Values[SelectedAppThemeKey]?.ToString();
-
-            if (savedTheme != null)
-            {
-                RootTheme = GetEnum<ElementTheme>(savedTheme);
-            }
+            ThemeHelper.Initialize();
 
             Type targetPageType = typeof(NewControlsPage);
             string targetPageArguments = string.Empty;

--- a/XamlControlsGallery/Behaviors/ImageScrollBehavior.cs
+++ b/XamlControlsGallery/Behaviors/ImageScrollBehavior.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Xaml.Interactivity;
+﻿using AppUIBasics.Common;
+using Microsoft.Xaml.Interactivity;
 using System.Linq;
 using Windows.Storage;
 using Windows.UI;
@@ -77,7 +78,7 @@ namespace AppUIBasics.Behaviors
             }
             else
             {
-                if (App.ActualTheme != ElementTheme.Dark)
+                if (ThemeHelper.ActualTheme != ElementTheme.Dark)
                 {
                     VisualStateManager.GoToState(header, "DefaultForeground", false);
                     Color foreground = new Color() { A = _alpha };

--- a/XamlControlsGallery/Common/ThemeHelper.cs
+++ b/XamlControlsGallery/Common/ThemeHelper.cs
@@ -1,4 +1,6 @@
 ﻿using Windows.Storage;
+using Windows.UI;
+using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 
 namespace AppUIBasics.Common
@@ -52,6 +54,7 @@ namespace AppUIBasics.Common
                 }
 
                 ApplicationData.Current.LocalSettings.Values[SelectedAppThemeKey] = value.ToString();
+                UpdateSystemCaptionButtonColors();
             }
         }
 
@@ -73,6 +76,20 @@ namespace AppUIBasics.Common
                 return Application.Current.RequestedTheme == ApplicationTheme.Dark;
             }
             return RootTheme == ElementTheme.Dark;
+        }
+
+        public static void UpdateSystemCaptionButtonColors()
+        {
+            ApplicationViewTitleBar titleBar = ApplicationView.GetForCurrentView().TitleBar;
+
+            if (ThemeHelper.IsDarkTheme())
+            {
+                titleBar.ButtonForegroundColor = Colors.White;
+            }
+            else
+            {
+                titleBar.ButtonForegroundColor = Colors.Black;
+            }
         }
     }
 }

--- a/XamlControlsGallery/Common/ThemeHelper.cs
+++ b/XamlControlsGallery/Common/ThemeHelper.cs
@@ -13,7 +13,8 @@ namespace AppUIBasics.Common
     {
         private const string SelectedAppThemeKey = "SelectedAppTheme";
         private static Window CurrentApplicationWindow;
-
+        // Keep reference so it does not optimized/gc'ed away
+        private static UISettings uiSettings;
         /// <summary>
         /// Gets the current actual theme of the app based on the requested theme of the
         /// root element, or if that value is Default, the requested theme of the Application.
@@ -72,17 +73,17 @@ namespace AppUIBasics.Common
             }
 
             // Registering to color changes, thus we notice when user changes theme system wide
-            UISettings uiSettings = new UISettings();
+            uiSettings = new UISettings();
             uiSettings.ColorValuesChanged += UiSettings_ColorValuesChanged;
         }
 
-        private async static void UiSettings_ColorValuesChanged(UISettings sender, object args)
+        private static void UiSettings_ColorValuesChanged(UISettings sender, object args)
         {
             // Make sure we have a reference to our window so we dispatch a UI change
             if (CurrentApplicationWindow != null)
             {
                 // Dispatch on UI thread so that we have a current appbar to access and change
-                await CurrentApplicationWindow.Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.High, () =>
+                CurrentApplicationWindow.Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.High, () =>
                         {
                             UpdateSystemCaptionButtonColors();
                         });

--- a/XamlControlsGallery/Common/ThemeHelper.cs
+++ b/XamlControlsGallery/Common/ThemeHelper.cs
@@ -1,13 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Windows.Storage;
+﻿using Windows.Storage;
 using Windows.UI.Xaml;
 
 namespace AppUIBasics.Common
 {
+    /// <summary>
+    /// Class providing functionality around switching and restoring theme settings
+    /// </summary>
     public static class ThemeHelper
     {
         private const string SelectedAppThemeKey = "SelectedAppTheme";
@@ -68,5 +66,13 @@ namespace AppUIBasics.Common
             }
         }
 
+        public static bool IsDarkTheme()
+        {
+            if(RootTheme == ElementTheme.Default)
+            {
+                return Application.Current.RequestedTheme == ApplicationTheme.Dark;
+            }
+            return RootTheme == ElementTheme.Dark;
+        }
     }
 }

--- a/XamlControlsGallery/Common/ThemeHelper.cs
+++ b/XamlControlsGallery/Common/ThemeHelper.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Storage;
+using Windows.UI.Xaml;
+
+namespace AppUIBasics.Common
+{
+    public static class ThemeHelper
+    {
+        private const string SelectedAppThemeKey = "SelectedAppTheme";
+
+        /// <summary>
+        /// Gets the current actual theme of the app based on the requested theme of the
+        /// root element, or if that value is Default, the requested theme of the Application.
+        /// </summary>
+        public static ElementTheme ActualTheme
+        {
+            get
+            {
+                if (Window.Current.Content is FrameworkElement rootElement)
+                {
+                    if (rootElement.RequestedTheme != ElementTheme.Default)
+                    {
+                        return rootElement.RequestedTheme;
+                    }
+                }
+
+                return AppUIBasics.App.GetEnum<ElementTheme>(App.Current.RequestedTheme.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets (with LocalSettings persistence) the RequestedTheme of the root element.
+        /// </summary>
+        public static ElementTheme RootTheme
+        {
+            get
+            {
+                if (Window.Current.Content is FrameworkElement rootElement)
+                {
+                    return rootElement.RequestedTheme;
+                }
+
+                return ElementTheme.Default;
+            }
+            set
+            {
+                if (Window.Current.Content is FrameworkElement rootElement)
+                {
+                    rootElement.RequestedTheme = value;
+                }
+
+                ApplicationData.Current.LocalSettings.Values[SelectedAppThemeKey] = value.ToString();
+            }
+        }
+
+        public static void Initialize()
+        {
+
+            string savedTheme = ApplicationData.Current.LocalSettings.Values[SelectedAppThemeKey]?.ToString();
+
+            if (savedTheme != null)
+            {
+                RootTheme = AppUIBasics.App.GetEnum<ElementTheme>(savedTheme);
+            }
+        }
+
+    }
+}

--- a/XamlControlsGallery/ControlExample.xaml.cs
+++ b/XamlControlsGallery/ControlExample.xaml.cs
@@ -7,6 +7,7 @@
 // PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
 //
 //*********************************************************
+using AppUIBasics.Common;
 using ColorCode;
 using ColorCode.Common;
 using System;
@@ -282,9 +283,9 @@ namespace AppUIBasics
 
         private RichTextBlockFormatter GenerateRichTextFormatter()
         {
-            var formatter = new RichTextBlockFormatter(App.ActualTheme);
+            var formatter = new RichTextBlockFormatter(ThemeHelper.ActualTheme);
 
-            if (App.ActualTheme == ElementTheme.Dark)
+            if (ThemeHelper.ActualTheme == ElementTheme.Dark)
             {
                 UpdateFormatterDarkThemeColors(formatter);
             }

--- a/XamlControlsGallery/ControlPages/PullToRefreshPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/PullToRefreshPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using AppUIBasics.Common;
+using System;
 using System.Collections.ObjectModel;
 using Windows.Foundation;
 using Windows.Foundation.Metadata;
@@ -57,7 +58,7 @@ namespace AppUIBasics.ControlPages
                 Image ptrImage = new Image();
                 AccessibilitySettings accessibilitySettings = new AccessibilitySettings();
                 // Checking light theme
-                if ((App.RootTheme == ElementTheme.Light || Application.Current.RequestedTheme == ApplicationTheme.Light) 
+                if ((ThemeHelper.RootTheme == ElementTheme.Light || Application.Current.RequestedTheme == ApplicationTheme.Light) 
                     && !accessibilitySettings.HighContrast)
                 {
                     ptrImage.Source = new BitmapImage(new Uri("ms-appx:///Assets/SunBlack.png"));

--- a/XamlControlsGallery/ItemPage.xaml.cs
+++ b/XamlControlsGallery/ItemPage.xaml.cs
@@ -101,7 +101,7 @@ namespace AppUIBasics
 
         private void OnToggleTheme()
         {
-            var currentElementTheme = ((_currentElementTheme ?? ElementTheme.Default) == ElementTheme.Default) ? App.ActualTheme : _currentElementTheme.Value;
+            var currentElementTheme = ((_currentElementTheme ?? ElementTheme.Default) == ElementTheme.Default) ? ThemeHelper.ActualTheme : _currentElementTheme.Value;
             var newTheme = currentElementTheme == ElementTheme.Dark ? ElementTheme.Light : ElementTheme.Dark;
             SetControlExamplesTheme(newTheme);
         }
@@ -193,7 +193,7 @@ namespace AppUIBasics
 
         protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
         {
-            SetControlExamplesTheme(App.ActualTheme);
+            SetControlExamplesTheme(ThemeHelper.ActualTheme);
 
             base.OnNavigatingFrom(e);
         }

--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
@@ -107,21 +107,8 @@ namespace AppUIBasics
                 titleBar.ButtonInactiveBackgroundColor = Colors.Transparent;
 
                 var currentTheme = ThemeHelper.RootTheme.ToString();
-                bool darkTheme = false;
 
-                switch (currentTheme)
-                {
-                    case "Dark":
-                        darkTheme = true;
-                        break;
-                    case "Default":
-                        if (Application.Current.RequestedTheme == ApplicationTheme.Dark)
-                        {
-                            darkTheme = true;
-                        }
-                        break;
-                }
-                if (darkTheme)
+                if (ThemeHelper.IsDarkTheme())
                 {
                     titleBar.ButtonForegroundColor = Colors.White;
                 }

--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
@@ -106,7 +106,7 @@ namespace AppUIBasics
                 titleBar.ButtonBackgroundColor = Colors.Transparent;
                 titleBar.ButtonInactiveBackgroundColor = Colors.Transparent;
 
-                var currentTheme = App.RootTheme.ToString();
+                var currentTheme = ThemeHelper.RootTheme.ToString();
                 bool darkTheme = false;
 
                 switch (currentTheme)

--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
@@ -106,16 +106,6 @@ namespace AppUIBasics
                 titleBar.ButtonBackgroundColor = Colors.Transparent;
                 titleBar.ButtonInactiveBackgroundColor = Colors.Transparent;
 
-                var currentTheme = ThemeHelper.RootTheme.ToString();
-
-                if (ThemeHelper.IsDarkTheme())
-                {
-                    titleBar.ButtonForegroundColor = Colors.White;
-                }
-                else
-                {
-                    titleBar.ButtonForegroundColor = Colors.Black;
-                }
             };
         }
 

--- a/XamlControlsGallery/SettingsPage.xaml.cs
+++ b/XamlControlsGallery/SettingsPage.xaml.cs
@@ -71,24 +71,13 @@ namespace AppUIBasics
             if (selectedTheme != null)
             {
                 ThemeHelper.RootTheme = App.GetEnum<ElementTheme>(selectedTheme);
-                if (selectedTheme == "Dark")
+                if (ThemeHelper.IsDarkTheme())
                 {
                     titleBar.ButtonForegroundColor = Colors.White;
                 }
-                else if (selectedTheme == "Light")
-                {
-                    titleBar.ButtonForegroundColor = Colors.Black;
-                }
                 else
                 {
-                    if (Application.Current.RequestedTheme == ApplicationTheme.Dark)
-                    {
-                        titleBar.ButtonForegroundColor = Colors.White;
-                    }
-                    else
-                    {
-                        titleBar.ButtonForegroundColor = Colors.Black;
-                    }
+                    titleBar.ButtonForegroundColor = Colors.Black;
                 }
             }
         }

--- a/XamlControlsGallery/SettingsPage.xaml.cs
+++ b/XamlControlsGallery/SettingsPage.xaml.cs
@@ -71,14 +71,6 @@ namespace AppUIBasics
             if (selectedTheme != null)
             {
                 ThemeHelper.RootTheme = App.GetEnum<ElementTheme>(selectedTheme);
-                if (ThemeHelper.IsDarkTheme())
-                {
-                    titleBar.ButtonForegroundColor = Colors.White;
-                }
-                else
-                {
-                    titleBar.ButtonForegroundColor = Colors.Black;
-                }
             }
         }
 

--- a/XamlControlsGallery/SettingsPage.xaml.cs
+++ b/XamlControlsGallery/SettingsPage.xaml.cs
@@ -7,6 +7,7 @@
 // PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
 //
 //*********************************************************
+using AppUIBasics.Common;
 using System;
 using System.Linq;
 using Windows.System;
@@ -58,7 +59,7 @@ namespace AppUIBasics
 
         private void OnSettingsPageLoaded(object sender, RoutedEventArgs e)
         {
-            var currentTheme = App.RootTheme.ToString();
+            var currentTheme = ThemeHelper.RootTheme.ToString();
             (ThemePanel.Children.Cast<RadioButton>().FirstOrDefault(c => c?.Tag?.ToString() == currentTheme)).IsChecked = true;
         }
 
@@ -69,7 +70,7 @@ namespace AppUIBasics
 
             if (selectedTheme != null)
             {
-                App.RootTheme = App.GetEnum<ElementTheme>(selectedTheme);
+                ThemeHelper.RootTheme = App.GetEnum<ElementTheme>(selectedTheme);
                 if (selectedTheme == "Dark")
                 {
                     titleBar.ButtonForegroundColor = Colors.White;

--- a/XamlControlsGallery/XamlControlsGallery.csproj
+++ b/XamlControlsGallery/XamlControlsGallery.csproj
@@ -278,6 +278,7 @@
     <Compile Include="Common\OrientedSize.cs" />
     <Compile Include="Common\RelayCommand.cs" />
     <Compile Include="Common\SuspensionManager.cs" />
+    <Compile Include="Common\ThemeHelper.cs" />
     <Compile Include="Common\UIHelper.cs" />
     <Compile Include="Common\WrapPanel.cs" />
     <Compile Include="ConnectedAnimationPages\CardPage.xaml.cs">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Refactored code related to theme saving and storing into a separate file `ThemeHelper` to make the handling of that easier and make future changes in that area easier. Now themes are stored there and not in the App class.

Also added a listener to system wide color (and thus theme) changes so we can update the system caption buttons when the user updates the theme system wide.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Remove redundant code, improve maintainability slightly. Also fixes #251 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested following scenarios:
- Switch from dark/light to light/dark (in App)
- Switch from use system to dark/light
- Switch from dark/light to use system settings
- Switch system theme while using the option "use system settings"
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x]   Bug fix (non-breaking change which fixes an issue)
- [x]   New feature (non-breaking change which adds functionality)
- [x] ? Breaking change (fix or feature that would cause existing functionality to change)
