### PR TITLE
Fix bug where focus reveal kind sample would not update

### DIFF
--- a/XamlControlsGallery/ControlPages/RevealFocusPage.xaml
+++ b/XamlControlsGallery/ControlPages/RevealFocusPage.xaml
@@ -93,9 +93,12 @@
             </local:ControlExample.Options>
             <local:ControlExample.Xaml>
                 <x:String>
-                    &lt;Application FocusVisualKind="Reveal"/&gt;
+                    &lt;Application FocusVisualKind="$(FocusVisualKind)"/&gt;
                 </x:String>
             </local:ControlExample.Xaml>
+            <local:ControlExample.Substitutions>
+                <local:ControlExampleSubstitution x:Name="FocusVisualKindSubstitution" Key="FocusVisualKind" Value="HighVisibility" IsEnabled="True"/>
+            </local:ControlExample.Substitutions>
         </local:ControlExample>
 
         <TextBlock Margin="0,16,0,0" TextWrapping="WrapWholeWords">

--- a/XamlControlsGallery/ControlPages/RevealFocusPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RevealFocusPage.xaml.cs
@@ -61,6 +61,7 @@ namespace AppUIBasics.ControlPages
             primaryBrushText.Value = "{StaticResource SystemControlFocusVisualPrimaryBrush}";
             primaryColorKeyText.Value = "SystemControlFocusVisualPrimaryBrush";
             Application.Current.FocusVisualKind = FocusVisualKind.HighVisibility;
+            FocusVisualKindSubstitution.Value = "HighVisibility";
         }
 
         // DEMO ONLY: Change focus visual mode to reveal focus
@@ -73,6 +74,7 @@ namespace AppUIBasics.ControlPages
                 primaryBrushText.Value = "{StaticResource SystemControlRevealFocusVisualBrush}";
                 primaryColorKeyText.Value = "SystemControlRevealFocusVisualBrush";
                 Application.Current.FocusVisualKind = FocusVisualKind.Reveal;
+                FocusVisualKindSubstitution.Value = "Reveal";
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added substitution that updates when we change the focus visual kind
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #253
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by starting application and changing the reveal mode.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
