### PR TITLE
Resolves 86 code style rule violations.

### DIFF
--- a/XamlControlsGallery/App.xaml.cs
+++ b/XamlControlsGallery/App.xaml.cs
@@ -1,4 +1,4 @@
-﻿//*********************************************************
+//*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
 // THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
@@ -194,8 +194,7 @@ namespace AppUIBasics
         private Frame GetRootFrame()
         {
             Frame rootFrame;
-            NavigationRootPage rootPage = Window.Current.Content as NavigationRootPage;
-            if (rootPage == null)
+            if (!(Window.Current.Content is NavigationRootPage rootPage))
             {
                 rootPage = new NavigationRootPage();
                 rootFrame = (Frame)rootPage.FindName("rootFrame");

--- a/XamlControlsGallery/Common/ActivityFeedLayout.cs
+++ b/XamlControlsGallery/Common/ActivityFeedLayout.cs
@@ -96,8 +96,7 @@ namespace AppUIBasics.Common
         {
             base.InitializeForContextCore(context);
 
-            var state = context.LayoutState as ActivityFeedLayoutState;
-            if (state == null)
+            if (!(context.LayoutState is ActivityFeedLayoutState state))
             {
                 // Store any state we might need since (in theory) the layout could be in use by multiple 
                 // elements simultaneously

--- a/XamlControlsGallery/Common/ImageLoader.cs
+++ b/XamlControlsGallery/Common/ImageLoader.cs
@@ -24,8 +24,7 @@ namespace AppUIBasics.Common
 
         private async static void OnPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            var image = d as Image;
-            if (image != null)
+            if (d is Image image)
             {
                 var item = await ControlInfoDataSource.Instance.GetItemAsync(e.NewValue?.ToString());
                 if (item?.ImagePath != null)

--- a/XamlControlsGallery/Common/NavigationHelper.cs
+++ b/XamlControlsGallery/Common/NavigationHelper.cs
@@ -77,7 +77,7 @@ namespace AppUIBasics.Common
 
         #region Process lifetime management
 
-        private String _pageKey;
+        private string _pageKey;
 
         /// <summary>
         /// Handle this event to populate the page using content passed
@@ -125,7 +125,7 @@ namespace AppUIBasics.Common
                 // Pass the navigation parameter and preserved page state to the page, using
                 // the same strategy for loading suspended state and recreating pages discarded
                 // from cache
-                this.LoadState?.Invoke(this, new LoadStateEventArgs(e.Parameter, (Dictionary<String, Object>)frameState[this._pageKey]));
+                this.LoadState?.Invoke(this, new LoadStateEventArgs(e.Parameter, (Dictionary<string, object>)frameState[this._pageKey]));
             }
         }
 
@@ -139,7 +139,7 @@ namespace AppUIBasics.Common
         public void OnNavigatedFrom(NavigationEventArgs e)
         {
             var frameState = SuspensionManager.SessionStateForFrame(this.Frame);
-            var pageState = new Dictionary<String, Object>();
+            var pageState = new Dictionary<string, object>();
             this.SaveState?.Invoke(this, new SaveStateEventArgs(pageState));
             frameState[_pageKey] = pageState;
         }
@@ -344,28 +344,28 @@ namespace AppUIBasics.Common
     public class LoadStateEventArgs : EventArgs
     {
         /// <summary>
-        /// The parameter value passed to <see cref="Frame.Navigate(Type, Object)"/>
+        /// The parameter value passed to <see cref="Frame.Navigate(Type, object)"/>
         /// when this page was initially requested.
         /// </summary>
-        public Object NavigationParameter { get; private set; }
+        public object NavigationParameter { get; private set; }
         /// <summary>
         /// A dictionary of state preserved by this page during an earlier
         /// session.  This will be null the first time a page is visited.
         /// </summary>
-        public Dictionary<string, Object> PageState { get; private set; }
+        public Dictionary<string, object> PageState { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LoadStateEventArgs"/> class.
         /// </summary>
         /// <param name="navigationParameter">
-        /// The parameter value passed to <see cref="Frame.Navigate(Type, Object)"/>
+        /// The parameter value passed to <see cref="Frame.Navigate(Type, object)"/>
         /// when this page was initially requested.
         /// </param>
         /// <param name="pageState">
         /// A dictionary of state preserved by this page during an earlier
         /// session.  This will be null the first time a page is visited.
         /// </param>
-        public LoadStateEventArgs(Object navigationParameter, Dictionary<string, Object> pageState)
+        public LoadStateEventArgs(object navigationParameter, Dictionary<string, object> pageState)
             : base()
         {
             this.NavigationParameter = navigationParameter;
@@ -380,13 +380,13 @@ namespace AppUIBasics.Common
         /// <summary>
         /// An empty dictionary to be populated with serializable state.
         /// </summary>
-        public Dictionary<string, Object> PageState { get; private set; }
+        public Dictionary<string, object> PageState { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SaveStateEventArgs"/> class.
         /// </summary>
         /// <param name="pageState">An empty dictionary to be populated with serializable state.</param>
-        public SaveStateEventArgs(Dictionary<string, Object> pageState)
+        public SaveStateEventArgs(Dictionary<string, object> pageState)
             : base()
         {
             this.PageState = pageState;

--- a/XamlControlsGallery/Common/SuspensionManager.cs
+++ b/XamlControlsGallery/Common/SuspensionManager.cs
@@ -99,7 +99,7 @@ namespace AppUIBasics.Common
         /// completes.</returns>
         public static async Task RestoreAsync()
         {
-            _sessionState = new Dictionary<String, Object>();
+            _sessionState = new Dictionary<string, object>();
 
             try
             {
@@ -129,9 +129,9 @@ namespace AppUIBasics.Common
         }
 
         private static DependencyProperty FrameSessionStateKeyProperty =
-            DependencyProperty.RegisterAttached("_FrameSessionStateKey", typeof(String), typeof(SuspensionManager), null);
+            DependencyProperty.RegisterAttached("_FrameSessionStateKey", typeof(string), typeof(SuspensionManager), null);
         private static DependencyProperty FrameSessionStateProperty =
-            DependencyProperty.RegisterAttached("_FrameSessionState", typeof(Dictionary<String, Object>), typeof(SuspensionManager), null);
+            DependencyProperty.RegisterAttached("_FrameSessionState", typeof(Dictionary<string, object>), typeof(SuspensionManager), null);
         private static List<WeakReference<Frame>> _registeredFrames = new List<WeakReference<Frame>>();
 
         /// <summary>
@@ -146,7 +146,7 @@ namespace AppUIBasics.Common
         /// <see cref="SuspensionManager"/></param>
         /// <param name="sessionStateKey">A unique key into <see cref="SessionState"/> used to
         /// store navigation-related information.</param>
-        public static void RegisterFrame(Frame frame, String sessionStateKey)
+        public static void RegisterFrame(Frame frame, string sessionStateKey)
         {
             if (frame.GetValue(FrameSessionStateKeyProperty) != null)
             {
@@ -178,7 +178,7 @@ namespace AppUIBasics.Common
         {
             // Remove session state and remove the frame from the list of frames whose navigation
             // state will be saved (along with any weak references that are no longer reachable)
-            SessionState.Remove((String)frame.GetValue(FrameSessionStateKeyProperty));
+            SessionState.Remove((string)frame.GetValue(FrameSessionStateKeyProperty));
             _registeredFrames.RemoveAll((weakFrameReference) =>
             {
                 return !weakFrameReference.TryGetTarget(out Frame testFrame) || testFrame == frame;
@@ -198,26 +198,26 @@ namespace AppUIBasics.Common
         /// <param name="frame">The instance for which session state is desired.</param>
         /// <returns>A collection of state subject to the same serialization mechanism as
         /// <see cref="SessionState"/>.</returns>
-        public static Dictionary<String, Object> SessionStateForFrame(Frame frame)
+        public static Dictionary<string, object> SessionStateForFrame(Frame frame)
         {
-            var frameState = (Dictionary<String, Object>)frame.GetValue(FrameSessionStateProperty);
+            var frameState = (Dictionary<string, object>)frame.GetValue(FrameSessionStateProperty);
 
             if (frameState == null)
             {
-                var frameSessionKey = (String)frame.GetValue(FrameSessionStateKeyProperty);
+                var frameSessionKey = (string)frame.GetValue(FrameSessionStateKeyProperty);
                 if (frameSessionKey != null)
                 {
                     // Registered frames reflect the corresponding session state
                     if (!_sessionState.ContainsKey(frameSessionKey))
                     {
-                        _sessionState[frameSessionKey] = new Dictionary<String, Object>();
+                        _sessionState[frameSessionKey] = new Dictionary<string, object>();
                     }
-                    frameState = (Dictionary<String, Object>)_sessionState[frameSessionKey];
+                    frameState = (Dictionary<string, object>)_sessionState[frameSessionKey];
                 }
                 else
                 {
                     // Frames that aren't registered have transient state
-                    frameState = new Dictionary<String, Object>();
+                    frameState = new Dictionary<string, object>();
                 }
                 frame.SetValue(FrameSessionStateProperty, frameState);
             }
@@ -229,7 +229,7 @@ namespace AppUIBasics.Common
             var frameState = SessionStateForFrame(frame);
             if (frameState.ContainsKey("Navigation"))
             {
-                frame.SetNavigationState((String)frameState["Navigation"]);
+                frame.SetNavigationState((string)frameState["Navigation"]);
             }
         }
 

--- a/XamlControlsGallery/ConnectedAnimationPages/CardPage.xaml.cs
+++ b/XamlControlsGallery/ConnectedAnimationPages/CardPage.xaml.cs
@@ -56,8 +56,7 @@ namespace AppUIBasics.ConnectedAnimationPages
             ConnectedAnimation animation = null;
 
             // Get the collection item corresponding to the clicked item.
-            var container = collection.ContainerFromItem(e.ClickedItem) as GridViewItem;
-            if (container != null)
+            if (collection.ContainerFromItem(e.ClickedItem) is GridViewItem container)
             {
                 // Stash the clicked item for use later. We'll need it when we connect back from the detailpage.
                 _storedItem = Convert.ToInt32(container.Content);

--- a/XamlControlsGallery/ConnectedAnimationPages/CollectionPage.xaml.cs
+++ b/XamlControlsGallery/ConnectedAnimationPages/CollectionPage.xaml.cs
@@ -48,8 +48,7 @@ namespace AppUIBasics.ConnectedAnimationPages
         private void collection_ItemClick(object sender, ItemClickEventArgs e)
         {
             // Get the collection item corresponding to the clicked item.
-            var container = collection.ContainerFromItem(e.ClickedItem) as ListViewItem;
-            if (container != null)
+            if (collection.ContainerFromItem(e.ClickedItem) is ListViewItem container)
             {
                 // Stash the clicked item for use later. We'll need it when we connect back from the detailpage.
                 _storeditem = container.Content as CustomDataObject;

--- a/XamlControlsGallery/ControlExample.xaml.cs
+++ b/XamlControlsGallery/ControlExample.xaml.cs
@@ -146,17 +146,17 @@ namespace AppUIBasics
             set { SetValue(ExampleHeightProperty, value); }
         }
 
-        public static readonly DependencyProperty WebViewHeightProperty = DependencyProperty.Register("WebViewHeight", typeof(Int32), typeof(ControlExample), new PropertyMetadata(400));
-        public Int32 WebViewHeight
+        public static readonly DependencyProperty WebViewHeightProperty = DependencyProperty.Register("WebViewHeight", typeof(int), typeof(ControlExample), new PropertyMetadata(400));
+        public int WebViewHeight
         {
-            get { return (Int32)GetValue(WebViewHeightProperty); }
+            get { return (int)GetValue(WebViewHeightProperty); }
             set { SetValue(WebViewHeightProperty, value); }
         }
 
-        public static readonly DependencyProperty WebViewWidthProperty = DependencyProperty.Register("WebViewWidth", typeof(Int32), typeof(ControlExample), new PropertyMetadata(800));
-        public Int32 WebViewWidth
+        public static readonly DependencyProperty WebViewWidthProperty = DependencyProperty.Register("WebViewWidth", typeof(int), typeof(ControlExample), new PropertyMetadata(800));
+        public int WebViewWidth
         {
-            get { return (Int32)GetValue(WebViewWidthProperty); }
+            get { return (int)GetValue(WebViewWidthProperty); }
             set { SetValue(WebViewWidthProperty, value); }
         }
 
@@ -228,7 +228,7 @@ namespace AppUIBasics
 
         private void GenerateSyntaxHighlightedContent(ContentPresenter presenter, string sampleString, Uri sampleUri, ILanguage highlightLanguage)
         {
-            if (!String.IsNullOrEmpty(sampleString))
+            if (!string.IsNullOrEmpty(sampleString))
             {
                 FormatAndRenderSampleFromString(sampleString, presenter, highlightLanguage);
             }
@@ -255,7 +255,7 @@ namespace AppUIBasics
         }
 
         private static Regex SubstitutionPattern = new Regex(@"\$\(([^\)]+)\)");
-        private void FormatAndRenderSampleFromString(String sampleString, ContentPresenter presenter, ILanguage highlightLanguage)
+        private void FormatAndRenderSampleFromString(string sampleString, ContentPresenter presenter, ILanguage highlightLanguage)
         {
             // Trim out stray blank lines at start and end.
             sampleString = sampleString.TrimStart('\n').TrimEnd();

--- a/XamlControlsGallery/ControlPages/AppBarButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AppBarButtonPage.xaml.cs
@@ -52,8 +52,7 @@ namespace AppUIBasics.ControlPages
 
         private void CompactButton_Click(object sender, RoutedEventArgs e)
         {
-            ToggleButton toggle = sender as ToggleButton;
-            if (toggle != null && toggle.IsChecked != null)
+            if (sender is ToggleButton toggle && toggle.IsChecked != null)
             {
                 Button1.IsCompact =
                 Button2.IsCompact =
@@ -64,9 +63,7 @@ namespace AppUIBasics.ControlPages
 
         private void AppBarButton_Click(object sender, RoutedEventArgs e)
         {
-            Button b = sender as Button;
-
-            if (b != null)
+            if (sender is Button b)
             {
                 string name = b.Name;
 

--- a/XamlControlsGallery/ControlPages/AppBarPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AppBarPage.xaml.cs
@@ -42,8 +42,7 @@ namespace AppUIBasics.ControlPages
         {
             ButtonBase b = (ButtonBase)sender;
 
-            Frame rootFrame = Window.Current.Content as Frame;
-            if (rootFrame != null && b.Tag != null)
+            if (Window.Current.Content is Frame rootFrame && b.Tag != null)
             {
                 if (b.Tag.ToString() == "Home")
                 {
@@ -58,9 +57,7 @@ namespace AppUIBasics.ControlPages
 
         private void AddButton_Click(object sender, RoutedEventArgs e)
         {
-            Button homeButton = AppBarContentPanel.Children[0] as Button;
-
-            if (homeButton != null && homeButton.Tag.ToString() != "Home")
+            if (AppBarContentPanel.Children[0] is Button homeButton && homeButton.Tag.ToString() != "Home")
             {
                 homeButton = new Button();
                 homeButton.Content = "Home";
@@ -84,9 +81,7 @@ namespace AppUIBasics.ControlPages
 
         private void RemoveHomeButton()
         {
-            Button homeButton = AppBarContentPanel.Children[0] as Button;
-
-            if (homeButton != null && homeButton.Tag.ToString() == "Home")
+            if (AppBarContentPanel.Children[0] is Button homeButton && homeButton.Tag.ToString() == "Home")
             {
                 homeButton.Click -= NavBarButton_Click;
                 AppBarContentPanel.Children.RemoveAt(0);

--- a/XamlControlsGallery/ControlPages/AppBarSeparatorPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AppBarSeparatorPage.xaml.cs
@@ -56,8 +56,7 @@ namespace AppUIBasics.ControlPages
             // the CommandBar sets the IsCompact property automatically. You only set it
             // yourself if the control in not in a CommandBar.
 
-            ToggleButton toggle = sender as ToggleButton;
-            if (toggle != null && toggle.IsChecked != null)
+            if (sender is ToggleButton toggle && toggle.IsChecked != null)
             {
                 foreach (ICommandBarElement element in Control1.Children)
                 {

--- a/XamlControlsGallery/ControlPages/AppBarToggleButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AppBarToggleButtonPage.xaml.cs
@@ -52,8 +52,7 @@ namespace AppUIBasics.ControlPages
 
         private void CompactButton_Click(object sender, RoutedEventArgs e)
         {
-            ToggleButton toggle = sender as ToggleButton;
-            if (toggle != null && toggle.IsChecked != null)
+            if (sender is ToggleButton toggle && toggle.IsChecked != null)
             {
                 Button1.IsCompact =
                 Button2.IsCompact =
@@ -64,9 +63,7 @@ namespace AppUIBasics.ControlPages
 
         private void AppBarButton_Click(object sender, RoutedEventArgs e)
         {
-            AppBarToggleButton b = sender as AppBarToggleButton;
-
-            if (b != null)
+            if (sender is AppBarToggleButton b)
             {
                 string name = b.Name;
 

--- a/XamlControlsGallery/ControlPages/BorderPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/BorderPage.xaml.cs
@@ -29,9 +29,7 @@ namespace AppUIBasics.ControlPages
 
         private void BGRadioButton_Checked(object sender, RoutedEventArgs e)
         {
-            RadioButton rb = sender as RadioButton;
-
-            if (rb != null && Control1 != null)
+            if (sender is RadioButton rb && Control1 != null)
             {
                 string colorName = rb.Content.ToString();
                 switch (colorName)
@@ -54,9 +52,7 @@ namespace AppUIBasics.ControlPages
 
         private void RadioButton_Checked(object sender, RoutedEventArgs e)
         {
-            RadioButton rb = sender as RadioButton;
-
-            if (rb != null && Control1 != null)
+            if (sender is RadioButton rb && Control1 != null)
             {
                 string colorName = rb.Content.ToString();
                 switch (colorName)

--- a/XamlControlsGallery/ControlPages/ButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ButtonPage.xaml.cs
@@ -21,9 +21,7 @@ namespace AppUIBasics.ControlPages
 
         private void Button_Click(object sender, RoutedEventArgs e)
         {
-            Button b = sender as Button;
-
-            if (b != null)
+            if (sender is Button b)
             {
                 string name = b.Name;
 

--- a/XamlControlsGallery/ControlPages/ConnectedAnimationPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ConnectedAnimationPage.xaml.cs
@@ -62,11 +62,11 @@ namespace AppUIBasics.ControlPages
     // Sample data object used to populate the collection page.
     public class CustomDataObject
     {
-        public String Title { get; set; }
-        public String ImageLocation { get; set; }
-        public String Views { get; set; }
+        public string Title { get; set; }
+        public string ImageLocation { get; set; }
+        public string Views { get; set; }
         public string Likes { get; set; }
-        public String Description { get; set; }
+        public string Description { get; set; }
 
         public CustomDataObject()
         {

--- a/XamlControlsGallery/ControlPages/FlyoutPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/FlyoutPage.xaml.cs
@@ -23,8 +23,7 @@ namespace AppUIBasics.ControlPages
 
         private void DeleteConfirmation_Click(object sender, RoutedEventArgs e)
         {
-            Flyout f = this.Control1.Flyout as Flyout;
-            if (f != null)
+            if (this.Control1.Flyout is Flyout f)
             {
                 f.Hide();
             }

--- a/XamlControlsGallery/ControlPages/ItemsRepeaterPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ItemsRepeaterPage.xaml.cs
@@ -131,7 +131,7 @@ namespace AppUIBasics.ControlPages
 
         private void RadioBtn_Click(object sender, RoutedEventArgs e)
         {
-            string itemTemplateKey = String.Empty;
+            string itemTemplateKey = string.Empty;
             var layoutKey = ((FrameworkElement)sender).Tag as string;
 
             if (layoutKey.Equals(nameof(this.VerticalStackLayout))) // we used x:Name in the resources which both acts as the x:Key value and creates a member field by the same name
@@ -215,10 +215,10 @@ namespace AppUIBasics.ControlPages
         // Animated Scrolling ItemsRepeater with Content Sample
         // ==========================================================================
 
-        private IList<String> GetColors()
+        private IList<string> GetColors()
         {
             // Initialize list of colors for animated scrolling sample
-            IList<String> colors = (typeof(Colors).GetRuntimeProperties().Select(c => c.ToString())).ToList();
+            IList<string> colors = (typeof(Colors).GetRuntimeProperties().Select(c => c.ToString())).ToList();
             for (int i = 0; i < colors.Count(); i++)
             {
                 colors[i] = colors[i].Substring(17);
@@ -418,7 +418,7 @@ namespace AppUIBasics.ControlPages
         protected override DataTemplate SelectTemplateCore(object item)
         {
             // Return the correct data template based on the item's type.
-            if (item.GetType() == typeof(String))
+            if (item.GetType() == typeof(string))
             {
                 return StringTemplate;
             }

--- a/XamlControlsGallery/ControlPages/MenuFlyoutPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/MenuFlyoutPage.xaml.cs
@@ -23,9 +23,7 @@ namespace AppUIBasics.ControlPages
 
         private void MenuFlyoutItem_Click(object sender, RoutedEventArgs e)
         {
-            MenuFlyoutItem selectedItem = sender as MenuFlyoutItem;
-
-            if (selectedItem != null)
+            if (sender is MenuFlyoutItem selectedItem)
             {
                 string sortOption = selectedItem.Tag.ToString();
                 switch (sortOption)

--- a/XamlControlsGallery/ControlPages/NavigationViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/NavigationViewPage.xaml.cs
@@ -22,9 +22,9 @@ namespace AppUIBasics.ControlPages
 {
     public sealed partial class NavigationViewPage : Page
     {
-        public static Boolean CameFromToggle = false;
+        public static bool CameFromToggle = false;
 
-        public static Boolean CameFromGridChange = false;
+        public static bool CameFromGridChange = false;
 
         public VirtualKey ArrowKey;
 
@@ -53,7 +53,7 @@ namespace AppUIBasics.ControlPages
             nvSample2.UpdateLayout();
         }
 
-        public Microsoft.UI.Xaml.Controls.NavigationViewPaneDisplayMode ChoosePanePosition(Boolean toggleOn)
+        public Microsoft.UI.Xaml.Controls.NavigationViewPaneDisplayMode ChoosePanePosition(bool toggleOn)
         {
             if (toggleOn)
             {

--- a/XamlControlsGallery/ControlPages/PasswordBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/PasswordBoxPage.xaml.cs
@@ -21,9 +21,7 @@ namespace AppUIBasics.ControlPages
 
         private void PasswordBox_PasswordChanged(object sender, RoutedEventArgs e)
         {
-            PasswordBox pb = sender as PasswordBox;
-
-            if (pb != null)
+            if (sender is PasswordBox pb)
             {
                 if (string.IsNullOrEmpty(pb.Password) || pb.Password == "Password")
                 {

--- a/XamlControlsGallery/ControlPages/RadioButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RadioButtonPage.xaml.cs
@@ -23,9 +23,7 @@ namespace AppUIBasics.ControlPages
 
         private void BGRadioButton_Checked(object sender, RoutedEventArgs e)
         {
-            RadioButton rb = sender as RadioButton;
-
-            if (rb != null && Control2Output != null)
+            if (sender is RadioButton rb && Control2Output != null)
             {
                 string colorName = rb.Tag.ToString();
                 switch (colorName)
@@ -48,9 +46,7 @@ namespace AppUIBasics.ControlPages
 
         private void BorderRadioButton_Checked(object sender, RoutedEventArgs e)
         {
-            RadioButton rb = sender as RadioButton;
-
-            if (rb != null && Control2Output != null)
+            if (sender is RadioButton rb && Control2Output != null)
             {
                 string colorName = rb.Tag.ToString();
                 switch (colorName)

--- a/XamlControlsGallery/ControlPages/ScrollViewerPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ScrollViewerPage.xaml.cs
@@ -25,8 +25,7 @@ namespace AppUIBasics.ControlPages
         {
             if (Control1 != null && ZoomSlider != null)
             {
-                ComboBox cb = sender as ComboBox;
-                if (cb != null)
+                if (sender is ComboBox cb)
                 {
                     switch (cb.SelectedIndex)
                     {
@@ -63,8 +62,7 @@ namespace AppUIBasics.ControlPages
         {
             if (Control1 != null)
             {
-                ComboBox cb = sender as ComboBox;
-                if (cb != null)
+                if (sender is ComboBox cb)
                 {
                     switch (cb.SelectedIndex)
                     {
@@ -89,8 +87,7 @@ namespace AppUIBasics.ControlPages
         {
             if (Control1 != null)
             {
-                ComboBox cb = sender as ComboBox;
-                if (cb != null)
+                if (sender is ComboBox cb)
                 {
                     switch (cb.SelectedIndex)
                     {
@@ -118,8 +115,7 @@ namespace AppUIBasics.ControlPages
         {
             if (Control1 != null)
             {
-                ComboBox cb = sender as ComboBox;
-                if (cb != null)
+                if (sender is ComboBox cb)
                 {
                     switch (cb.SelectedIndex)
                     {
@@ -144,8 +140,7 @@ namespace AppUIBasics.ControlPages
         {
             if (Control1 != null)
             {
-                ComboBox cb = sender as ComboBox;
-                if (cb != null)
+                if (sender is ComboBox cb)
                 {
                     switch (cb.SelectedIndex)
                     {

--- a/XamlControlsGallery/ControlPages/StandardUICommandPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/StandardUICommandPage.xaml.cs
@@ -10,7 +10,7 @@ namespace AppUIBasics.ControlPages
 {
     public class ListItemData
     {
-        public String Text { get; set; }
+        public string Text { get; set; }
         public ICommand Command { get; set; }
     }
 

--- a/XamlControlsGallery/ControlPages/TreeViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/TreeViewPage.xaml.cs
@@ -166,7 +166,7 @@ namespace AppUIBasics.ControlPages
     {
         public event PropertyChangedEventHandler PropertyChanged;
         public enum ExplorerItemType { Folder, File };
-        public String Name { get; set; }
+        public string Name { get; set; }
         public ExplorerItemType Type { get; set; }
         private ObservableCollection<ExplorerItem> m_children;
         public ObservableCollection<ExplorerItem> Children
@@ -215,7 +215,7 @@ namespace AppUIBasics.ControlPages
 
         }
 
-        private void NotifyPropertyChanged(String propertyName)
+        private void NotifyPropertyChanged(string propertyName)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }

--- a/XamlControlsGallery/ControlPages/ViewBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ViewBoxPage.xaml.cs
@@ -22,9 +22,7 @@ namespace AppUIBasics.ControlPages
 
         private void StretchDirectionButton_Checked(object sender, RoutedEventArgs e)
         {
-            RadioButton rb = sender as RadioButton;
-
-            if (rb != null && Control1 != null)
+            if (sender is RadioButton rb && Control1 != null)
             {
                 string direction = rb.Tag.ToString();
                 switch (direction)
@@ -44,9 +42,7 @@ namespace AppUIBasics.ControlPages
 
         private void StretchButton_Checked(object sender, RoutedEventArgs e)
         {
-            RadioButton rb = sender as RadioButton;
-
-            if (rb != null && Control1 != null)
+            if (sender is RadioButton rb && Control1 != null)
             {
                 string stretch = rb.Tag.ToString();
                 switch (stretch)

--- a/XamlControlsGallery/ControlPages/XamlCompInteropPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/XamlCompInteropPage.xaml.cs
@@ -135,7 +135,7 @@ namespace AppUIBasics.ControlPages
             String yOffset = "0"; // We don't need to offset y because the buttons naturally layout vertically centered.
 
             // We combine X, Y, and Z subchannels into a single animation because we can only start a single animation on Translation.
-            String expression = String.Format("Vector3({0}*cos({1})+{2}, {0}*sin({1})+{3},0)", radius, theta, xOffset, yOffset);
+            String expression = string.Format("Vector3({0}*cos({1})+{2}, {0}*sin({1})+{3},0)", radius, theta, xOffset, yOffset);
 
             int totalElements = 8;
             for (int i = 0; i < totalElements; i++)

--- a/XamlControlsGallery/DataModel/ControlInfoDataSource.cs
+++ b/XamlControlsGallery/DataModel/ControlInfoDataSource.cs
@@ -32,7 +32,7 @@ namespace AppUIBasics.Data
     /// </summary>
     public class ControlInfoDataItem
     {
-        public ControlInfoDataItem(String uniqueId, String title, String subtitle, String imagePath, String badgeString, String description, String content, bool isNew, bool isUpdated, bool isPreview)
+        public ControlInfoDataItem(string uniqueId, string title, string subtitle, string imagePath, string badgeString, string description, string content, bool isNew, bool isUpdated, bool isPreview)
         {
             this.UniqueId = uniqueId;
             this.Title = title;
@@ -84,7 +84,7 @@ namespace AppUIBasics.Data
     /// </summary>
     public class ControlInfoDataGroup
     {
-        public ControlInfoDataGroup(String uniqueId, String title, String subtitle, String imagePath, String description)
+        public ControlInfoDataGroup(string uniqueId, string title, string subtitle, string imagePath, string description)
         {
             this.UniqueId = uniqueId;
             this.Title = title;

--- a/XamlControlsGallery/ItemPage.xaml.cs
+++ b/XamlControlsGallery/ItemPage.xaml.cs
@@ -131,7 +131,7 @@ namespace AppUIBasics
 
         protected override async void OnNavigatedTo(NavigationEventArgs e)
         {
-            var item = await ControlInfoDataSource.Instance.GetItemAsync((String)e.Parameter);
+            var item = await ControlInfoDataSource.Instance.GetItemAsync((string)e.Parameter);
 
             if (item != null)
             {
@@ -157,7 +157,7 @@ namespace AppUIBasics
                     return;
                 }
 
-                ControlInfoDataGroup group = await ControlInfoDataSource.Instance.GetGroupFromItemAsync((String)e.Parameter);
+                ControlInfoDataGroup group = await ControlInfoDataSource.Instance.GetGroupFromItemAsync((string)e.Parameter);
                 var menuItem = NavigationRootPage.Current.NavigationView.MenuItems.Cast<Microsoft.UI.Xaml.Controls.NavigationViewItemBase>().FirstOrDefault(m => m.Tag?.ToString() == group.UniqueId);
                 if (menuItem != null)
                 {

--- a/XamlControlsGallery/ItemsPageBase.cs
+++ b/XamlControlsGallery/ItemsPageBase.cs
@@ -131,7 +131,7 @@ namespace AppUIBasics
             }
         }
 
-        protected bool SetProperty<T>(ref T storage, T value, [CallerMemberName] String propertyName = null)
+        protected bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string propertyName = null)
         {
             if (Equals(storage, value)) return false;
 

--- a/XamlControlsGallery/SearchResultsPage.xaml.cs
+++ b/XamlControlsGallery/SearchResultsPage.xaml.cs
@@ -152,12 +152,12 @@ namespace AppUIBasics
     /// </summary>
     public sealed class Filter : INotifyPropertyChanged
     {
-        private String _name;
+        private string _name;
         private int _count;
         private bool? _active;
         private List<ControlInfoDataItem> _items;
 
-        public Filter(String name, int count, List<ControlInfoDataItem> controlInfoList, bool active = false)
+        public Filter(string name, int count, List<ControlInfoDataItem> controlInfoList, bool active = false)
         {
             this.Name = name;
             this.Count = count;
@@ -165,7 +165,7 @@ namespace AppUIBasics
             this.Items = controlInfoList;
         }
 
-        public override String ToString()
+        public override string ToString()
         {
             return Description;
         }
@@ -176,7 +176,7 @@ namespace AppUIBasics
             set { this.SetProperty(ref _items, value); }
         }
 
-        public String Name
+        public string Name
         {
             get { return _name; }
             set { if (this.SetProperty(ref _name, value)) this.NotifyPropertyChanged(nameof(Description)); }
@@ -194,9 +194,9 @@ namespace AppUIBasics
             set { this.SetProperty(ref _active, value); }
         }
 
-        public String Description
+        public string Description
         {
-            get { return String.Format("{0} ({1})", _name, _count); }
+            get { return string.Format("{0} ({1})", _name, _count); }
         }
 
         /// <summary>
@@ -216,7 +216,7 @@ namespace AppUIBasics
         /// support CallerMemberName.</param>
         /// <returns>True if the value was changed, false if the existing value matched the
         /// desired value.</returns>
-        private bool SetProperty<T>(ref T storage, T value, [CallerMemberName] String propertyName = null)
+        private bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string propertyName = null)
         {
             if (object.Equals(storage, value)) return false;
 

--- a/XamlControlsGallery/SettingsPage.xaml.cs
+++ b/XamlControlsGallery/SettingsPage.xaml.cs
@@ -30,7 +30,7 @@ namespace AppUIBasics
             get
             {
                 var version = Windows.ApplicationModel.Package.Current.Id.Version;
-                return String.Format("{0}.{1}.{2}.{3}", version.Major, version.Minor, version.Build, version.Revision);
+                return string.Format("{0}.{1}.{2}.{3}", version.Major, version.Minor, version.Build, version.Revision);
             }
         }
 


### PR DESCRIPTION
This PR resolves all violations of the following rules:

- IDE0019: Use pattern matching over as with null check
- IDE0049: Use type keywords

## Description

### IDE0019: Use pattern matching over as with null check

Recommendation:

> Use pattern matching with the *is expression* over the `as` operator with a null check.

Rationale: https://styleascode.net/ID/IDE0019

Instances resolved: 28

### IDE0049: Use type keywords

Recommendation:

> For locals, parameters and type members, prefer types that have a language keyword to represent them (`int, double, string`, etc.) to use that keyword instead of the type name (`Int32, Int64`, etc.).

> Prefer the keyword whenever a member-access expression is used on a type with a keyword representation (`int, double, string`, etc.).

Rationale: https://styleascode.net/ID/IDE0049

Instances resolved: 58

## Motivation and Context
See #331 & #363.

## How Has This Been Tested?
Tests were not run. Solution does compile & run without errors.

## Types of changes
- [X] Code quality