### PR TITLE
Should use Share icon for Share button

### DIFF
--- a/XamlControlsGallery/ControlPages/CommandBarPage.xaml
+++ b/XamlControlsGallery/ControlPages/CommandBarPage.xaml
@@ -47,8 +47,8 @@
 
             <CommandBar x:Name="PrimaryCommandBar" IsOpen="False" DefaultLabelPosition="Right">
                 <AppBarButton x:Name="addButton" Icon="Add" Label="Add"/>
-                <AppBarButton x:Name="shareButton" Icon="ReShare" Label="Share"/>
                 <AppBarButton x:Name="editButton" Icon="Edit" Label="Edit"/>
+                <AppBarButton x:Name="shareButton" Icon="Share" Label="Share"/>
                 <CommandBar.SecondaryCommands>
                     <AppBarButton x:Name="settingsButton" Icon="Setting" Label="Settings">
                         <AppBarButton.KeyboardAccelerators>
@@ -73,9 +73,9 @@
             <local:ControlExample.Xaml>
                 <x:String xml:space="preserve">
 &lt;CommandBar Background="Transparent" IsOpen="$(IsOpen)" DefaultLabelPosition="Right"$(IsSticky)&gt;
-    &lt;AppBarButton Icon="Add" Label="Add"/&gt;
-    &lt;AppBarButton Icon="ReShare" Label="Share"/&gt;
+    &lt;AppBarButton Icon="Add" Label="Add"/&gt;    
     &lt;AppBarButton Icon="Edit" Label="Edit"/&gt;
+    &lt;AppBarButton Icon="Share" Label="Share"/&gt;
     &lt;CommandBar.SecondaryCommands&gt;
         &lt;AppBarButton Icon=&quot;Setting&quot; Label=&quot;Settings&quot;&gt;
             &lt;AppBarButton.KeyboardAccelerators&gt;


### PR DESCRIPTION
in CommandBar sample, re-ordered buttons so Share in corner.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Should use the OS icon for Share when we labeled the button 'Share', moved it over too so it's near the menu.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/24302614/70841160-f9d15180-1dcc-11ea-9fe2-b53cb7ef541d.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
