### PR TITLE
Fix crash with NumberBox value being NaN

### DIFF
--- a/XamlControlsGallery/ControlPages/ProgressBarPage.xaml
+++ b/XamlControlsGallery/ControlPages/ProgressBarPage.xaml
@@ -44,10 +44,10 @@
 
         <local:ControlExample HeaderText="A determinate progress bar.">
             <StackPanel x:Name="Control2" Orientation="Horizontal">
-                <muxc:ProgressBar Width="130" x:Name="ProgressBar2" Value="{x:Bind ProgressValue.Value, Mode=OneWay}"/>
+                <muxc:ProgressBar Width="130" x:Name="ProgressBar2"/>
                 <TextBlock x:Name="Control2Output" Style="{ThemeResource OutputTextBlockStyle}" Width="60" TextAlignment="Center" />
                 <TextBlock x:Name="ProgresLabel"  Text="Progress" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                <muxc:NumberBox x:Name="ProgressValue" AutomationProperties.LabeledBy="{Binding ElementName=ProgresLabel}" Minimum="0" Maximum="100" SpinButtonPlacementMode="Inline"/>
+                <muxc:NumberBox x:Name="ProgressValue" AutomationProperties.LabeledBy="{Binding ElementName=ProgresLabel}" Minimum="0" Maximum="100" SpinButtonPlacementMode="Inline" ValueChanged="ProgressValue_ValueChanged"/>
             </StackPanel>
             <local:ControlExample.Xaml>
                 <x:String>

--- a/XamlControlsGallery/ControlPages/ProgressBarPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ProgressBarPage.xaml.cs
@@ -24,14 +24,17 @@ namespace AppUIBasics.ControlPages
             this.InitializeComponent();
         }
 
-        private int _clicks = 0;
-        private void RepeatButton_Click(object sender, RoutedEventArgs e)
+        private void ProgressValue_ValueChanged(Microsoft.UI.Xaml.Controls.NumberBox sender, Microsoft.UI.Xaml.Controls.NumberBoxValueChangedEventArgs args)
         {
-            _clicks += 1;
-            Control2Output.Text = _clicks.ToString();
-            ProgressBar2.Value = _clicks;
-
-            if (_clicks >= 100) _clicks = 0;
+            // Value might be NaN, which is not valid as value, thus we need to handle changes ourselves
+            if (!sender.Value.IsNaN())
+            {
+                ProgressBar2.Value = sender.Value;
+            }
+            else
+            {
+                sender.Value = 0;
+            }
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add manual handling of NumberBox value change, instead of using binding. It seems like the ProgressBar page is the only page where we are using a binding,

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #353 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by reproducing steps in issue:
1. Launch XAML Controls Gallery.
2. Activate ProgressBar from All Controls Page.
3. Click on text box present under header A determinate Progress bar, clear the value of text box and then either press context menu key or right click with mouse and observe.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
