### PR TITLE
Width of code snippet expanded to remove horizontal scrolling

### DIFF
--- a/XamlControlsGallery/ItemPage.xaml
+++ b/XamlControlsGallery/ItemPage.xaml
@@ -51,7 +51,7 @@
                 <VisualState x:Name="NormalFrameContent" />
                 <VisualState x:Name="WideFrameContent">
                     <VisualState.Setters>
-                        <Setter Target="contentFrame.Width" Value="1000" />
+                        <Setter Target="contentFrame.Width" Value="1028" />
                         <Setter Target="contentFrame.HorizontalAlignment" Value="Left" />
                     </VisualState.Setters>
                 </VisualState>


### PR DESCRIPTION
Changed the width of the content frame so that it is wide enough for wide content code snippets

## Description
Scrolling vertically can be interrupted by a horizontal scroll in the code snippet when the users mouse enters the vicinity of the code snippet area. I have changed the width for WideFrameContent ever so slightly so that there is no longer a need to scroll horizontally. At least as tested on the Tab View page. This also removes the difficulty of reading code that barely doesn't fit, and requires the user to scroll horizontally to see the content on the Tab View page, and other pages hopefully as well.

## Motivation and Context
Code snippets can sometimes be a bit to wide to fit on the page, so to see all of it you have to scroll horizontally, I wanted to remove the need for that, so it's easier to read by the user. When vertically scrolling and entering an area which has horizontal scrolling, stops the vertical scroll and starts scrolling horizontally, therefore if someones mouse is in the area of the code snippet whilst vertically scrolling, it will start scrolling horizontally in the code snippet. This removes that, at least when tested on 1080p, which most people use.

## How Has This Been Tested?
Building before and after, this property is set whenever you load a page based on the width of the content.

## Screenshots (if appropriate):
Before
![image](https://user-images.githubusercontent.com/32169182/68672370-5da3f880-0549-11ea-8acf-2e373405b12a.png)

After
![image](https://user-images.githubusercontent.com/32169182/68672419-7e6c4e00-0549-11ea-806c-e6a1cd3b6b0a.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
