### PR TITLE
Fix bug where cut and paste would not correctly work on SplitButtonPage and RichEditBoxPage

### DIFF
--- a/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
@@ -28,6 +28,8 @@ namespace AppUIBasics.ControlPages
         // String used to restore the colors when the focus gets reenabled
         // See #144 for more info https://github.com/microsoft/Xaml-Controls-Gallery/issues/144
         private string LastFormattedText = "";
+        private int LastRawTextLength = 0;
+
         public RichEditBoxPage()
         {
             this.InitializeComponent();
@@ -157,6 +159,13 @@ namespace AppUIBasics.ControlPages
 
         private void Editor_GotFocus(object sender, RoutedEventArgs e)
         {
+            editor.Document.GetText(TextGetOptions.UseCrlf, out string currentRawText);
+            if (currentRawText.Length != LastRawTextLength)
+            {
+                // User used cut or paste from action command, skip the event
+                return;
+            }
+            
             // reset colors to correct defaults for Focused state
             ITextRange documentRange = editor.Document.GetRange(0, TextConstants.MaxUnitCount);
             SolidColorBrush background = (SolidColorBrush)App.Current.Resources["TextControlBackgroundFocused"];
@@ -189,6 +198,10 @@ namespace AppUIBasics.ControlPages
 
         private void Editor_LosingFocus(object sender, RoutedEventArgs e)
         {
+            // Save text length to determine text length change
+            editor.Document.GetText(TextGetOptions.UseCrlf, out string lastRawText);
+            LastRawTextLength = lastRawText.Length; 
+            
             editor.Document.GetText(TextGetOptions.FormatRtf, out LastFormattedText);
         }
 

--- a/XamlControlsGallery/ControlPages/SplitButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/SplitButtonPage.xaml.cs
@@ -15,6 +15,8 @@ namespace AppUIBasics.ControlPages
         // (which also applies to this RichEditBox)
         private string LastFormattedText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, " +
                 "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Tempor commodo ullamcorper a lacus.";
+        private int LastRawTextLength = 0;
+
         public SplitButtonPage()
         {
             this.InitializeComponent();
@@ -38,7 +40,7 @@ namespace AppUIBasics.ControlPages
             currentColor = color;
         }
 
-        private void RevealColorButton_Click(object sender,RoutedEventArgs e)
+        private void RevealColorButton_Click(object sender, RoutedEventArgs e)
         {
             myColorButtonReveal.Flyout.Hide();
         }
@@ -65,6 +67,12 @@ namespace AppUIBasics.ControlPages
 
         private void MyRichEditBox_GotFocus(object sender, RoutedEventArgs e)
         {
+            myRichEditBox.Document.GetText(TextGetOptions.UseCrlf, out string currentRawText);
+            if (currentRawText.Length != LastRawTextLength)
+            {
+                // User used cut or paste from action command, skip the event
+                return;
+            }
             // reset colors to correct defaults for Focused state
             ITextRange documentRange = myRichEditBox.Document.GetRange(0, TextConstants.MaxUnitCount);
             SolidColorBrush background = (SolidColorBrush)App.Current.Resources["TextControlBackgroundFocused"];
@@ -97,6 +105,11 @@ namespace AppUIBasics.ControlPages
 
         private void MyRichEditBox_LosingFocus(object sender, RoutedEventArgs e)
         {
+            // Save text length to determine text length change
+            myRichEditBox.Document.GetText(TextGetOptions.UseCrlf, out string lastRawText);
+            LastRawTextLength = lastRawText.Length;
+
+            // Save formatted to restore formatting upon regaining focus
             myRichEditBox.Document.GetText(TextGetOptions.FormatRtf, out LastFormattedText);
         }
     }

--- a/XamlControlsGallery/ControlPagesSampleCode/Text/RichEditBox/RichEditBoxSample3_cs.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/Text/RichEditBox/RichEditBoxSample3_cs.txt
@@ -1,5 +1,6 @@
 ﻿private Color currentColor = Colors.Black;
 private string LastFormattedText = "";
+private int LastRawTextLength = 0;
 
 private async void OpenButton_Click(object sender, RoutedEventArgs e)
 {
@@ -114,6 +115,12 @@ private void FindBoxRemoveHighlights()
 
 private void Editor_GotFocus(object sender, RoutedEventArgs e)
 {
+    editor.Document.GetText(TextGetOptions.UseCrlf, out string currentRawText);
+    if (currentRawText.Length != LastRawTextLength)
+    {
+        // User used cut or paste from action command, skip the event
+        return;
+    }
     // reset colors to correct defaults for Focused state
     ITextRange documentRange = editor.Document.GetRange(0, TextConstants.MaxUnitCount);
     SolidColorBrush background = (SolidColorBrush)App.Current.Resources["TextControlBackgroundFocused"];
@@ -145,6 +152,11 @@ private void Editor_GotFocus(object sender, RoutedEventArgs e)
 
 private void Editor_LosingFocus(object sender, RoutedEventArgs e)
 {
+    // Save text length to determine text length change
+    editor.Document.GetText(TextGetOptions.UseCrlf, out string lastRawText);
+    LastRawTextLength = lastRawText.Length; 
+            
+    // Save formatted to restore formatting upon regaining focus
     editor.Document.GetText(TextGetOptions.FormatRtf, out LastFormattedText);
 }
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed bug #286 by detecting when user has changed text upon REB gaining focus, to not interfere with that.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #286 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by reproducing steps in #286:

1. Launch XAML Control Gallery app.
2. Navigate to "SplitButton" or "RichEditBox" in All controls and activate it.
3. In the textbox (or last sample of RichEditBox page), select the text written and right click to invoke the context menu and select "Cut" menu item.
4. Again invoke the context menu and activate "Paste" menu item and observe.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
