### PR TITLE
Disable AppWindow part of TabView sample on old versions of Win10

### DIFF
--- a/XamlControlsGallery/ControlPages/TabViewPage.xaml
+++ b/XamlControlsGallery/ControlPages/TabViewPage.xaml
@@ -300,7 +300,7 @@
             </local:ControlExample.Xaml>
         </local:ControlExample>
 
-        <local:ControlExample HeaderText="Complete TabView windowing sample">
+        <local:ControlExample HeaderText="Complete TabView windowing sample" MinimumUniversalAPIContract="8">
             <local:ControlExample.Example>
                 <Button Content="Click here to launch the sample" Click="TabViewWindowingButton_Click"/>
             </local:ControlExample.Example>

--- a/XamlControlsGallery/DataModel/ControlInfoData.json
+++ b/XamlControlsGallery/DataModel/ControlInfoData.json
@@ -1515,6 +1515,10 @@
             {
               "Title": "Guidance",
               "Uri": "https://docs.microsoft.com/windows/uwp/design/controls-and-patterns/tab-view"
+            },
+            {
+              "Title": "Show multiple views for an app",
+              "Uri": "https://docs.microsoft.com/windows/uwp/design/layout/show-multiple-views"
             }
           ],
           "RelatedControls": [

--- a/XamlControlsGallery/TabViewPages/TabViewWindowingSamplePage.xaml.cs
+++ b/XamlControlsGallery/TabViewPages/TabViewWindowingSamplePage.xaml.cs
@@ -3,6 +3,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Windows.ApplicationModel.Core;
 using Windows.ApplicationModel.DataTransfer;
+using Windows.Foundation.Metadata;
 using Windows.UI.ViewManagement;
 using Windows.UI.WindowManagement;
 using Windows.UI.Xaml;
@@ -122,6 +123,15 @@ namespace AppUIBasics.TabViewPages
         // Create a new Window once the Tab is dragged outside.
         private async void Tabs_TabDroppedOutside(TabView sender, TabViewTabDroppedOutsideEventArgs args)
         {
+            // AppWindow was introduced in Windows 10 version 18362 (ApiContract version 8). 
+            // If the app is running on a version earlier than 18362, simply no-op.
+            // If your app needs to support multiple windows on earlier versions of Win10, you can use CoreWindow/ApplicationView.
+            // More information about showing multiple views can be found here: https://docs.microsoft.com/windows/uwp/design/layout/show-multiple-views
+            if (!ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
+            {
+                return;
+            }
+
             AppWindow newWindow = await AppWindow.TryCreateAsync();
 
             var newPage = new TabViewWindowingSamplePage();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes #282 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The complete TabView sample includes a complete sample that shows how to make TabView go into the titlebar, rearrange tabs, and pull tabs into their own window. The underlying tech for the last sample is AppWindow, which is only available on 18362+.

This change adds a warning to the sample and disables the TabView tear out behavior. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual testing on a 17763 VM

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25991996/70568614-18291a00-1b4d-11ea-8da8-9e2195b5f8d5.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
