### PR TITLE
Fix app crash when trying to set pencil to rectangle on inktoolbar page

### DIFF
--- a/XamlControlsGallery/ControlPages/InkToolbarPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/InkToolbarPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Windows.UI.Core;
+﻿using System;
+using Windows.UI.Core;
 using Windows.UI.Input.Inking;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -26,9 +27,12 @@ namespace AppUIBasics.ControlPages
             {
                 var defaultAttributes = _inkPresenter.CopyDefaultDrawingAttributes();
 
-                defaultAttributes.PenTip = (bool)penTipShape.IsChecked ? PenTipShape.Circle : PenTipShape.Rectangle;
-
-                _inkPresenter.UpdateDefaultDrawingAttributes(defaultAttributes);
+                // If we are using a pencil, changing pentip is not allowed!
+                if(defaultAttributes.Kind != InkDrawingAttributesKind.Pencil)
+                {
+                    defaultAttributes.PenTip = (bool)penTipShape.IsChecked ? PenTipShape.Circle : PenTipShape.Rectangle;
+                    _inkPresenter.UpdateDefaultDrawingAttributes(defaultAttributes);
+                }
             }
         }
 

--- a/XamlControlsGallery/ControlPages/InkToolbarPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/InkToolbarPage.xaml.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Windows.UI.Core;
+﻿using Windows.UI.Core;
 using Windows.UI.Input.Inking;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;

--- a/XamlControlsGallery/ControlPages/InkToolbarPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/InkToolbarPage.xaml.cs
@@ -27,7 +27,7 @@ namespace AppUIBasics.ControlPages
                 var defaultAttributes = _inkPresenter.CopyDefaultDrawingAttributes();
 
                 // If we are using a pencil, changing pentip is not allowed!
-                if(defaultAttributes.Kind != InkDrawingAttributesKind.Pencil)
+                if(defaultAttributes.Kind == InkDrawingAttributesKind.Default)
                 {
                     defaultAttributes.PenTip = (bool)penTipShape.IsChecked ? PenTipShape.Circle : PenTipShape.Rectangle;
                     _inkPresenter.UpdateDefaultDrawingAttributes(defaultAttributes);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Apparently "Rectangle" is not a valid value for pencil's, thus simply changing the PenTip value, when the user selected pencil through the InkToolBar.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#333
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by reproducing steps in issue.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
