### PR TITLE
Fix typo with backbutton visibility in NavigationView sample

### DIFF
--- a/XamlControlsGallery/ControlPagesSampleCode/NavigationView/NavigationViewSample4_xaml.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/NavigationView/NavigationViewSample4_xaml.txt
@@ -1,5 +1,5 @@
 ﻿<muxc:NavigationView x:Name="nvSample" PaneDisplayMode="Top" 
-    SelectionFollowsFocus="Enabled" BackButtonVisibility="Collapsed">
+    SelectionFollowsFocus="Enabled" IsBackButtonVisible="Collapsed">
     <muxc:NavigationView.MenuItems>
         <muxc:NavigationViewItem Icon="Play" Content="Item1" x:Name="SamplePage1Item" />
         <muxc:NavigationViewItem Icon="Save" Content="Item2" x:Name="SamplePage2Item" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed typo "BackButtonVisibility" to "IsBackButtonVisible".

BTW: Why is "IsBackButtonVisible" a Visibility and not a boolean? Seems a bit counter intuitive to me. 😅
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #283 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by starting app and navigating to NavigationView page.
## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/16122379/70341864-2842b000-1854-11ea-9596-261f88b8f4c8.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
