### PR TITLE
Fixed bug in Issue #327 - GridView Accessibility

### DIFF
--- a/XamlControlsGallery/ControlPages/GridViewPage.xaml
+++ b/XamlControlsGallery/ControlPages/GridViewPage.xaml
@@ -66,7 +66,7 @@
         </DataTemplate>
 
         <DataTemplate x:Key="ImageOverlayTemplate" x:DataType="local1:CustomDataObject">
-            <Grid Width="100">
+            <Grid Width="100" AutomationProperties.Name="{x:Bind Title}">
                 <Image Source="{x:Bind ImageLocation}" Stretch="UniformToFill"/>
                 <StackPanel Orientation="Vertical" Height="40" VerticalAlignment="Bottom" Padding="5,1,5,1" Background="{ThemeResource SystemControlBackgroundBaseMediumBrush}" Opacity=".75">
                     <TextBlock Text="{x:Bind Title}" Foreground="{ThemeResource SystemControlForegroundAltHighBrush}"/>


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed the bug described in issue #327 where GridViewItems don't show up in a screenreader/Accessibility Insights with a descriptive name. 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with AccessibilityInsights for Desktop to make sure that item names were appearing and were descriptive (bound to their Title property).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
