### PR TITLE
Patch - ListView Page: Changed color of message box for visibility

### DIFF
--- a/XamlControlsGallery/ControlPages/ListViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ListViewPage.xaml.cs
@@ -337,7 +337,7 @@ namespace AppUIBasics.ControlPages
             // If sent message, use light gray
             else if (MsgAlignment == HorizontalAlignment.Right)
             {
-                BgColor = (SolidColorBrush)Application.Current.Resources["SystemControlBackgroundChromeMediumBrush"];
+                BgColor = (SolidColorBrush)Application.Current.Resources["SystemControlErrorTextForegroundBrush"];
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The message boxes in the Inverted ListView for Messaging or Data Logging sample were hard to read in both light and dark mode, so I changed the color to make them more distinct and readable. This was done after feedback from @pag3 that his screen made it really difficult to read the text in the message boxes with the current colors and contrast.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally on my machine and different monitors in both light and dark mode.
## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22504341/72175069-0d51e700-3390-11ea-80b6-c4d4059418bd.png)
![image](https://user-images.githubusercontent.com/22504341/72175087-1cd13000-3390-11ea-85aa-25c04c646b61.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
