### PR TITLE
Enable Debug builds to run side-by-side with store version

### DIFF
--- a/UITests/base.cs
+++ b/UITests/base.cs
@@ -25,7 +25,11 @@ namespace UITests
     public class Test_Base
     {
         private const string WindowsApplicationDriverUrl = "http://127.0.0.1:4723";
+#if DEBUG
+        private const string AppUIBasicAppId = "Microsoft.XAMLControlsGallery.Debug_8wekyb3d8bbwe!App";
+#else
         private const string AppUIBasicAppId = "Microsoft.XAMLControlsGallery_8wekyb3d8bbwe!App";
+#endif
         protected static WindowsDriver<WindowsElement> session = null;
 
         public static void Setup(TestContext context)

--- a/XamlControlsGallery/ControlPages/TreeViewPage.xaml
+++ b/XamlControlsGallery/ControlPages/TreeViewPage.xaml
@@ -72,7 +72,7 @@
         <local:ControlExample HeaderText="A TreeView with DataBinding Using ItemSource" XamlSource="TreeView\TreeViewDataBindingSample_xaml.txt">
             <local:ControlExample.Example>
                 <Grid Height="400" BorderBrush="{ThemeResource TextControlBorderBrush}" BorderThickness="1">
-                    <muxc:TreeView Name="TreeView1" 
+                    <muxc:TreeView x:Name="TreeView1" 
                                           MinWidth="345" 
                                           MaxHeight="400" 
                                           Margin="0,12,0,0"
@@ -92,7 +92,7 @@
         <local:ControlExample HeaderText="A TreeView with ItemTemplateSelector" XamlSource="TreeView\TreeViewTemplateSelectorSample_xaml.txt">
             <local:ControlExample.Example>
                 <Grid Height="400" BorderBrush="{ThemeResource TextControlBorderBrush}" BorderThickness="1">
-                    <muxc:TreeView Name="FileTree" Grid.Column="2" MinWidth="345" MaxHeight="400" Margin="0,12,0,0"
+                    <muxc:TreeView x:Name="FileTree" Grid.Column="2" MinWidth="345" MaxHeight="400" Margin="0,12,0,0"
                             HorizontalAlignment="Center" VerticalAlignment="Top" ItemsSource="{x:Bind DataSource}" 
                             ItemTemplateSelector="{StaticResource ExplorerItemTemplateSelector}" />
                 </Grid>

--- a/XamlControlsGallery/Debug.appxmanifest
+++ b/XamlControlsGallery/Debug.appxmanifest
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" IgnorableNamespaces="uap mp uap3">
+  <Identity Name="Microsoft.XAMLControlsGallery.Debug" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="1.2.9.0" />
+  <mp:PhoneIdentity PhoneProductId="1DE51B2F-78B7-4c23-9045-66DD91CDFE62" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
+  <Properties>
+    <DisplayName>XAML Controls Gallery (Debug)</DisplayName>
+    <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
+    <Logo>Assets\Tiles\StoreLogo-sdk.png</Logo>
+  </Properties>
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.14393.0" MaxVersionTested="10.0.17763.0" />
+  </Dependencies>
+  <Resources>
+    <Resource Language="x-generate" />
+  </Resources>
+  <Applications>
+    <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="XamlControlsSample.App">
+      <uap:VisualElements DisplayName="XAML Controls Gallery (Debug)" Square150x150Logo="Assets\Tiles\squaretile-sdk.png" Square44x44Logo="Assets\Tiles\SmallTile-sdk.png" Description="Xaml Controls Gallery (Debug)" BackgroundColor="#00b2f0">
+        <uap:DefaultTile Square310x310Logo="Assets\Tiles\LargeTile.png" Wide310x150Logo="Assets\Tiles\WideTile.png" Square71x71Logo="Assets\Tiles\SmallTile.png">
+          <uap:ShowNameOnTiles>
+            <uap:ShowOn Tile="square150x150Logo" />
+            <uap:ShowOn Tile="wide310x150Logo" />
+            <uap:ShowOn Tile="square310x310Logo" />
+          </uap:ShowNameOnTiles>
+        </uap:DefaultTile>
+        <uap:SplashScreen Image="Assets\Tiles\splash-sdk.png" BackgroundColor="#00b2f0" />
+      </uap:VisualElements>
+      <Extensions>
+        <uap:Extension Category="windows.protocol">
+          <uap:Protocol Name="xamlcontrolsgallery">
+            <uap:DisplayName>XAML Controls Gallery (Debug)</uap:DisplayName>
+          </uap:Protocol>
+        </uap:Extension>
+        <uap3:Extension Category="windows.appUriHandler">
+          <uap3:AppUriHandler>
+            <uap3:Host Name="xamlcontrolsgallery.com" />
+          </uap3:AppUriHandler>
+        </uap3:Extension>
+      </Extensions>
+    </Application>
+  </Applications>
+  <Capabilities>
+    <Capability Name="internetClient" />
+  </Capabilities>
+</Package>

--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml
@@ -59,7 +59,7 @@
                 Height="{Binding ElementName=NavigationViewControl, Path=CompactPaneLength}"
                 Canvas.ZIndex="1">
             <TextBlock x:Name="AppTitle"
-                       Text="XAML Controls Gallery"
+                       Text="{x:Bind GetAppTitleFromSystem()}"
                        VerticalAlignment="Center"
                        Style="{StaticResource CaptionTextBlockStyle}" />
         </Border>

--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
@@ -29,6 +29,7 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 using Windows.Foundation.Metadata;
 using Windows.UI;
+using Windows.Management.Deployment;
 
 namespace AppUIBasics
 {
@@ -114,6 +115,11 @@ namespace AppUIBasics
             //ensure the custom title bar does not overlap window caption controls
             Thickness currMargin = AppTitleBar.Margin;
             AppTitleBar.Margin = new Thickness(currMargin.Left, currMargin.Top, coreTitleBar.SystemOverlayRightInset, currMargin.Bottom);
+        }
+
+        public string GetAppTitleFromSystem()
+        {
+            return Windows.ApplicationModel.Package.Current.DisplayName;
         }
 
         public bool CheckNewControlSelected()

--- a/XamlControlsGallery/XamlControlsGallery.csproj
+++ b/XamlControlsGallery/XamlControlsGallery.csproj
@@ -611,7 +611,10 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <AppxManifest Include="Package.appxmanifest">
+    <AppxManifest Include="Package.appxmanifest" Condition="!('$(Configuration)' == 'Debug')">
+      <SubType>Designer</SubType>
+    </AppxManifest>
+    <AppxManifest Include="Debug.appxmanifest" Condition="'$(Configuration)' == 'Debug'">
       <SubType>Designer</SubType>
     </AppxManifest>
     <Content Include="Assets\AutoSuggestBox.png" />


### PR DESCRIPTION
Fixes #275 

Added Debug.appxmanifest where the app's display name and package name are different ("XAML Controls Gallery (Debug)", and changed the code so that the title is pulled from the package configuration instead of hard-coded in XAML.

Also fixed an error I kept seeing where some TreeView page elements were using Name instead of x:Name and the compiler complained.