### PR TITLE
Resolves 13 code style rule violations.

### DIFF
--- a/XamlControlsGallery/.editorconfig
+++ b/XamlControlsGallery/.editorconfig
@@ -1,5 +1,5 @@
 # EditorConfig  https://EditorConfig.org
-# Style as Code Minimal EditorConfig v.2020.02.06.0 https://styleascode.net
+# Style as Code Minimal EditorConfig v.2020.02.16.0 https://styleascode.net
 
 # top-most EditorConfig file
 root = true

--- a/XamlControlsGallery/Common/NavigationHelper.cs
+++ b/XamlControlsGallery/Common/NavigationHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -118,20 +118,14 @@ namespace AppUIBasics.Common
                 }
 
                 // Pass the navigation parameter to the new page
-                if (this.LoadState != null)
-                {
-                    this.LoadState(this, new LoadStateEventArgs(e.Parameter, null));
-                }
+                this.LoadState?.Invoke(this, new LoadStateEventArgs(e.Parameter, null));
             }
             else
             {
                 // Pass the navigation parameter and preserved page state to the page, using
                 // the same strategy for loading suspended state and recreating pages discarded
                 // from cache
-                if (this.LoadState != null)
-                {
-                    this.LoadState(this, new LoadStateEventArgs(e.Parameter, (Dictionary<String, Object>)frameState[this._pageKey]));
-                }
+                this.LoadState?.Invoke(this, new LoadStateEventArgs(e.Parameter, (Dictionary<String, Object>)frameState[this._pageKey]));
             }
         }
 
@@ -146,10 +140,7 @@ namespace AppUIBasics.Common
         {
             var frameState = SuspensionManager.SessionStateForFrame(this.Frame);
             var pageState = new Dictionary<String, Object>();
-            if (this.SaveState != null)
-            {
-                this.SaveState(this, new SaveStateEventArgs(pageState));
-            }
+            this.SaveState?.Invoke(this, new SaveStateEventArgs(pageState));
             frameState[_pageKey] = pageState;
         }
 

--- a/XamlControlsGallery/Common/ObservableDictionary.cs
+++ b/XamlControlsGallery/Common/ObservableDictionary.cs
@@ -28,11 +28,7 @@ namespace AppUIBasics.Common
 
         private void InvokeMapChanged(CollectionChange change, string key)
         {
-            var eventHandler = MapChanged;
-            if (eventHandler != null)
-            {
-                eventHandler(this, new ObservableDictionaryChangedEventArgs(change, key));
-            }
+            MapChanged?.Invoke(this, new ObservableDictionaryChangedEventArgs(change, key));
         }
 
         public void Add(string key, object value)

--- a/XamlControlsGallery/Common/ObservableDictionary.cs
+++ b/XamlControlsGallery/Common/ObservableDictionary.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Windows.Foundation.Collections;
@@ -58,8 +58,7 @@ namespace AppUIBasics.Common
 
         public bool Remove(KeyValuePair<string, object> item)
         {
-            object currentValue;
-            if (this._dictionary.TryGetValue(item.Key, out currentValue) &&
+            if (this._dictionary.TryGetValue(item.Key, out object currentValue) &&
                 Object.Equals(item.Value, currentValue) && this._dictionary.Remove(item.Key))
             {
                 this.InvokeMapChanged(CollectionChange.ItemRemoved, item.Key);

--- a/XamlControlsGallery/Common/RelayCommand.cs
+++ b/XamlControlsGallery/Common/RelayCommand.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -74,11 +74,7 @@ namespace AppUIBasics.Common
         /// </summary>
         public void RaiseCanExecuteChanged()
         {
-            var handler = CanExecuteChanged;
-            if (handler != null)
-            {
-                handler(this, EventArgs.Empty);
-            }
+            CanExecuteChanged?.Invoke(this, EventArgs.Empty);
         }
     }
 }

--- a/XamlControlsGallery/Common/SuspensionManager.cs
+++ b/XamlControlsGallery/Common/SuspensionManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -62,8 +62,7 @@ namespace AppUIBasics.Common
                 // Save the navigation state for all registered frames
                 foreach (var weakFrameReference in _registeredFrames)
                 {
-                    Frame frame;
-                    if (weakFrameReference.TryGetTarget(out frame))
+                    if (weakFrameReference.TryGetTarget(out Frame frame))
                     {
                         SaveFrameNavigationState(frame);
                     }
@@ -116,8 +115,7 @@ namespace AppUIBasics.Common
                 // Restore any registered frames to their saved state
                 foreach (var weakFrameReference in _registeredFrames)
                 {
-                    Frame frame;
-                    if (weakFrameReference.TryGetTarget(out frame))
+                    if (weakFrameReference.TryGetTarget(out Frame frame))
                     {
                         frame.ClearValue(FrameSessionStateProperty);
                         RestoreFrameNavigationState(frame);
@@ -183,8 +181,7 @@ namespace AppUIBasics.Common
             SessionState.Remove((String)frame.GetValue(FrameSessionStateKeyProperty));
             _registeredFrames.RemoveAll((weakFrameReference) =>
             {
-                Frame testFrame;
-                return !weakFrameReference.TryGetTarget(out testFrame) || testFrame == frame;
+                return !weakFrameReference.TryGetTarget(out Frame testFrame) || testFrame == frame;
             });
         }
 

--- a/XamlControlsGallery/ControlPages/CalendarViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/CalendarViewPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -48,8 +48,7 @@ namespace AppUIBasics.ControlPages
 
         private void SelectionMode_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            CalendarViewSelectionMode selectionMode;
-            if (Enum.TryParse<CalendarViewSelectionMode>((sender as ComboBox).SelectedItem.ToString(), out selectionMode))
+            if (Enum.TryParse<CalendarViewSelectionMode>((sender as ComboBox).SelectedItem.ToString(), out CalendarViewSelectionMode selectionMode))
             {
                 Control1.SelectionMode = selectionMode;
             }

--- a/XamlControlsGallery/ControlPages/CommandBarPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/CommandBarPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿//*********************************************************
+//*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
 // THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
@@ -35,8 +35,7 @@ namespace AppUIBasics.ControlPages
 
         public void OnPropertyChanged(string PropertyName)
         {
-            if (PropertyChanged != null)
-                PropertyChanged(this, new PropertyChangedEventArgs(PropertyName));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(PropertyName));
         }
 
         public CommandBarPage()

--- a/XamlControlsGallery/ControlPages/TreeViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/TreeViewPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using Windows.UI.Xaml;
@@ -217,10 +217,7 @@ namespace AppUIBasics.ControlPages
 
         private void NotifyPropertyChanged(String propertyName)
         {
-            if (PropertyChanged != null)
-            {
-                PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
-            }
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 

--- a/XamlControlsGallery/TabViewPages/TabViewWindowingSamplePage.xaml.cs
+++ b/XamlControlsGallery/TabViewPages/TabViewWindowingSamplePage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Windows.ApplicationModel.Core;
@@ -162,8 +162,7 @@ namespace AppUIBasics.TabViewPages
             // This event is called when we're dragging between different TabViews
             // It is responsible for handling the drop of the item into the second TabView
 
-            object obj;
-            if (e.DataView.Properties.TryGetValue(DataIdentifier, out obj))
+            if (e.DataView.Properties.TryGetValue(DataIdentifier, out object obj))
             {
                 // Ensure that the obj property is set before continuing. 
                 if (obj == null)


### PR DESCRIPTION
This PR resolves all violations of the following rules:

- IDE0018: Variable declaration can be inlined
- IDE1005: Delegate invocation can be simplified

## Description

### IDE0018: Variable declaration can be inlined

Recommendation:

> `out` variables should be declared inline when possible.

Rationale: https://styleascode.net/ID/IDE0018

Instances resolved: 6

---

### IDE1005: Delegate invocation can be simplified

Recommendation:

> The null-conditional operator should be used to simplify delegate invocation when possible.

Rationale: https://styleascode.net/ID/IDE1005

Instances resolved: 7

## Motivation and Context
See #331.

## How Has This Been Tested?
Tests were not run. Solution does compile & run without errors.
