### PR TITLE
Increase ComboBox width to account for text scaling

### DIFF
--- a/XamlControlsGallery/ControlPages/ComboBoxPage.xaml
+++ b/XamlControlsGallery/ControlPages/ComboBoxPage.xaml
@@ -44,7 +44,7 @@
             <local:ControlExample.Example>
                 <StackPanel>
                     <ComboBox x:Name="Combo2" ItemsSource="{x:Bind Fonts}" DisplayMemberPath="Item1"
-                            SelectedValuePath="Item2" Header="Font" Width="300" Loaded="Combo2_Loaded" />
+                            SelectedValuePath="Item2" Header="Font" MinWidth="200" Loaded="Combo2_Loaded" />
                     <TextBlock x:Name="Control2Output" Text="You can set the font used for this text."
                             FontFamily="{x:Bind (FontFamily)Combo2.SelectedValue, Mode=OneWay}"
                             Style="{StaticResource OutputTextBlockStyle}" />

--- a/XamlControlsGallery/ControlPages/ComboBoxPage.xaml
+++ b/XamlControlsGallery/ControlPages/ComboBoxPage.xaml
@@ -44,7 +44,7 @@
             <local:ControlExample.Example>
                 <StackPanel>
                     <ComboBox x:Name="Combo2" ItemsSource="{x:Bind Fonts}" DisplayMemberPath="Item1"
-                            SelectedValuePath="Item2" Header="Font" Width="200" Loaded="Combo2_Loaded" />
+                            SelectedValuePath="Item2" Header="Font" Width="300" Loaded="Combo2_Loaded" />
                     <TextBlock x:Name="Control2Output" Text="You can set the font used for this text."
                             FontFamily="{x:Bind (FontFamily)Combo2.SelectedValue, Mode=OneWay}"
                             Style="{StaticResource OutputTextBlockStyle}" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Increase width of ComboBox to account for text scaling >= 200% and prevent clipped text.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #354
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually with text scaling 225% (see screenshot)
## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/16122379/74584721-a4d0d800-4fd5-11ea-9993-79f1b759aea4.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
