### PR TITLE
Adds a minimal EditorConfig and resolves a rule violation.

### DIFF
--- a/SharedContent/cs/Default.rd.xml
+++ b/SharedContent/cs/Default.rd.xml
@@ -12,7 +12,7 @@
     <TypeInstantiation Name="App1.AppClass" Arguments="System.Int32" Activate="Required Public" />
 
     Using the Namespace directive to apply reflection policy to all the types in a particular namespace
-    <Namespace Name="DataClasses.ViewModels" Seralize="All" />
+    <Namespace Name="DataClasses.ViewModels" Serialize="All" />
 -->
 
 <Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">

--- a/XamlControlsGallery/.editorconfig
+++ b/XamlControlsGallery/.editorconfig
@@ -10,7 +10,7 @@ indent_style = space
 
 # Code files
 [*.{cs,csx,xaml,xml}]
-charset = utf-8-bom
+charset = utf-8
 indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true

--- a/XamlControlsGallery/.editorconfig
+++ b/XamlControlsGallery/.editorconfig
@@ -1,0 +1,109 @@
+﻿# EditorConfig  https://EditorConfig.org
+# Style as Code Minimal EditorConfig v.2020.02.04.0 https://styleascode.net
+
+# top-most EditorConfig file
+root = true
+
+# Uses spaces for indentation.
+[*]
+indent_style = space
+
+# Code files
+[*.{cs,csx}]
+indent_size = 4
+insert_final_newline = true
+
+# C# files
+[*.cs]
+
+########################
+# Formatting
+########################
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_switch_labels = true
+
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Sort using and Import directives with System.* appearing first
+dotnet_sort_system_directives_first = true
+
+########################
+# Naming
+########################
+
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+dotnet_naming_symbols.static_fields.required_modifiers = static
+
+########################
+# Language Features
+########################
+
+# IDE1005: Delegate invocation can be simplified
+csharp_style_conditional_delegate_call = true:suggestion
+
+# IDE0018: Variable declaration can be inlined
+csharp_style_inlined_variable_declaration = true:suggestion
+
+# IDE0019: Use pattern matching
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+
+# 
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+
+# IDE0016: Null check can be simplified
+csharp_style_throw_expression = true:suggestion
+
+# 
+dotnet_style_coalesce_expression = true:suggestion
+
+# IDE0028: Collection initialization can be simplified
+dotnet_style_collection_initializer = true:suggestion
+
+#
+dotnet_style_explicit_tuple_names = true:suggestion
+
+# 
+dotnet_style_null_propagation = true:suggestion
+
+# IDE0017: Object initialization can be simplified
+dotnet_style_object_initializer = true:suggestion
+
+# IDE0049: Name can be simplified
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion

--- a/XamlControlsGallery/.editorconfig
+++ b/XamlControlsGallery/.editorconfig
@@ -1,17 +1,19 @@
-﻿# EditorConfig  https://EditorConfig.org
-# Style as Code Minimal EditorConfig v.2020.02.04.0 https://styleascode.net
+# EditorConfig  https://EditorConfig.org
+# Style as Code Minimal EditorConfig v.2020.02.06.0 https://styleascode.net
 
 # top-most EditorConfig file
 root = true
 
-# Uses spaces for indentation.
+# Use spaces for indentation.
 [*]
 indent_style = space
 
 # Code files
-[*.{cs,csx}]
+[*.{cs,csx,xaml,xml}]
+charset = utf-8-bom
 indent_size = 4
 insert_final_newline = true
+trim_trailing_whitespace = true
 
 # C# files
 [*.cs]
@@ -67,7 +69,6 @@ dotnet_sort_system_directives_first = true
 # Naming
 ########################
 
-dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 dotnet_naming_symbols.static_fields.required_modifiers = static
 
 ########################

--- a/XamlControlsGallery/Common/ActivityFeedLayout.cs
+++ b/XamlControlsGallery/Common/ActivityFeedLayout.cs
@@ -160,7 +160,7 @@ namespace AppUIBasics.Common
             // created because it isn't until after our MeasureOverride completes that the unused elements 
             // will be recycled and available to use.  We could avoid this by choosing to track the first/last
             // index from the previous layout pass.  The diff between the previous range and current range 
-            // would represent the elements that we can pre-emptively make available for re-use by calling 
+            // would represent the elements that we can preemptively make available for re-use by calling 
             // context.RecycleElement(element).
             for (int rowIndex = firstRowIndex; rowIndex < lastRowIndex; rowIndex++)
             {

--- a/XamlControlsGallery/Common/NavigationHelper.cs
+++ b/XamlControlsGallery/Common/NavigationHelper.cs
@@ -326,7 +326,7 @@ namespace AppUIBasics.Common
                 properties.IsMiddleButtonPressed)
                 return;
 
-            // If back or foward are pressed (but not both) navigate appropriately
+            // If back or forward are pressed (but not both) navigate appropriately
             bool backPressed = properties.IsXButton1Pressed;
             bool forwardPressed = properties.IsXButton2Pressed;
             if (backPressed ^ forwardPressed)

--- a/XamlControlsGallery/Common/RelayCommand.cs
+++ b/XamlControlsGallery/Common/RelayCommand.cs
@@ -40,9 +40,7 @@ namespace AppUIBasics.Common
         /// <param name="canExecute">The execution status logic.</param>
         public RelayCommand(Action execute, Func<bool> canExecute)
         {
-            if (execute == null)
-                throw new ArgumentNullException("execute");
-            _execute = execute;
+            _execute = execute ?? throw new ArgumentNullException("execute");
             _canExecute = canExecute;
         }
 

--- a/XamlControlsGallery/Common/ThemeHelper.cs
+++ b/XamlControlsGallery/Common/ThemeHelper.cs
@@ -13,7 +13,7 @@ namespace AppUIBasics.Common
     {
         private const string SelectedAppThemeKey = "SelectedAppTheme";
         private static Window CurrentApplicationWindow;
-        // Keep reference so it does not optimized/gc'ed away
+        // Keep reference so it does not get optimized/garbage collected
         private static UISettings uiSettings;
         /// <summary>
         /// Gets the current actual theme of the app based on the requested theme of the

--- a/XamlControlsGallery/ControlPages/AcrylicPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AcrylicPage.xaml.cs
@@ -7,9 +7,6 @@ using Windows.UI.Xaml.Shapes;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class AcrylicPage : Page
     {
         public AcrylicPage()

--- a/XamlControlsGallery/ControlPages/AcrylicPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AcrylicPage.xaml.cs
@@ -5,8 +5,6 @@ using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Shapes;
 
-// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/AppBarButtonPage.xaml
+++ b/XamlControlsGallery/ControlPages/AppBarButtonPage.xaml
@@ -104,7 +104,7 @@
                 <x:String xml:space="preserve">
 &lt;AppBarButton Icon="Save" Label="Save" Click="AppBarButton_Click"&gt;
     &lt;AppBarButton.KeyboardAccelerators&gt;
-        &lt;KeybardAccelerator Modifiers="Control" Key="S"/&gt;
+        &lt;KeyboardAccelerator Modifiers="Control" Key="S"/&gt;
     &lt;AppBarButton.KeyboardAccelerators/&gt;
 &lt;/AppBarButton&gt;
                 </x:String>

--- a/XamlControlsGallery/ControlPages/AppBarButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AppBarButtonPage.xaml.cs
@@ -14,9 +14,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class AppBarButtonPage : Page
     {
         AppBarToggleButton compactButton = null;

--- a/XamlControlsGallery/ControlPages/AppBarButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AppBarButtonPage.xaml.cs
@@ -12,8 +12,6 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/AppBarPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AppBarPage.xaml.cs
@@ -14,9 +14,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class AppBarPage : Page
     {
         public AppBarPage()

--- a/XamlControlsGallery/ControlPages/AppBarPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AppBarPage.xaml.cs
@@ -12,8 +12,6 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/AppBarSeparatorPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AppBarSeparatorPage.xaml.cs
@@ -14,9 +14,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class AppBarSeparatorPage : Page
     {
         AppBarToggleButton compactButton = null;

--- a/XamlControlsGallery/ControlPages/AppBarSeparatorPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AppBarSeparatorPage.xaml.cs
@@ -12,8 +12,6 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/AppBarToggleButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AppBarToggleButtonPage.xaml.cs
@@ -14,9 +14,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class AppBarToggleButtonPage : Page
     {
         AppBarToggleButton compactButton = null;

--- a/XamlControlsGallery/ControlPages/AppBarToggleButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AppBarToggleButtonPage.xaml.cs
@@ -12,8 +12,6 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/AutoSuggestBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AutoSuggestBoxPage.xaml.cs
@@ -17,8 +17,6 @@ using AppUIBasics.Data;
 using System.Threading.Tasks;
 using Windows.UI.Xaml.Media.Imaging;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/AutoSuggestBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AutoSuggestBoxPage.xaml.cs
@@ -19,9 +19,6 @@ using Windows.UI.Xaml.Media.Imaging;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class AutoSuggestBoxPage : Page
     {
         public AutoSuggestBoxPage()

--- a/XamlControlsGallery/ControlPages/AutomationPropertiesPage.xaml
+++ b/XamlControlsGallery/ControlPages/AutomationPropertiesPage.xaml
@@ -32,7 +32,7 @@
             </local:ControlExample.Example>
             <local:ControlExample.Xaml>
                 <x:String xml:space="preserve">
-&lt;!-- This image will be anounced as "Image of treetops,Image" --&gt;
+&lt;!-- This image will be announced as "Image of treetops,Image" --&gt;
 &lt;Image Source="/Assets/SampleMedia/treetops.jpg" Height="100" 
        AutomationProperties.Name="Image of treetops"/&gt;
                 </x:String>
@@ -68,7 +68,7 @@
         </local:ControlExample>
         
         <!-- AutomationProperties.AccessibilityView sample-->
-        <local:ControlExample HeaderText="Modifiyng accessibility view of custom templates">
+        <local:ControlExample HeaderText="Modifying accessibility view of custom templates">
             <local:ControlExample.Example>
                 <StackPanel Orientation="Horizontal">
                     <Image Source="/Assets/SampleMedia/treetops.jpg" AutomationProperties.AccessibilityView="Raw" Height="40" VerticalAlignment="Top"/>

--- a/XamlControlsGallery/ControlPages/AutomationPropertiesPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AutomationPropertiesPage.xaml.cs
@@ -30,7 +30,7 @@ namespace AppUIBasics.ControlPages
             }
             else
             {
-                // We fell below minimu, so lets restore a correct value
+                // We fell below minimum, so lets restore a correct value
                 sender.Value = sender.Minimum;
             }
         }

--- a/XamlControlsGallery/ControlPages/BorderPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/BorderPage.xaml.cs
@@ -15,9 +15,6 @@ using Windows.UI.Xaml.Media;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class BorderPage : Page
     {
         public BorderPage()

--- a/XamlControlsGallery/ControlPages/BorderPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/BorderPage.xaml.cs
@@ -13,8 +13,6 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Media;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/ButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ButtonPage.xaml.cs
@@ -12,9 +12,6 @@ using Windows.UI.Xaml.Controls;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class ButtonPage : Page
     {
         public ButtonPage()

--- a/XamlControlsGallery/ControlPages/ButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ButtonPage.xaml.cs
@@ -10,8 +10,6 @@
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/CalendarDatePickerPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/CalendarDatePickerPage.xaml.cs
@@ -1,7 +1,5 @@
 ﻿using Windows.UI.Xaml.Controls;
 
-// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/CalendarDatePickerPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/CalendarDatePickerPage.xaml.cs
@@ -2,9 +2,6 @@
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class CalendarDatePickerPage : Page
     {
         public CalendarDatePickerPage()

--- a/XamlControlsGallery/ControlPages/CalendarViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/CalendarViewPage.xaml.cs
@@ -19,9 +19,6 @@ using AppUIBasics.Common;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class CalendarViewPage : Page
     {
         public CalendarViewPage()

--- a/XamlControlsGallery/ControlPages/CalendarViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/CalendarViewPage.xaml.cs
@@ -17,8 +17,6 @@ using Windows.Globalization;
 using Windows.UI.Popups;
 using AppUIBasics.Common;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/CanvasPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/CanvasPage.xaml.cs
@@ -24,9 +24,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class CanvasPage : Page
     {
         public CanvasPage()

--- a/XamlControlsGallery/ControlPages/CanvasPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/CanvasPage.xaml.cs
@@ -22,8 +22,6 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/CheckBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/CheckBoxPage.xaml.cs
@@ -13,9 +13,6 @@ using Windows.UI.Xaml.Controls;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class CheckBoxPage : Page
     {
         public CheckBoxPage()

--- a/XamlControlsGallery/ControlPages/CheckBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/CheckBoxPage.xaml.cs
@@ -11,8 +11,6 @@ using System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/ColorPickerPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ColorPickerPage.xaml.cs
@@ -1,8 +1,6 @@
 ﻿using System.Linq;
 using Windows.UI.Xaml.Controls;
 
-// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/ColorPickerPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ColorPickerPage.xaml.cs
@@ -3,9 +3,6 @@ using Windows.UI.Xaml.Controls;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class ColorPickerPage : Page
     {
         public ColorPickerPage()

--- a/XamlControlsGallery/ControlPages/ComboBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ComboBoxPage.xaml.cs
@@ -14,8 +14,6 @@ using Windows.UI;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/ComboBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ComboBoxPage.xaml.cs
@@ -16,9 +16,6 @@ using Windows.UI.Xaml.Media;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class ComboBoxPage : Page
     {
         public List<Tuple<string, FontFamily>> Fonts { get; } = new List<Tuple<string, FontFamily>>()

--- a/XamlControlsGallery/ControlPages/CommandBarPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/CommandBarPage.xaml.cs
@@ -14,9 +14,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class CommandBarPage : Page, INotifyPropertyChanged
     {
         private bool multipleButtons = false;

--- a/XamlControlsGallery/ControlPages/CommandBarPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/CommandBarPage.xaml.cs
@@ -12,8 +12,6 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/ContentDialogExample.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ContentDialogExample.xaml.cs
@@ -15,9 +15,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class ContentDialogExample : ContentDialog
     {
         public ContentDialogExample()

--- a/XamlControlsGallery/ControlPages/ContentDialogExample.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ContentDialogExample.xaml.cs
@@ -13,8 +13,6 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/ContentDialogPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ContentDialogPage.xaml.cs
@@ -13,8 +13,6 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/ContentDialogPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ContentDialogPage.xaml.cs
@@ -15,9 +15,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class ContentDialogPage : Page
     {
         public ContentDialogPage()

--- a/XamlControlsGallery/ControlPages/DatePickerPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/DatePickerPage.xaml.cs
@@ -11,8 +11,6 @@ using System;
 using Windows.UI.Xaml.Navigation;
 using Windows.UI.Xaml.Controls;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/DatePickerPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/DatePickerPage.xaml.cs
@@ -13,9 +13,6 @@ using Windows.UI.Xaml.Controls;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class DatePickerPage : Page
     {
         public DatePickerPage()

--- a/XamlControlsGallery/ControlPages/DropDownButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/DropDownButtonPage.xaml.cs
@@ -13,8 +13,6 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/DropDownButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/DropDownButtonPage.xaml.cs
@@ -15,9 +15,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class DropDownButtonPage : Page
     {
         public DropDownButtonPage()

--- a/XamlControlsGallery/ControlPages/EasingFunctionPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/EasingFunctionPage.xaml.cs
@@ -27,9 +27,6 @@ namespace AppUIBasics.ControlPages
         }
     }
 
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class EasingFunctionPage : Page
     {
         private List<NamedEasingFunction> EasingFunctions { get; } = new List<NamedEasingFunction>()

--- a/XamlControlsGallery/ControlPages/EasingFunctionPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/EasingFunctionPage.xaml.cs
@@ -14,8 +14,6 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Animation;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     public class NamedEasingFunction

--- a/XamlControlsGallery/ControlPages/FlipViewPage.xaml
+++ b/XamlControlsGallery/ControlPages/FlipViewPage.xaml
@@ -32,7 +32,7 @@
 &lt;FlipView MaxWidth="400" Height="270"&gt;
     &lt;Image Source="ms-appx:///Assets/SampleMedia/cliff.jpg" AutomationProperties.Name="Cliff"/&gt;
     &lt;Image Source="ms-appx:///Assets/SampleMedia/grapes.jpg" AutomationProperties.Name="Grapes"/&gt;
-    &lt;Image Source="ms-appx:///Assets/SampleMedia/rainer.jpg" AutomationProperties.Name="Rainier"/&gt;
+    &lt;Image Source="ms-appx:///Assets/SampleMedia/rainier.jpg" AutomationProperties.Name="Rainier"/&gt;
     &lt;Image Source="ms-appx:///Assets/SampleMedia/sunset.jpg" AutomationProperties.Name="Sunset"/&gt;
     &lt;Image Source="ms-appx:///Assets/SampleMedia/valley.jpg" AutomationProperties.Name="Valley"/&gt;
 &lt;/FlipView&gt;

--- a/XamlControlsGallery/ControlPages/FlipViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/FlipViewPage.xaml.cs
@@ -16,9 +16,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class FlipViewPage : ItemsPageBase
     {
         public FlipViewPage()

--- a/XamlControlsGallery/ControlPages/FlyoutPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/FlyoutPage.xaml.cs
@@ -12,8 +12,6 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Input;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/FlyoutPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/FlyoutPage.xaml.cs
@@ -14,9 +14,6 @@ using Windows.UI.Xaml.Input;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class FlyoutPage : Page
     {
         public FlyoutPage()

--- a/XamlControlsGallery/ControlPages/GridPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/GridPage.xaml.cs
@@ -24,9 +24,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class GridPage : Page
     {
         public GridPage()

--- a/XamlControlsGallery/ControlPages/GridPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/GridPage.xaml.cs
@@ -22,8 +22,6 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/GridViewPage.xaml
+++ b/XamlControlsGallery/ControlPages/GridViewPage.xaml
@@ -286,7 +286,7 @@ The data template is defined to display a CustomDataObject object (same type as 
     SelectionMode="$(SelectionMode)"
     SelectionChanged="ContentGridView_SelectionChanged"
     ItemClick="ContentGridView_ItemClick" 
-    FlowDirection="$(FlowDirec)"/&gt;
+    FlowDirection="$(FlowDirection)"/&gt;
 
 &lt;!-- ContentGridView_SelectionChanged and ContentGridView_ItemClick are functions defined in the code-behind
 to handle the events of when a selection changes on the GridView and when an item is clicked. --&gt;
@@ -304,7 +304,7 @@ $(DisplayDT)
                 <local:ControlExampleSubstitution Key="CanDropItems" Value="{x:Bind ContentGridView.AllowDrop, Mode=OneWay}" />
                 <local:ControlExampleSubstitution Key="CanReorderItems" Value="{x:Bind ContentGridView.CanReorderItems, Mode=OneWay}" />
                 <local:ControlExampleSubstitution Key="SelectionMode" Value="{x:Bind ContentGridView.SelectionMode, Mode=OneWay}" />
-                <local:ControlExampleSubstitution Key="FlowDirec" Value="{x:Bind ContentGridView.FlowDirection, Mode=OneWay}" />
+                <local:ControlExampleSubstitution Key="FlowDirection" Value="{x:Bind ContentGridView.FlowDirection, Mode=OneWay}" />
                 <local:ControlExampleSubstitution x:Name="DisplayDT" Key="DisplayDT" />
 
             </local:ControlExample.Substitutions>

--- a/XamlControlsGallery/ControlPages/HyperlinkButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/HyperlinkButtonPage.xaml.cs
@@ -12,9 +12,6 @@ using Windows.UI.Xaml.Controls;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class HyperlinkButtonPage : Page
     {
         public HyperlinkButtonPage()

--- a/XamlControlsGallery/ControlPages/HyperlinkButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/HyperlinkButtonPage.xaml.cs
@@ -10,8 +10,6 @@
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/ImagePage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ImagePage.xaml.cs
@@ -14,8 +14,6 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 using Windows.UI.Xaml.Documents;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/ImagePage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ImagePage.xaml.cs
@@ -16,9 +16,6 @@ using Windows.UI.Xaml.Documents;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class ImagePage : Page
     {
         public ImagePage()

--- a/XamlControlsGallery/ControlPages/InkCanvasPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/InkCanvasPage.xaml.cs
@@ -18,9 +18,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class InkCanvasPage : Page
     {
         private InkPresenter _inkPresenter;

--- a/XamlControlsGallery/ControlPages/InkCanvasPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/InkCanvasPage.xaml.cs
@@ -16,8 +16,6 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/ItemsRepeaterPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ItemsRepeaterPage.xaml.cs
@@ -11,9 +11,6 @@ using Windows.UI.Xaml.Controls;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class ItemsRepeaterPage : ItemsPageBase
     {
         private Random random = new Random();

--- a/XamlControlsGallery/ControlPages/ItemsRepeaterPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ItemsRepeaterPage.xaml.cs
@@ -67,7 +67,7 @@ namespace AppUIBasics.ControlPages
                                                             "Sweet potato",
                                                             "Cauliflower",
                                                             "Onion",
-                                                            "Brussel sprouts",
+                                                            "Brussels sprouts",
                                                             "Carrots"
                 }));
 

--- a/XamlControlsGallery/ControlPages/ListBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ListBoxPage.xaml.cs
@@ -14,9 +14,6 @@ using Windows.UI.Xaml.Media;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class ListBoxPage : Page
     {
         private List<Tuple<string, FontFamily>> _fonts = new List<Tuple<string, FontFamily>>()

--- a/XamlControlsGallery/ControlPages/ListBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ListBoxPage.xaml.cs
@@ -12,8 +12,6 @@ using System.Collections.Generic;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/ListViewPage.xaml
+++ b/XamlControlsGallery/ControlPages/ListViewPage.xaml
@@ -120,7 +120,7 @@
                         <Bold>Multiple</Bold> causes checkboxes to appear next to items, so that multiple items can be chosen from the list.
                     </Paragraph>
                     <Paragraph>
-                        <Bold>Extended</Bold> allows the user to select multiple items by using Ctrl+Click to select the indvidual items they want, or Shift+Click to select a range of contiguous items.
+                        <Bold>Extended</Bold> allows the user to select multiple items by using Ctrl+Click to select the individual items they want, or Shift+Click to select a range of contiguous items.
                     </Paragraph>
                 </RichTextBlock>
                 <ListView x:Name="Control2" 
@@ -343,7 +343,7 @@ source code for the XAML Controls Gallery. -->
 &lt;!-- Data template used: --&gt;
 &lt;!-- The data template is bound to a custom DataType called Message. --&gt;
 &lt;!-- Each Message object has a color and alignment assigned to it based on whether it was 
-sent or recieved, and those values are bound in the DataTemplate.--&gt;
+sent or received, and those values are bound in the DataTemplate.--&gt;
 &lt;DataTemplate x:Key="MessageViewTemplate" x:DataType="local1:Message"&gt;
     &lt;Grid Height="Auto" Margin="4" HorizontalAlignment="{x:Bind MsgAlignment}"&gt;
         &lt;StackPanel MinHeight="75" Width="350" Padding="10, 0, 0, 10" Background="{x:Bind BgColor}" CornerRadius="4"&gt;
@@ -358,7 +358,7 @@ sent or recieved, and those values are bound in the DataTemplate.--&gt;
             <local:ControlExample.Options>
                 <StackPanel HorizontalAlignment="Right">
                     <Button Click="{x:Bind AddItemToEnd}" Margin="0 0 0 10">Send Message</Button>
-                    <Button Click="MessageRecieved">Recieve Message</Button>
+                    <Button Click="MessageReceived">Receive Message</Button>
                 </StackPanel>
             </local:ControlExample.Options>
 

--- a/XamlControlsGallery/ControlPages/ListViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ListViewPage.xaml.cs
@@ -51,7 +51,7 @@ namespace AppUIBasics.ControlPages
             DragDropListView.ItemsSource = contacts1;
 
             contacts2.Add(new Contact("John", "Doe", "ABC Printers"));
-            contacts2.Add(new Contact("Jane", "Doe", "XYZ Refridgerators"));
+            contacts2.Add(new Contact("Jane", "Doe", "XYZ Refrigerators"));
             contacts2.Add(new Contact("Santa", "Claus", "North Pole Toy Factory Inc."));
             DragDropListView2.ItemsSource = contacts2;
 
@@ -308,7 +308,7 @@ namespace AppUIBasics.ControlPages
                 );
         }
 
-        private void MessageRecieved(object sender, RoutedEventArgs e)
+        private void MessageReceived(object sender, RoutedEventArgs e)
         {
             InvertedListView.Items.Add(
                 new Message("Message " + ++messageNumber, DateTime.Now, HorizontalAlignment.Left)
@@ -328,7 +328,7 @@ namespace AppUIBasics.ControlPages
             MsgDateTime = dateTime;
             MsgAlignment = align;
 
-            // If recieved message, use accent background
+            // If received message, use accent background
             if (MsgAlignment == HorizontalAlignment.Left)
             {
                 BgColor = (SolidColorBrush)Application.Current.Resources["SystemControlBackgroundAccentBrush"];

--- a/XamlControlsGallery/ControlPages/MediaPlayerElementPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/MediaPlayerElementPage.xaml.cs
@@ -13,8 +13,6 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/MediaPlayerElementPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/MediaPlayerElementPage.xaml.cs
@@ -15,9 +15,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class MediaPlayerElementPage : Page
     {
         public MediaPlayerElementPage()

--- a/XamlControlsGallery/ControlPages/MenuBarPage.xaml
+++ b/XamlControlsGallery/ControlPages/MenuBarPage.xaml
@@ -99,7 +99,7 @@
             </StackPanel>
         </local:ControlExample>
 
-        <local:ControlExample HeaderText="MenuBar with submenus, seperators, and radio items"
+        <local:ControlExample HeaderText="MenuBar with submenus, separators, and radio items"
                               XamlSource="MenuBar\MenuBarSample2.txt">
             <StackPanel>
                 <TextBlock x:Name="SelectedOptionText2" Text="" />

--- a/XamlControlsGallery/ControlPages/MenuBarPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/MenuBarPage.xaml.cs
@@ -13,8 +13,6 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/MenuBarPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/MenuBarPage.xaml.cs
@@ -15,9 +15,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class MenuBarPage : Page
     {
         public MenuBarPage()

--- a/XamlControlsGallery/ControlPages/MenuFlyoutPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/MenuFlyoutPage.xaml.cs
@@ -12,8 +12,6 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Input;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/MenuFlyoutPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/MenuFlyoutPage.xaml.cs
@@ -14,9 +14,6 @@ using Windows.UI.Xaml.Input;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class MenuFlyoutPage : Page
     {
         public MenuFlyoutPage()

--- a/XamlControlsGallery/ControlPages/NavigationViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/NavigationViewPage.xaml.cs
@@ -18,8 +18,6 @@ using Windows.UI.Core;
 using AppUIBasics.Data;
 using Windows.UI.Xaml.Automation;
 
-// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/NavigationViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/NavigationViewPage.xaml.cs
@@ -20,9 +20,6 @@ using Windows.UI.Xaml.Automation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class NavigationViewPage : Page
     {
         public static Boolean CameFromToggle = false;

--- a/XamlControlsGallery/ControlPages/NumberBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/NumberBoxPage.xaml.cs
@@ -6,7 +6,7 @@
 // IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
 // PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
 //
-//*********************************************************C:\Users\saschule\Source\Repos\Xaml-Controls-Gallery\XamlControlsGallery\Assets\InkCanvas.png
+//*********************************************************
 using Microsoft.UI.Xaml.Controls;
 using Windows.Globalization.NumberFormatting;
 using Windows.UI.Xaml;

--- a/XamlControlsGallery/ControlPages/PageTransitionPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/PageTransitionPage.xaml.cs
@@ -14,8 +14,6 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Animation;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     public sealed partial class PageTransitionPage : Page

--- a/XamlControlsGallery/ControlPages/ParallaxViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ParallaxViewPage.xaml.cs
@@ -9,9 +9,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class ParallaxViewPage : ItemsPageBase
     {
         public ParallaxViewPage()

--- a/XamlControlsGallery/ControlPages/PasswordBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/PasswordBoxPage.xaml.cs
@@ -10,8 +10,6 @@
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/PasswordBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/PasswordBoxPage.xaml.cs
@@ -12,9 +12,6 @@ using Windows.UI.Xaml.Controls;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class PasswordBoxPage : Page
     {
         public PasswordBoxPage()

--- a/XamlControlsGallery/ControlPages/PersonPicturePage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/PersonPicturePage.xaml.cs
@@ -2,9 +2,6 @@
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class PersonPicturePage : Page
     {
         public PersonPicturePage()

--- a/XamlControlsGallery/ControlPages/PersonPicturePage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/PersonPicturePage.xaml.cs
@@ -1,7 +1,5 @@
 ﻿using Windows.UI.Xaml.Controls;
 
-// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/PivotPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/PivotPage.xaml.cs
@@ -13,8 +13,6 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/PivotPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/PivotPage.xaml.cs
@@ -15,9 +15,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class PivotPage : Page
     {
         public PivotPage()

--- a/XamlControlsGallery/ControlPages/ProgressBarPage.xaml
+++ b/XamlControlsGallery/ControlPages/ProgressBarPage.xaml
@@ -46,8 +46,8 @@
             <StackPanel x:Name="Control2" Orientation="Horizontal">
                 <muxc:ProgressBar Width="130" x:Name="ProgressBar2" Value="{x:Bind ProgressValue.Value, Mode=OneWay}"/>
                 <TextBlock x:Name="Control2Output" Style="{ThemeResource OutputTextBlockStyle}" Width="60" TextAlignment="Center" />
-                <TextBlock x:Name="ProgresLabel"  Text="Progress" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                <muxc:NumberBox x:Name="ProgressValue" AutomationProperties.LabeledBy="{Binding ElementName=ProgresLabel}" Minimum="0" Maximum="100" SpinButtonPlacementMode="Inline"/>
+                <TextBlock x:Name="ProgressLabel"  Text="Progress" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                <muxc:NumberBox x:Name="ProgressValue" AutomationProperties.LabeledBy="{Binding ElementName=ProgressLabel}" Minimum="0" Maximum="100" SpinButtonPlacementMode="Inline"/>
             </StackPanel>
             <local:ControlExample.Xaml>
                 <x:String>

--- a/XamlControlsGallery/ControlPages/ProgressBarPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ProgressBarPage.xaml.cs
@@ -10,8 +10,6 @@
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/ProgressBarPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ProgressBarPage.xaml.cs
@@ -12,9 +12,6 @@ using Windows.UI.Xaml.Controls;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class ProgressBarPage : Page
     {
         public ProgressBarPage()

--- a/XamlControlsGallery/ControlPages/ProgressRingPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ProgressRingPage.xaml.cs
@@ -22,8 +22,6 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/ProgressRingPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ProgressRingPage.xaml.cs
@@ -24,9 +24,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class ProgressRingPage : Page
     {
         public ProgressRingPage()

--- a/XamlControlsGallery/ControlPages/PullToRefreshPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/PullToRefreshPage.xaml.cs
@@ -13,8 +13,6 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=402352&clcid=0x409
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/PullToRefreshPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/PullToRefreshPage.xaml.cs
@@ -15,9 +15,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class PullToRefreshPage : Page
     {
         private ObservableCollection<string> items1 = new ObservableCollection<string>();

--- a/XamlControlsGallery/ControlPages/RadioButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RadioButtonPage.xaml.cs
@@ -14,9 +14,6 @@ using Windows.UI.Xaml.Media;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class RadioButtonPage : Page
     {
         public RadioButtonPage()

--- a/XamlControlsGallery/ControlPages/RadioButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RadioButtonPage.xaml.cs
@@ -12,8 +12,6 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/RatingsControlPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RatingsControlPage.xaml.cs
@@ -2,9 +2,6 @@
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class RatingControlPage : Page
     {
         public RatingControlPage()

--- a/XamlControlsGallery/ControlPages/RatingsControlPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RatingsControlPage.xaml.cs
@@ -1,7 +1,5 @@
 ﻿using Windows.UI.Xaml.Controls;
 
-// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/RelativePanelPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RelativePanelPage.xaml.cs
@@ -13,8 +13,6 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/RelativePanelPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RelativePanelPage.xaml.cs
@@ -15,9 +15,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class RelativePanelPage : Page
     {
         public RelativePanelPage()

--- a/XamlControlsGallery/ControlPages/RepeatButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RepeatButtonPage.xaml.cs
@@ -12,9 +12,6 @@ using Windows.UI.Xaml.Controls;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class RepeatButtonPage : Page
     {
         public RepeatButtonPage()

--- a/XamlControlsGallery/ControlPages/RepeatButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RepeatButtonPage.xaml.cs
@@ -10,8 +10,6 @@
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/RevealFocusPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RevealFocusPage.xaml.cs
@@ -17,9 +17,6 @@ using Windows.UI.Xaml.Media;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class RevealFocusPage : Page
     {
         public RevealFocusPage()

--- a/XamlControlsGallery/ControlPages/RevealPage.xaml
+++ b/XamlControlsGallery/ControlPages/RevealPage.xaml
@@ -18,7 +18,7 @@
         <local:ControlExample x:Name="Example1" HeaderText="Reveal by default">
             <StackPanel Orientation="Vertical" HorizontalAlignment="Left">
                 <Grid BorderThickness="0,0,0,1" BorderBrush="{ThemeResource ButtonBackground}" Margin="0,10,10,10">
-                    <TextBlock Margin="5" TextWrapping="WrapWholeWords" Text="Reveal is on by default for many of our controls. For those controls, no enabling of Reveal is required. Please see the guidance documention for a full list."/>
+                    <TextBlock Margin="5" TextWrapping="WrapWholeWords" Text="Reveal is on by default for many of our controls. For those controls, no enabling of Reveal is required. Please see the guidance documentation for a full list."/>
                 </Grid>
                 <CommandBar OverflowButtonVisibility="Visible" DefaultLabelPosition="Right" HorizontalAlignment="Left">
                     <AppBarButton Icon="Admin" Label="Admin"/>

--- a/XamlControlsGallery/ControlPages/RevealPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RevealPage.xaml.cs
@@ -2,9 +2,6 @@
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class RevealPage : Page
     {
         public RevealPage()

--- a/XamlControlsGallery/ControlPages/RevealPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RevealPage.xaml.cs
@@ -1,7 +1,5 @@
 ﻿using Windows.UI.Xaml.Controls;
 
-// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/RichTextBlockPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RichTextBlockPage.xaml.cs
@@ -22,8 +22,6 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/RichTextBlockPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RichTextBlockPage.xaml.cs
@@ -24,9 +24,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class RichTextBlockPage : Page
     {
         public RichTextBlockPage()

--- a/XamlControlsGallery/ControlPages/ScrollViewerPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ScrollViewerPage.xaml.cs
@@ -12,8 +12,6 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Input;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/ScrollViewerPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ScrollViewerPage.xaml.cs
@@ -14,9 +14,6 @@ using Windows.UI.Xaml.Input;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class ScrollViewerPage : Page
     {
         public ScrollViewerPage()

--- a/XamlControlsGallery/ControlPages/SemanticZoomPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/SemanticZoomPage.xaml.cs
@@ -13,8 +13,6 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/SemanticZoomPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/SemanticZoomPage.xaml.cs
@@ -15,9 +15,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class SemanticZoomPage : Page
     {
         private IEnumerable<ControlInfoDataGroup> _groups;

--- a/XamlControlsGallery/ControlPages/SliderPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/SliderPage.xaml.cs
@@ -24,9 +24,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class SliderPage : Page
     {
         public SliderPage()

--- a/XamlControlsGallery/ControlPages/SliderPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/SliderPage.xaml.cs
@@ -22,8 +22,6 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/SoundPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/SoundPage.xaml.cs
@@ -13,8 +13,6 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/SoundPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/SoundPage.xaml.cs
@@ -15,9 +15,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class SoundPage : Page
     {
         public SoundPage()

--- a/XamlControlsGallery/ControlPages/SplitButtonPage.xaml
+++ b/XamlControlsGallery/ControlPages/SplitButtonPage.xaml
@@ -12,7 +12,7 @@
     </Page.Resources>
 
     <StackPanel>
-        <local:ControlExample x:Name="Example1" HeaderText="A SplitButton controling text color in a RichEditBox" 
+        <local:ControlExample x:Name="Example1" HeaderText="A SplitButton controlling text color in a RichEditBox" 
                               XamlSource="Buttons\SplitButton\SplitButtonSample1.txt"
                               WebViewHeight="150">
             <Grid x:Name="Control1" ColumnSpacing="24">

--- a/XamlControlsGallery/ControlPages/SplitButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/SplitButtonPage.xaml.cs
@@ -55,7 +55,7 @@ namespace AppUIBasics.ControlPages
 
         private void MyRichEditBox_TextChanging(object sender, RichEditBoxTextChangingEventArgs e)
         {
-            // Hitting control+b and similiar commands my overwrite the color,
+            // Hitting control+b and similar commands my overwrite the color,
             // which result to black text on black background when losing focus on dark theme.
             // Solution: check if text actually changed
             if (e.IsContentChanging)

--- a/XamlControlsGallery/ControlPages/SplitViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/SplitViewPage.xaml.cs
@@ -18,9 +18,6 @@ using Windows.UI;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class SplitViewPage : Page
     {
         private ObservableCollection<NavLink> _navLinks =  new ObservableCollection<NavLink>()

--- a/XamlControlsGallery/ControlPages/SplitViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/SplitViewPage.xaml.cs
@@ -16,8 +16,6 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 using Windows.UI;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/TabViewPage.xaml
+++ b/XamlControlsGallery/ControlPages/TabViewPage.xaml
@@ -223,7 +223,7 @@
                                     <muxc:BitmapIconSource UriSource="/Assets/TabViewIcons/cmd.png" ShowAsMonochrome="False" />
                                 </muxc:TabViewItem.IconSource>
                             </muxc:TabViewItem>
-                            <muxc:TabViewItem Header="Powershell" IsClosable="False">
+                            <muxc:TabViewItem Header="PowerShell" IsClosable="False">
                                 <muxc:TabViewItem.IconSource>
                                     <muxc:BitmapIconSource UriSource="/Assets/TabViewIcons/powershell.png" ShowAsMonochrome="False" />
                                 </muxc:TabViewItem.IconSource>
@@ -247,7 +247,7 @@
                 &lt;muxc:BitmapIconSource UriSource="/Assets/TabViewIcons/cmd.png" ShowAsMonochrome="False" /&gt;
             &lt;/muxc:TabViewItem.IconSource&gt;
         &lt;/muxc:TabViewItem&gt;
-        &lt;muxc:TabViewItem Header="Powershell"&gt;
+        &lt;muxc:TabViewItem Header="PowerShell"&gt;
             &lt;muxc:TabViewItem.IconSource&gt;
                 &lt;muxc:BitmapIconSource UriSource="/Assets/TabViewIcons/powershell.png" ShowAsMonochrome="False" /&gt;
             &lt;/muxc:TabViewItem.IconSource&gt;

--- a/XamlControlsGallery/ControlPages/TeachingTipPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/TeachingTipPage.xaml.cs
@@ -11,8 +11,6 @@ using Microsoft.UI.Xaml.Controls;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     public sealed partial class TeachingTipPage : Page

--- a/XamlControlsGallery/ControlPages/TextBlockPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/TextBlockPage.xaml.cs
@@ -24,9 +24,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class TextBlockPage : Page
     {
         public TextBlockPage()

--- a/XamlControlsGallery/ControlPages/TextBlockPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/TextBlockPage.xaml.cs
@@ -22,8 +22,6 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/TextBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/TextBoxPage.xaml.cs
@@ -24,9 +24,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class TextBoxPage : Page
     {
         public TextBoxPage()

--- a/XamlControlsGallery/ControlPages/TextBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/TextBoxPage.xaml.cs
@@ -22,8 +22,6 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/ThemeTransitionPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ThemeTransitionPage.xaml.cs
@@ -13,8 +13,6 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/ThemeTransitionPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ThemeTransitionPage.xaml.cs
@@ -15,9 +15,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class ThemeTransitionPage : Page
     {
 

--- a/XamlControlsGallery/ControlPages/TimePickerPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/TimePickerPage.xaml.cs
@@ -22,8 +22,6 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/TimePickerPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/TimePickerPage.xaml.cs
@@ -24,9 +24,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class TimePickerPage : Page
     {
         public TimePickerPage()

--- a/XamlControlsGallery/ControlPages/ToggleButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ToggleButtonPage.xaml.cs
@@ -12,9 +12,6 @@ using Windows.UI.Xaml.Controls;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class ToggleButtonPage : Page
     {
         public ToggleButtonPage()

--- a/XamlControlsGallery/ControlPages/ToggleButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ToggleButtonPage.xaml.cs
@@ -18,7 +18,7 @@ namespace AppUIBasics.ControlPages
         {
             this.InitializeComponent();
 
-            // Set initial outpput value.
+            // Set initial output value.
             Control1Output.Text = (bool)Toggle1.IsChecked ? "On" : "Off";
             ControlRevealOutput.Text = (bool)ToggleReveal.IsChecked ? "On" : "Off";
         }

--- a/XamlControlsGallery/ControlPages/ToggleButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ToggleButtonPage.xaml.cs
@@ -10,8 +10,6 @@
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/ToggleSwitchPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ToggleSwitchPage.xaml.cs
@@ -22,8 +22,6 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/ToggleSwitchPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ToggleSwitchPage.xaml.cs
@@ -24,9 +24,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class ToggleSwitchPage : Page
     {
         public ToggleSwitchPage()

--- a/XamlControlsGallery/ControlPages/ToolTipPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ToolTipPage.xaml.cs
@@ -24,9 +24,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class ToolTipPage : Page
     {
         public ToolTipPage()

--- a/XamlControlsGallery/ControlPages/ToolTipPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ToolTipPage.xaml.cs
@@ -22,8 +22,6 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/TreeViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/TreeViewPage.xaml.cs
@@ -5,9 +5,6 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using mux = Microsoft.UI.Xaml.Controls;
 
-
-// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/TreeViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/TreeViewPage.xaml.cs
@@ -7,9 +7,6 @@ using mux = Microsoft.UI.Xaml.Controls;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class TreeViewPage : Page
     {
         mux.TreeViewNode personalFolder;

--- a/XamlControlsGallery/ControlPages/VariableSizedWrapGridPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/VariableSizedWrapGridPage.xaml.cs
@@ -10,8 +10,6 @@
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/VariableSizedWrapGridPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/VariableSizedWrapGridPage.xaml.cs
@@ -12,9 +12,6 @@ using Windows.UI.Xaml.Controls;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class VariableSizedWrapGridPage : Page
     {
         public VariableSizedWrapGridPage()

--- a/XamlControlsGallery/ControlPages/ViewBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ViewBoxPage.xaml.cs
@@ -11,8 +11,6 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
     /// <summary>

--- a/XamlControlsGallery/ControlPages/ViewBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ViewBoxPage.xaml.cs
@@ -13,9 +13,6 @@ using Windows.UI.Xaml.Media;
 
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class ViewBoxPage : Page
     {
         public ViewBoxPage()

--- a/XamlControlsGallery/ControlPages/WebViewPage.xaml
+++ b/XamlControlsGallery/ControlPages/WebViewPage.xaml
@@ -16,7 +16,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d">
 
-    <!-- URL's on this page have a en-us as localization since having them not have a fixed locale results in the page having the language used by the user, 
+    <!-- URLs on this page have a en-us as localization since having them not have a fixed locale results in the page having the language used by the user, 
         which may be a different language than the app is using. This was quite confusing to see and was not intuitive.-->
     <local:ControlExample HeaderText="A simple WebView " HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
         <local:ControlExample.Example>

--- a/XamlControlsGallery/SamplePages/SamplePage3.xaml.cs
+++ b/XamlControlsGallery/SamplePages/SamplePage3.xaml.cs
@@ -13,8 +13,6 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.SamplePages
 {
     /// <summary>

--- a/XamlControlsGallery/SamplePages/SamplePage3.xaml.cs
+++ b/XamlControlsGallery/SamplePages/SamplePage3.xaml.cs
@@ -15,9 +15,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.SamplePages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class SamplePage3 : Page
     {
         public SamplePage3()

--- a/XamlControlsGallery/SamplePages/SamplePage4.xaml.cs
+++ b/XamlControlsGallery/SamplePages/SamplePage4.xaml.cs
@@ -13,8 +13,6 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.SamplePages
 {
     /// <summary>

--- a/XamlControlsGallery/SamplePages/SamplePage4.xaml.cs
+++ b/XamlControlsGallery/SamplePages/SamplePage4.xaml.cs
@@ -15,9 +15,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.SamplePages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class SamplePage4 : Page
     {
         public SamplePage4()

--- a/XamlControlsGallery/SamplePages/SampleSettingsPage.xaml.cs
+++ b/XamlControlsGallery/SamplePages/SampleSettingsPage.xaml.cs
@@ -13,8 +13,6 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.SamplePages
 {
     /// <summary>

--- a/XamlControlsGallery/SamplePages/SampleSettingsPage.xaml.cs
+++ b/XamlControlsGallery/SamplePages/SampleSettingsPage.xaml.cs
@@ -15,9 +15,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.SamplePages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class SampleSettingsPage : Page
     {
         public SampleSettingsPage()

--- a/XamlControlsGallery/SamplePages/SampleStandardSizingPage.xaml.cs
+++ b/XamlControlsGallery/SamplePages/SampleStandardSizingPage.xaml.cs
@@ -13,8 +13,6 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.SamplePages
 {
     /// <summary>

--- a/XamlControlsGallery/SamplePages/SampleStandardSizingPage.xaml.cs
+++ b/XamlControlsGallery/SamplePages/SampleStandardSizingPage.xaml.cs
@@ -15,9 +15,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace AppUIBasics.SamplePages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class SampleStandardSizingPage : Page
     {
         public SampleStandardSizingPage()

--- a/XamlControlsGallery/TabViewPages/TabViewWindowingSamplePage.xaml.cs
+++ b/XamlControlsGallery/TabViewPages/TabViewWindowingSamplePage.xaml.cs
@@ -179,7 +179,7 @@ namespace AppUIBasics.TabViewPages
                     // First we need to get the position in the List to drop to
                     var index = -1;
 
-                    // Determine which items in the list our pointer is inbetween.
+                    // Determine which items in the list our pointer is between.
                     for (int i = 0; i < destinationTabView.TabItems.Count; i++)
                     {
                         var item = destinationTabView.ContainerFromIndex(i) as TabViewItem;

--- a/XamlControlsGallery/XamlControlsGallery.csproj
+++ b/XamlControlsGallery/XamlControlsGallery.csproj
@@ -1151,6 +1151,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include=".editorconfig" />
     <None Include="XamlControlsGallery_TemporaryKey.pfx" />
   </ItemGroup>
   <ItemGroup />

--- a/XamlControlsGallery/XamlControlsGallery.sln
+++ b/XamlControlsGallery/XamlControlsGallery.sln
@@ -1,9 +1,14 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2027
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29728.190
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XamlControlsGallery", "XamlControlsGallery.csproj", "{3F68773A-31A5-59FE-926C-0569E415C9D9}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{541693E7-E756-46D0-BE74-5307EDFF025E}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
Adds a minimal EditorConfig file to the repo and resolves a rule violation. 

## Description
Adds the minimal EditorConfig file defined [here](https://github.com/kmgallahan/Style-as-Code/blob/master/editorconfig/.editorconfig_minimal).

Resolves 1 violation of rule IDE0016 where the recommendation is to:

Use throw expressions to simplify null checks when possible.

See the rationale for this rule here:

https://styleascode.net/ID/IDE0016

## Motivation and Context
This is the first step in taking action on #331.

See [this comment](https://github.com/microsoft/Xaml-Controls-Gallery/issues/331#issuecomment-582246759) for additional information and feedback.

For [added clarity](https://github.com/microsoft/Xaml-Controls-Gallery/issues/331#issuecomment-582528848), the plan would be to:

1. Submit the minimal EditorConfig
2. Agree on starting point and resolve some violations
3. Move to non-minimal EditorConfig (very few differences for now)
4. Begin adding additional rules 1-2 at a time with proper justification (minimal config is no longer touched at this point)

## How Has This Been Tested?
UI tests not run.

## Types of changes
- [X] Code style