### PR TITLE
Fix misspelled page transition DrillInNavigation

### DIFF
--- a/XamlControlsGallery/ControlPages/PageTransitionPage.xaml
+++ b/XamlControlsGallery/ControlPages/PageTransitionPage.xaml
@@ -16,7 +16,7 @@
                 <TextBlock Margin="0,0,0,8">Transition modes</TextBlock>
                 <RadioButton x:Name="DefaultRB" Content="Default" IsChecked="True" Checked="TransitionRadioButton_Checked" AutomationProperties.Name="Default NavigationTransitionInfo"/>
                 <RadioButton x:Name="EntranceRB" Content="Entrance" Checked="TransitionRadioButton_Checked" AutomationProperties.Name="EntranceNavigationTransitionInfo" />
-                <RadioButton x:Name="DrillRB" Content="Drill" Checked="TransitionRadioButton_Checked" AutomationProperties.Name="DrillInNavigationTransitionInfo" />
+                <RadioButton x:Name="DrillRB" Content="DrillIn" Checked="TransitionRadioButton_Checked" AutomationProperties.Name="DrillInNavigationTransitionInfo" />
                 <RadioButton x:Name="SuppressRB" Content="Suppress" Checked="TransitionRadioButton_Checked" AutomationProperties.Name="SuppressNavigationTransitionInfo" />
                 <contract7Present:RadioButton x:Name="SlideFromRightRB" Content="Slide from Right" Checked="TransitionRadioButton_Checked" AutomationProperties.Name="SlideNavigationTransitionInfo From Right" />
                 <contract7Present:RadioButton x:Name="SlideFromLeftRB" Content="Slide from Left" Checked="TransitionRadioButton_Checked" AutomationProperties.Name="SlideNavigationTransitionInfo From Left" />

--- a/XamlControlsGallery/ControlPages/PageTransitionPage.xaml
+++ b/XamlControlsGallery/ControlPages/PageTransitionPage.xaml
@@ -16,7 +16,7 @@
                 <TextBlock Margin="0,0,0,8">Transition modes</TextBlock>
                 <RadioButton x:Name="DefaultRB" Content="Default" IsChecked="True" Checked="TransitionRadioButton_Checked" AutomationProperties.Name="Default NavigationTransitionInfo"/>
                 <RadioButton x:Name="EntranceRB" Content="Entrance" Checked="TransitionRadioButton_Checked" AutomationProperties.Name="EntranceNavigationTransitionInfo" />
-                <RadioButton x:Name="DrillRB" Content="Drill" Checked="TransitionRadioButton_Checked" AutomationProperties.Name="DrillNavigationTransitionInfo" />
+                <RadioButton x:Name="DrillRB" Content="Drill" Checked="TransitionRadioButton_Checked" AutomationProperties.Name="DrillInNavigationTransitionInfo" />
                 <RadioButton x:Name="SuppressRB" Content="Suppress" Checked="TransitionRadioButton_Checked" AutomationProperties.Name="SuppressNavigationTransitionInfo" />
                 <contract7Present:RadioButton x:Name="SlideFromRightRB" Content="Slide from Right" Checked="TransitionRadioButton_Checked" AutomationProperties.Name="SlideNavigationTransitionInfo From Right" />
                 <contract7Present:RadioButton x:Name="SlideFromLeftRB" Content="Slide from Left" Checked="TransitionRadioButton_Checked" AutomationProperties.Name="SlideNavigationTransitionInfo From Left" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The PageTransition "Drill" would result in the C# code sample displaying the "DrillNavigationTransitionInfo" which does not exist. Instead it should be "DrillInNavigationTransitionInfo"
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes sample code issue
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
