### PR TITLE
Update to use latest WinUI 2.4 pre-release pacakge

### DIFF
--- a/XamlControlsGallery/XamlControlsGallery.csproj
+++ b/XamlControlsGallery/XamlControlsGallery.csproj
@@ -1141,7 +1141,7 @@
       <Version>6.1.9</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
-      <Version>2.4.0-prerelease.200113001</Version>
+      <Version>2.4.0-prerelease.200203002</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed">
       <Version>2.0.0</Version>


### PR DESCRIPTION

## Description
Updating the WinUI package to the latest 2.4 pre-release. Release notes can be found [here](https://github.com/microsoft/microsoft-ui-xaml/releases/tag/v2.4.0-prerelease.200203002).