### PR TITLE
CommandBarFlyout last button used/state utilising the modification I made to the ControlExample, showing it above now

### DIFF
--- a/XamlControlsGallery/ControlExample.xaml
+++ b/XamlControlsGallery/ControlExample.xaml
@@ -64,6 +64,7 @@
         </Grid.RowDefinitions>
 
         <TextBlock Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,15" Text="{x:Bind HeaderText}" />
+        <TextBlock Margin="0,40" Text="{x:Bind onClickedText}"/>
 
         <RichTextBlock x:Name="ErrorTextBlock" Visibility="Collapsed" Grid.Row="1" Margin="0,0,0,12" Foreground="Red" IsTextSelectionEnabled="True">
             <Paragraph>

--- a/XamlControlsGallery/ControlExample.xaml
+++ b/XamlControlsGallery/ControlExample.xaml
@@ -63,9 +63,9 @@
             <RowDefinition />
         </Grid.RowDefinitions>
 
-        <TextBlock Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,15" Text="{x:Bind HeaderText}" />
-        <TextBlock Margin="0,40" Text="{x:Bind onClickedText, Mode=TwoWay}"/>
-
+        <TextBlock Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,16" Text="{x:Bind HeaderText}" />
+        <TextBlock Margin="0,40,0,4" Text="{x:Bind onClickedText, Mode=TwoWay}"/>
+        
         <RichTextBlock x:Name="ErrorTextBlock" Visibility="Collapsed" Grid.Row="1" Margin="0,0,0,12" Foreground="Red" IsTextSelectionEnabled="True">
             <Paragraph>
                 This sample requires a later version of Windows to be fully functional. Learn more about version adaptive apps:

--- a/XamlControlsGallery/ControlExample.xaml
+++ b/XamlControlsGallery/ControlExample.xaml
@@ -64,7 +64,7 @@
         </Grid.RowDefinitions>
 
         <TextBlock Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,15" Text="{x:Bind HeaderText}" />
-        <TextBlock Margin="0,40" Text="{x:Bind onClickedText}"/>
+        <TextBlock Margin="0,40" Text="{x:Bind onClickedText, Mode=TwoWay}"/>
 
         <RichTextBlock x:Name="ErrorTextBlock" Visibility="Collapsed" Grid.Row="1" Margin="0,0,0,12" Foreground="Red" IsTextSelectionEnabled="True">
             <Paragraph>

--- a/XamlControlsGallery/ControlExample.xaml.cs
+++ b/XamlControlsGallery/ControlExample.xaml.cs
@@ -90,6 +90,13 @@ namespace AppUIBasics
             set { SetValue(HeaderTextProperty, value); }
         }
 
+        public static readonly DependencyProperty onClickedTextProperty = DependencyProperty.Register("onClickedText", typeof(string), typeof(ControlExample), new PropertyMetadata(null));
+        public string onClickedText
+        {
+            get { return (string)GetValue(onClickedTextProperty); }
+            set { SetValue(onClickedTextProperty, value); }
+        }
+
         public static readonly DependencyProperty ExampleProperty = DependencyProperty.Register("Example", typeof(object), typeof(ControlExample), new PropertyMetadata(null));
         public object Example
         {

--- a/XamlControlsGallery/ControlExample.xaml.cs
+++ b/XamlControlsGallery/ControlExample.xaml.cs
@@ -90,7 +90,7 @@ namespace AppUIBasics
             set { SetValue(HeaderTextProperty, value); }
         }
 
-        public static readonly DependencyProperty onClickedTextProperty = DependencyProperty.Register("onClickedText", typeof(string), typeof(ControlExample), new PropertyMetadata(null));
+        public static DependencyProperty onClickedTextProperty = DependencyProperty.Register("onClickedText", typeof(string), typeof(ControlExample), new PropertyMetadata(null));
         public string onClickedText
         {
             get { return (string)GetValue(onClickedTextProperty); }

--- a/XamlControlsGallery/ControlPages/CommandBarFlyoutPage.xaml
+++ b/XamlControlsGallery/ControlPages/CommandBarFlyoutPage.xaml
@@ -28,7 +28,7 @@
                         Click="MyImageButton_Click" ContextRequested="MyImageButton_ContextRequested" >
                     <Image x:Name="Image1" Height="300" Source="/Assets/SampleMedia/rainier.jpg"/>
                 </Button>
-                <TextBlock x:Name="SelectedOptionText" Text="" />
+                <!--<TextBlock x:Name="SelectedOptionText" Text="" />-->
             </StackPanel>
         </local:ControlExample>
     </StackPanel>

--- a/XamlControlsGallery/ControlPages/CommandBarFlyoutPage.xaml
+++ b/XamlControlsGallery/ControlPages/CommandBarFlyoutPage.xaml
@@ -28,7 +28,6 @@
                         Click="MyImageButton_Click" ContextRequested="MyImageButton_ContextRequested" >
                     <Image x:Name="Image1" Height="300" Source="/Assets/SampleMedia/rainier.jpg"/>
                 </Button>
-                <!--<TextBlock x:Name="SelectedOptionText" Text="" />-->
             </StackPanel>
         </local:ControlExample>
     </StackPanel>

--- a/XamlControlsGallery/ControlPages/CommandBarFlyoutPage.xaml
+++ b/XamlControlsGallery/ControlPages/CommandBarFlyoutPage.xaml
@@ -20,7 +20,7 @@
     </Page.Resources>
     
     <StackPanel>
-        <local:ControlExample HeaderText="CommandBarFlyout for commands on an in-app object" XamlSource="CommandBarFlyout/CommandBarFlyoutSample1_xaml.txt"
+        <local:ControlExample x:Name="example" HeaderText="CommandBarFlyout for commands on an in-app object" XamlSource="CommandBarFlyout/CommandBarFlyoutSample1_xaml.txt"
                               CSharpSource="CommandBarFlyout/CommandBarFlyoutSample1_cs.txt">
             <StackPanel>
                 <TextBlock Text="Click or right click the image to open a CommandBarFlyout" />

--- a/XamlControlsGallery/ControlPages/CommandBarFlyoutPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/CommandBarFlyoutPage.xaml.cs
@@ -17,7 +17,7 @@ namespace AppUIBasics.ControlPages
         private void OnElementClicked(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
             // Do custom logic
-            SelectedOptionText.Text = "You clicked: " + (sender as AppBarButton).Label;
+            example.onClickedText = "You clicked: " + (sender as AppBarButton).Label;
         }
 
         private void ShowMenu(bool isTransient)

--- a/XamlControlsGallery/ControlPages/CommandBarFlyoutPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/CommandBarFlyoutPage.xaml.cs
@@ -16,7 +16,6 @@ namespace AppUIBasics.ControlPages
 
         private void OnElementClicked(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
-            // Do custom logic
             example.onClickedText = "You clicked: " + (sender as AppBarButton).Label;
         }
 

--- a/XamlControlsGallery/ControlPages/MenuBarPage.xaml
+++ b/XamlControlsGallery/ControlPages/MenuBarPage.xaml
@@ -15,7 +15,7 @@
             <muxc:MenuBar>
                 <muxc:MenuBarItem Title="File">
                     <MenuFlyoutItem Text="New" Click="OnElementClicked"/>
-                    <MenuFlyoutItem Text="Open..." Click="OnElementClicked"/>
+                    <MenuFlyoutItem Text="Open" Click="OnElementClicked"/>
                     <MenuFlyoutItem Text="Save" Click="OnElementClicked"/>
                     <MenuFlyoutItem Text="Exit" Click="OnElementClicked"/>
                 </muxc:MenuBarItem>

--- a/XamlControlsGallery/ControlPages/MenuBarPage.xaml
+++ b/XamlControlsGallery/ControlPages/MenuBarPage.xaml
@@ -32,6 +32,7 @@
                 </muxc:MenuBarItem>
             </muxc:MenuBar>
         </local:ControlExample>
+        <TextBlock x:Name="SelectedOptionText" Text="" />
 
         <local:ControlExample HeaderText="MenuBar with keyboard accelerators" 
                               XamlSource="Menubar\MenuBarSample3.txt">

--- a/XamlControlsGallery/ControlPages/MenuBarPage.xaml
+++ b/XamlControlsGallery/ControlPages/MenuBarPage.xaml
@@ -93,6 +93,7 @@
 
             </muxc:MenuBar>
         </local:ControlExample>
+        <TextBlock x:Name="SelectedOptionText1" Text="" />
 
         <local:ControlExample HeaderText="MenuBar with submenus, seperators, and radio items"
                               XamlSource="MenuBar\MenuBarSample2.txt">

--- a/XamlControlsGallery/ControlPages/MenuBarPage.xaml
+++ b/XamlControlsGallery/ControlPages/MenuBarPage.xaml
@@ -38,7 +38,7 @@
                               XamlSource="Menubar\MenuBarSample3.txt">
             <muxc:MenuBar>
                 <muxc:MenuBarItem Title="File">
-                    <MenuFlyoutItem Text="New">
+                    <MenuFlyoutItem Text="New" Click="OnElementClicked1">
                         <MenuFlyoutItem.KeyboardAccelerators>
                             <KeyboardAccelerator Modifiers="Control" Key="N"/>
                         </MenuFlyoutItem.KeyboardAccelerators>

--- a/XamlControlsGallery/ControlPages/MenuBarPage.xaml
+++ b/XamlControlsGallery/ControlPages/MenuBarPage.xaml
@@ -35,7 +35,7 @@
         <TextBlock x:Name="SelectedOptionText" Text="" />
 
         <local:ControlExample HeaderText="MenuBar with keyboard accelerators" 
-                              XamlSource="Menubar\MenuBarSample3.txt">
+                              XamlSource="Menubar\MenuBarSample3.txt" onClickedText="">
             <muxc:MenuBar>
                 <muxc:MenuBarItem Title="File">
                     <MenuFlyoutItem Text="New" Click="OnElementClicked1">

--- a/XamlControlsGallery/ControlPages/MenuBarPage.xaml
+++ b/XamlControlsGallery/ControlPages/MenuBarPage.xaml
@@ -94,7 +94,7 @@
             </muxc:MenuBar>
         </local:ControlExample>
         <TextBlock x:Name="SelectedOptionText1" Text="" />
-
+        
         <local:ControlExample HeaderText="MenuBar with submenus, seperators, and radio items"
                               XamlSource="MenuBar\MenuBarSample2.txt">
             <muxc:MenuBar>

--- a/XamlControlsGallery/ControlPages/MenuBarPage.xaml
+++ b/XamlControlsGallery/ControlPages/MenuBarPage.xaml
@@ -104,7 +104,7 @@
                         <MenuFlyoutItem Text="Rich Text Document" Click="OnElementClicked2"/>
                         <MenuFlyoutItem Text="Other Formats..." Click="OnElementClicked2"/>
                     </MenuFlyoutSubItem>
-                    <MenuFlyoutItem Text="Open..." Click="OnElementClicked2"/>
+                    <MenuFlyoutItem Text="Open" Click="OnElementClicked2"/>
                     <MenuFlyoutItem Text="Save" Click="OnElementClicked2"/>
                     <MenuFlyoutSeparator />
                     <MenuFlyoutItem Text="Exit" Click="OnElementClicked2"/>

--- a/XamlControlsGallery/ControlPages/MenuBarPage.xaml
+++ b/XamlControlsGallery/ControlPages/MenuBarPage.xaml
@@ -32,7 +32,6 @@
                 </muxc:MenuBarItem>
             </muxc:MenuBar>
         </local:ControlExample>
-        <TextBlock x:Name="SelectedOptionText" Text="" />
 
         <local:ControlExample x:Name="example1" HeaderText="MenuBar with keyboard accelerators" 
                               XamlSource="Menubar\MenuBarSample3.txt" onClickedText="">
@@ -93,8 +92,7 @@
 
             </muxc:MenuBar>
         </local:ControlExample>
-        <TextBlock x:Name="SelectedOptionText1" Text="" />
-        
+
         <local:ControlExample x:Name="example2" HeaderText="MenuBar with submenus, seperators, and radio items"
                               XamlSource="MenuBar\MenuBarSample2.txt">
             <muxc:MenuBar>
@@ -133,6 +131,5 @@
                 </muxc:MenuBarItem>
             </muxc:MenuBar>
         </local:ControlExample>
-        <TextBlock x:Name="SelectedOptionText2" Text="" />
     </StackPanel>
 </Page>

--- a/XamlControlsGallery/ControlPages/MenuBarPage.xaml
+++ b/XamlControlsGallery/ControlPages/MenuBarPage.xaml
@@ -10,7 +10,7 @@
       xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
       mc:Ignorable="d">
     <StackPanel>
-        <local:ControlExample HeaderText="A simple MenuBar" 
+        <local:ControlExample x:Name="example" HeaderText="A simple MenuBar" 
                               XamlSource="MenuBar\MenuBarSample1.txt">
             <muxc:MenuBar>
                 <muxc:MenuBarItem Title="File">
@@ -34,7 +34,7 @@
         </local:ControlExample>
         <TextBlock x:Name="SelectedOptionText" Text="" />
 
-        <local:ControlExample HeaderText="MenuBar with keyboard accelerators" 
+        <local:ControlExample x:Name="example1" HeaderText="MenuBar with keyboard accelerators" 
                               XamlSource="Menubar\MenuBarSample3.txt" onClickedText="">
             <muxc:MenuBar>
                 <muxc:MenuBarItem Title="File">
@@ -95,7 +95,7 @@
         </local:ControlExample>
         <TextBlock x:Name="SelectedOptionText1" Text="" />
         
-        <local:ControlExample HeaderText="MenuBar with submenus, seperators, and radio items"
+        <local:ControlExample x:Name="example2" HeaderText="MenuBar with submenus, seperators, and radio items"
                               XamlSource="MenuBar\MenuBarSample2.txt">
             <muxc:MenuBar>
                 <muxc:MenuBarItem Title="File">

--- a/XamlControlsGallery/ControlPages/MenuBarPage.xaml
+++ b/XamlControlsGallery/ControlPages/MenuBarPage.xaml
@@ -14,21 +14,21 @@
                               XamlSource="MenuBar\MenuBarSample1.txt">
             <muxc:MenuBar>
                 <muxc:MenuBarItem Title="File">
-                    <MenuFlyoutItem Text="New"/>
-                    <MenuFlyoutItem Text="Open..."/>
-                    <MenuFlyoutItem Text="Save"/>
-                    <MenuFlyoutItem Text="Exit"/>
+                    <MenuFlyoutItem Text="New" Click="OnElementClicked"/>
+                    <MenuFlyoutItem Text="Open..." Click="OnElementClicked"/>
+                    <MenuFlyoutItem Text="Save" Click="OnElementClicked"/>
+                    <MenuFlyoutItem Text="Exit" Click="OnElementClicked"/>
                 </muxc:MenuBarItem>
 
                 <muxc:MenuBarItem Title="Edit">
-                    <MenuFlyoutItem Text="Undo"/>
-                    <MenuFlyoutItem Text="Cut"/>
-                    <MenuFlyoutItem Text="Copy"/>
-                    <MenuFlyoutItem Text="Paste"/>
+                    <MenuFlyoutItem Text="Undo" Click="OnElementClicked"/>
+                    <MenuFlyoutItem Text="Cut" Click="OnElementClicked"/>
+                    <MenuFlyoutItem Text="Copy" Click="OnElementClicked"/>
+                    <MenuFlyoutItem Text="Paste" Click="OnElementClicked"/>
                 </muxc:MenuBarItem>
 
                 <muxc:MenuBarItem Title="Help">
-                    <MenuFlyoutItem Text="About"/>
+                    <MenuFlyoutItem Text="About" Click="OnElementClicked"/>
                 </muxc:MenuBarItem>
             </muxc:MenuBar>
         </local:ControlExample>

--- a/XamlControlsGallery/ControlPages/MenuBarPage.xaml
+++ b/XamlControlsGallery/ControlPages/MenuBarPage.xaml
@@ -100,25 +100,25 @@
             <muxc:MenuBar>
                 <muxc:MenuBarItem Title="File">
                     <MenuFlyoutSubItem Text="New">
-                        <MenuFlyoutItem Text="Plain Text Document"/>
-                        <MenuFlyoutItem Text="Rich Text Document"/>
-                        <MenuFlyoutItem Text="Other Formats..."/>
+                        <MenuFlyoutItem Text="Plain Text Document" Click="OnElementClicked2"/>
+                        <MenuFlyoutItem Text="Rich Text Document" Click="OnElementClicked2"/>
+                        <MenuFlyoutItem Text="Other Formats..." Click="OnElementClicked2"/>
                     </MenuFlyoutSubItem>
-                    <MenuFlyoutItem Text="Open..."/>
-                    <MenuFlyoutItem Text="Save"/>
+                    <MenuFlyoutItem Text="Open..." Click="OnElementClicked2"/>
+                    <MenuFlyoutItem Text="Save" Click="OnElementClicked2"/>
                     <MenuFlyoutSeparator />
-                    <MenuFlyoutItem Text="Exit"/>
+                    <MenuFlyoutItem Text="Exit" Click="OnElementClicked2"/>
                 </muxc:MenuBarItem>
 
                 <muxc:MenuBarItem Title="Edit">
-                    <MenuFlyoutItem Text="Undo"/>
-                    <MenuFlyoutItem Text="Cut"/>
-                    <MenuFlyoutItem Text="Copy"/>
-                    <MenuFlyoutItem Text="Paste"/>
+                    <MenuFlyoutItem Text="Undo" Click="OnElementClicked2"/>
+                    <MenuFlyoutItem Text="Cut" Click="OnElementClicked2"/>
+                    <MenuFlyoutItem Text="Copy" Click="OnElementClicked2"/>
+                    <MenuFlyoutItem Text="Paste" Click="OnElementClicked2"/>
                 </muxc:MenuBarItem>
 
                 <muxc:MenuBarItem Title="View">
-                    <MenuFlyoutItem Text="Output"/>
+                    <MenuFlyoutItem Text="Output" Click="OnElementClicked2"/>
                     <MenuFlyoutSeparator/>
                     <muxc:RadioMenuFlyoutItem Text="Landscape" GroupName="OrientationGroup"/>
                     <muxc:RadioMenuFlyoutItem Text="Portrait" GroupName="OrientationGroup" IsChecked="True"/>
@@ -129,7 +129,7 @@
                 </muxc:MenuBarItem>
 
                 <muxc:MenuBarItem Title="Help">
-                    <MenuFlyoutItem Text="About"/>
+                    <MenuFlyoutItem Text="About" Click="OnElementClicked2"/>
                 </muxc:MenuBarItem>
             </muxc:MenuBar>
         </local:ControlExample>

--- a/XamlControlsGallery/ControlPages/MenuBarPage.xaml
+++ b/XamlControlsGallery/ControlPages/MenuBarPage.xaml
@@ -43,7 +43,7 @@
                             <KeyboardAccelerator Modifiers="Control" Key="N"/>
                         </MenuFlyoutItem.KeyboardAccelerators>
                     </MenuFlyoutItem>
-                    <MenuFlyoutItem Text="Open...">
+                    <MenuFlyoutItem Text="Open">
                         <MenuFlyoutItem.KeyboardAccelerators>
                             <KeyboardAccelerator Modifiers="Control" Key="O"/>
                         </MenuFlyoutItem.KeyboardAccelerators>

--- a/XamlControlsGallery/ControlPages/MenuBarPage.xaml
+++ b/XamlControlsGallery/ControlPages/MenuBarPage.xaml
@@ -102,7 +102,7 @@
                     <MenuFlyoutSubItem Text="New">
                         <MenuFlyoutItem Text="Plain Text Document" Click="OnElementClicked2"/>
                         <MenuFlyoutItem Text="Rich Text Document" Click="OnElementClicked2"/>
-                        <MenuFlyoutItem Text="Other Formats..." Click="OnElementClicked2"/>
+                        <MenuFlyoutItem Text="Other Formats" Click="OnElementClicked2"/>
                     </MenuFlyoutSubItem>
                     <MenuFlyoutItem Text="Open" Click="OnElementClicked2"/>
                     <MenuFlyoutItem Text="Save" Click="OnElementClicked2"/>

--- a/XamlControlsGallery/ControlPages/MenuBarPage.xaml
+++ b/XamlControlsGallery/ControlPages/MenuBarPage.xaml
@@ -43,17 +43,17 @@
                             <KeyboardAccelerator Modifiers="Control" Key="N"/>
                         </MenuFlyoutItem.KeyboardAccelerators>
                     </MenuFlyoutItem>
-                    <MenuFlyoutItem Text="Open">
+                    <MenuFlyoutItem Text="Open" Click="OnElementClicked1">
                         <MenuFlyoutItem.KeyboardAccelerators>
                             <KeyboardAccelerator Modifiers="Control" Key="O"/>
                         </MenuFlyoutItem.KeyboardAccelerators>
                     </MenuFlyoutItem>
-                    <MenuFlyoutItem Text="Save">
+                    <MenuFlyoutItem Text="Save" Click="OnElementClicked1">
                         <MenuFlyoutItem.KeyboardAccelerators>
                             <KeyboardAccelerator Modifiers="Control" Key="S"/>
                         </MenuFlyoutItem.KeyboardAccelerators>
                     </MenuFlyoutItem>
-                    <MenuFlyoutItem Text="Exit">
+                    <MenuFlyoutItem Text="Exit" Click="OnElementClicked1">
                         <MenuFlyoutItem.KeyboardAccelerators>
                             <KeyboardAccelerator Modifiers="Control" Key="E"/>
                         </MenuFlyoutItem.KeyboardAccelerators>
@@ -61,22 +61,22 @@
                 </muxc:MenuBarItem>
 
                 <muxc:MenuBarItem Title="Edit">
-                    <MenuFlyoutItem Text="Undo">
+                    <MenuFlyoutItem Text="Undo" Click="OnElementClicked1">
                         <MenuFlyoutItem.KeyboardAccelerators>
                             <KeyboardAccelerator Modifiers="Control" Key="Z"/>
                         </MenuFlyoutItem.KeyboardAccelerators>
                     </MenuFlyoutItem>
-                    <MenuFlyoutItem Text="Cut">
+                    <MenuFlyoutItem Text="Cut" Click="OnElementClicked1">
                         <MenuFlyoutItem.KeyboardAccelerators>
                             <KeyboardAccelerator Modifiers="Control" Key="X"/>
                         </MenuFlyoutItem.KeyboardAccelerators>
                     </MenuFlyoutItem>
-                    <MenuFlyoutItem Text="Copy">
+                    <MenuFlyoutItem Text="Copy" Click="OnElementClicked1">
                         <MenuFlyoutItem.KeyboardAccelerators>
                             <KeyboardAccelerator Modifiers="Control" Key="C"/>
                         </MenuFlyoutItem.KeyboardAccelerators>
                     </MenuFlyoutItem>
-                    <MenuFlyoutItem Text="Paste">
+                    <MenuFlyoutItem Text="Paste" Click="OnElementClicked1">
                         <MenuFlyoutItem.KeyboardAccelerators>
                             <KeyboardAccelerator Modifiers="Control" Key="V"/>
                         </MenuFlyoutItem.KeyboardAccelerators>
@@ -84,7 +84,7 @@
                 </muxc:MenuBarItem>
 
                 <muxc:MenuBarItem Title="Help">
-                    <MenuFlyoutItem Text="About">
+                    <MenuFlyoutItem Text="About" Click="OnElementClicked1">
                         <MenuFlyoutItem.KeyboardAccelerators>
                             <KeyboardAccelerator Modifiers="Control" Key="I"/>
                         </MenuFlyoutItem.KeyboardAccelerators>
@@ -133,5 +133,6 @@
                 </muxc:MenuBarItem>
             </muxc:MenuBar>
         </local:ControlExample>
+        <TextBlock x:Name="SelectedOptionText2" Text="" />
     </StackPanel>
 </Page>

--- a/XamlControlsGallery/ControlPages/MenuBarPage.xaml
+++ b/XamlControlsGallery/ControlPages/MenuBarPage.xaml
@@ -120,12 +120,12 @@
                 <muxc:MenuBarItem Title="View">
                     <MenuFlyoutItem Text="Output" Click="OnElementClicked2"/>
                     <MenuFlyoutSeparator/>
-                    <muxc:RadioMenuFlyoutItem Text="Landscape" GroupName="OrientationGroup"/>
-                    <muxc:RadioMenuFlyoutItem Text="Portrait" GroupName="OrientationGroup" IsChecked="True"/>
+                    <muxc:RadioMenuFlyoutItem Text="Landscape" GroupName="OrientationGroup" Click="OnElementClicked2"/>
+                    <muxc:RadioMenuFlyoutItem Text="Portrait" GroupName="OrientationGroup" IsChecked="True" Click="OnElementClicked2"/>
                     <MenuFlyoutSeparator/>
-                    <muxc:RadioMenuFlyoutItem Text="Small icons" GroupName="SizeGroup"/>
-                    <muxc:RadioMenuFlyoutItem Text="Medium icons" IsChecked="True" GroupName="SizeGroup"/>
-                    <muxc:RadioMenuFlyoutItem Text="Large icons" GroupName="SizeGroup"/>
+                    <muxc:RadioMenuFlyoutItem Text="Small icons" GroupName="SizeGroup" Click="OnElementClicked2"/>
+                    <muxc:RadioMenuFlyoutItem Text="Medium icons" IsChecked="True" GroupName="SizeGroup" Click="OnElementClicked2"/>
+                    <muxc:RadioMenuFlyoutItem Text="Large icons" GroupName="SizeGroup" Click="OnElementClicked2"/>
                 </muxc:MenuBarItem>
 
                 <muxc:MenuBarItem Title="Help">

--- a/XamlControlsGallery/ControlPages/MenuBarPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/MenuBarPage.xaml.cs
@@ -26,5 +26,11 @@ namespace AppUIBasics.ControlPages
         {
             this.InitializeComponent();
         }
+
+        private void OnElementClicked(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            // Do custom logic
+            SelectedOptionText.Text = "You clicked: " + (sender as MenuFlyoutItem).Text;
+        }
     }
 }

--- a/XamlControlsGallery/ControlPages/MenuBarPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/MenuBarPage.xaml.cs
@@ -32,5 +32,11 @@ namespace AppUIBasics.ControlPages
             // Do custom logic
             SelectedOptionText.Text = "You clicked: " + (sender as MenuFlyoutItem).Text;
         }
+
+        private void OnElementClicked1(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            // Do custom logic
+            SelectedOptionText.Text = "You clicked: " + (sender as MenuFlyoutItem).Text;
+        }
     }
 }

--- a/XamlControlsGallery/ControlPages/MenuBarPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/MenuBarPage.xaml.cs
@@ -37,6 +37,7 @@ namespace AppUIBasics.ControlPages
         {
             // Do custom logic
             SelectedOptionText1.Text = "You clicked: " + (sender as MenuFlyoutItem).Text;
+            onclickedbar
         }
         private void OnElementClicked2(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {

--- a/XamlControlsGallery/ControlPages/MenuBarPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/MenuBarPage.xaml.cs
@@ -29,18 +29,15 @@ namespace AppUIBasics.ControlPages
 
         private void OnElementClicked(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
-            // Do custom logic
             example.onClickedText = "You clicked: " + (sender as MenuFlyoutItem).Text;
         }
 
         private void OnElementClicked1(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
-            // Do custom logic
             example1.onClickedText = "You clicked: " + (sender as MenuFlyoutItem).Text;
         }
         private void OnElementClicked2(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
-            // Do custom logic
             example2.onClickedText = "You clicked: " + (sender as MenuFlyoutItem).Text;
         }
     }

--- a/XamlControlsGallery/ControlPages/MenuBarPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/MenuBarPage.xaml.cs
@@ -38,5 +38,10 @@ namespace AppUIBasics.ControlPages
             // Do custom logic
             SelectedOptionText1.Text = "You clicked: " + (sender as MenuFlyoutItem).Text;
         }
+        private void OnElementClicked2(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            // Do custom logic
+            SelectedOptionText2.Text = "You clicked: " + (sender as MenuFlyoutItem).Text;
+        }
     }
 }

--- a/XamlControlsGallery/ControlPages/MenuBarPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/MenuBarPage.xaml.cs
@@ -36,7 +36,7 @@ namespace AppUIBasics.ControlPages
         private void OnElementClicked1(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
             // Do custom logic
-            SelectedOptionText.Text = "You clicked: " + (sender as MenuFlyoutItem).Text;
+            SelectedOptionText1.Text = "You clicked: " + (sender as MenuFlyoutItem).Text;
         }
     }
 }

--- a/XamlControlsGallery/ControlPages/MenuBarPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/MenuBarPage.xaml.cs
@@ -30,19 +30,18 @@ namespace AppUIBasics.ControlPages
         private void OnElementClicked(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
             // Do custom logic
-            SelectedOptionText.Text = "You clicked: " + (sender as MenuFlyoutItem).Text;
+            example.onClickedText = "You clicked: " + (sender as MenuFlyoutItem).Text;
         }
 
         private void OnElementClicked1(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
             // Do custom logic
-            SelectedOptionText1.Text = "You clicked: " + (sender as MenuFlyoutItem).Text;
-            onclickedbar
+            example1.onClickedText = "You clicked: " + (sender as MenuFlyoutItem).Text;
         }
         private void OnElementClicked2(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
             // Do custom logic
-            SelectedOptionText2.Text = "You clicked: " + (sender as MenuFlyoutItem).Text;
+            example2.onClickedText = "You clicked: " + (sender as MenuFlyoutItem).Text;
         }
     }
 }


### PR DESCRIPTION
https://github.com/microsoft/Xaml-Controls-Gallery/issues/258 brought the issue of the MenuFlyout not having the last Flyout that was chosen shown to the user. As a result I made these changes https://github.com/microsoft/Xaml-Controls-Gallery/pull/263 and modified the ControlExamples XAML and CS, which means I can just set the property for this page as well, separate PR because I'm not sure if this is preferable or not.


## Motivation and Context
Consistency with the MenuFlyout change

## How Has This Been Tested?
Building the project, testing the flyout buttons

## Screenshots (if appropriate):
Before:
![image](https://user-images.githubusercontent.com/32169182/68709037-c82a5800-058c-11ea-8c21-722c36642bd4.png)


After:
![image](https://user-images.githubusercontent.com/32169182/68708968-a7620280-058c-11ea-8d88-7749c018485c.png)

The real motivation behind this PR is to make it consistent with the position of the state change here that I built into the ControlsExample 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
