### PR TITLE
Fixing dark mode issue

### DIFF
--- a/XamlControlsGallery/ControlPages/ItemsRepeaterPage.xaml
+++ b/XamlControlsGallery/ControlPages/ItemsRepeaterPage.xaml
@@ -255,7 +255,8 @@ the following attributes: Height, MaxHeight, Length, MaxLength, Diameter, and Ma
                                         Click="Animated_GotItem" 
                                         GotFocus="Animated_GotItem" 
                                         HorizontalAlignment="Stretch"
-                                        Loaded="GetButtonSize"/>
+                                        Loaded="GetButtonSize"
+                                        Foreground="{StaticResource SystemBaseHighColor}"/>
                             </DataTemplate>
                     </muxc:ItemsRepeater>
                 </ScrollViewer>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changing the color of the text in the animated scrolling ItemsRepeater sample so that it's always black, and visible despite being on dark or light mode. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixing issue #360.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in light and dark mode on my machine.

## Screenshots (if appropriate):
Light mode:
![image](https://user-images.githubusercontent.com/22504341/75201048-44037700-571c-11ea-8d54-b7c1c281523d.png)

Dark mode:
![image](https://user-images.githubusercontent.com/22504341/75201029-38b04b80-571c-11ea-8eaf-7b66b169e1e6.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
