### PR TITLE
Resolves 25 code style rule violations.

### DIFF
--- a/XamlControlsGallery/Common/VariedImageSizeLayout.cs
+++ b/XamlControlsGallery/Common/VariedImageSizeLayout.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Collections.Generic;
@@ -108,8 +108,7 @@ namespace AppUIBasics.Common
 
             for (int index = 0; index < m_cachedBounds.Count; index++)
             {
-                double nextOffset = 0.0;
-                int columnIndex = GetIndexOfLowestColumn(m_columnOffsets, out nextOffset);
+                int columnIndex = GetIndexOfLowestColumn(m_columnOffsets, out var nextOffset);
                 var oldHeight = m_cachedBounds[index].Height;
                 m_cachedBounds[index] = new Rect(columnIndex * Width, nextOffset, Width, oldHeight);
                 m_columnOffsets[columnIndex] += oldHeight;

--- a/XamlControlsGallery/ControlExample.xaml.cs
+++ b/XamlControlsGallery/ControlExample.xaml.cs
@@ -1,4 +1,4 @@
-﻿//*********************************************************
+//*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
 // THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
@@ -273,8 +273,7 @@ namespace AppUIBasics
                 throw new KeyNotFoundException(match.Groups[1].Value);
             });
 
-            var sampleCodeRTB = new RichTextBlock();
-            sampleCodeRTB.FontFamily = new FontFamily("Consolas");
+            var sampleCodeRTB = new RichTextBlock {FontFamily = new FontFamily("Consolas")};
 
             var formatter = GenerateRichTextFormatter();
             formatter.FormatRichTextBlock(sampleString, highlightLanguage, sampleCodeRTB);

--- a/XamlControlsGallery/ControlPages/AppBarButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AppBarButtonPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿//*********************************************************
+//*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
 // THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
@@ -43,9 +43,11 @@ namespace AppUIBasics.ControlPages
             separator = new AppBarSeparator();
             appBar.PrimaryCommands.Insert(0, separator);
 
-            compactButton = new AppBarToggleButton();
-            compactButton.Icon = new SymbolIcon(Symbol.FontSize);
-            compactButton.Label = "IsCompact";
+            compactButton = new AppBarToggleButton
+            {
+                Icon = new SymbolIcon(Symbol.FontSize),
+                Label = "IsCompact"
+            };
             compactButton.Click += CompactButton_Click;
             appBar.PrimaryCommands.Insert(0, compactButton);
         }

--- a/XamlControlsGallery/ControlPages/AppBarPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AppBarPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿//*********************************************************
+//*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
 // THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
@@ -59,9 +59,11 @@ namespace AppUIBasics.ControlPages
         {
             if (AppBarContentPanel.Children[0] is Button homeButton && homeButton.Tag.ToString() != "Home")
             {
-                homeButton = new Button();
-                homeButton.Content = "Home";
-                homeButton.Tag = "Home";
+                homeButton = new Button
+                {
+                    Content = "Home",
+                    Tag = "Home"
+                };
                 homeButton.Click += NavBarButton_Click;
 
                 AppBarContentPanel.Children.Insert(0, homeButton);

--- a/XamlControlsGallery/ControlPages/AppBarSeparatorPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AppBarSeparatorPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿//*********************************************************
+//*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
 // THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
@@ -39,15 +39,17 @@ namespace AppUIBasics.ControlPages
             // Add compact button to the command bar. It provides functionality specific
             // to this page, and is removed when leaving the page.
 
-                CommandBar appBar = NavigationRootPage.Current.PageHeader.TopCommandBar;
-                separator = new AppBarSeparator();
-                appBar.PrimaryCommands.Insert(0, separator);
+            CommandBar appBar = NavigationRootPage.Current.PageHeader.TopCommandBar;
+            separator = new AppBarSeparator();
+            appBar.PrimaryCommands.Insert(0, separator);
 
-                compactButton = new AppBarToggleButton();
-                compactButton.Icon = new SymbolIcon(Symbol.FontSize);
-                compactButton.Label = "IsCompact";
-                compactButton.Click += CompactButton_Click;
-                appBar.PrimaryCommands.Insert(0, compactButton);
+            compactButton = new AppBarToggleButton
+            {
+                Icon = new SymbolIcon(Symbol.FontSize),
+                Label = "IsCompact"
+            };
+            compactButton.Click += CompactButton_Click;
+            appBar.PrimaryCommands.Insert(0, compactButton);
         }
 
         private void CompactButton_Click(object sender, RoutedEventArgs e)

--- a/XamlControlsGallery/ControlPages/AppBarToggleButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AppBarToggleButtonPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿//*********************************************************
+//*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
 // THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
@@ -39,15 +39,17 @@ namespace AppUIBasics.ControlPages
             // Add compact button to the command bar. It provides functionality specific
             // to this page, and is removed when leaving the page.
 
-                CommandBar appBar = NavigationRootPage.Current.PageHeader.TopCommandBar;
-                separator = new AppBarSeparator();
-                appBar.PrimaryCommands.Insert(0, separator);
+            CommandBar appBar = NavigationRootPage.Current.PageHeader.TopCommandBar;
+            separator = new AppBarSeparator();
+            appBar.PrimaryCommands.Insert(0, separator);
 
-                compactButton = new AppBarToggleButton();
-                compactButton.Icon = new SymbolIcon(Symbol.FontSize);
-                compactButton.Label = "IsCompact";
-                compactButton.Click += CompactButton_Click;
-                appBar.PrimaryCommands.Insert(0, compactButton);
+            compactButton = new AppBarToggleButton
+            {
+                Icon = new SymbolIcon(Symbol.FontSize),
+                Label = "IsCompact"
+            };
+            compactButton.Click += CompactButton_Click;
+            appBar.PrimaryCommands.Insert(0, compactButton);
         }
 
         private void CompactButton_Click(object sender, RoutedEventArgs e)

--- a/XamlControlsGallery/ControlPages/ComboBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ComboBoxPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿//*********************************************************
+//*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
 // THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
@@ -104,10 +104,12 @@ namespace AppUIBasics.ControlPages
                 // If the item is invalid, reject it and revert the text. 
                 sender.Text = sender.SelectedValue.ToString();
 
-                var dialog = new ContentDialog();
-                dialog.Content = "The font size must be a number between 8 and 100.";
-                dialog.CloseButtonText = "Close";
-                dialog.DefaultButton = ContentDialogButton.Close;
+                var dialog = new ContentDialog
+                {
+                    Content = "The font size must be a number between 8 and 100.",
+                    CloseButtonText = "Close",
+                    DefaultButton = ContentDialogButton.Close
+                };
                 var task = dialog.ShowAsync();
             }
 

--- a/XamlControlsGallery/ControlPages/CommandBarFlyoutPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/CommandBarFlyoutPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Windows.Foundation.Metadata;
+using Windows.Foundation.Metadata;
 using Windows.UI;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
@@ -24,9 +24,11 @@ namespace AppUIBasics.ControlPages
         {
             if(ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 7))
             {
-                FlyoutShowOptions myOption = new FlyoutShowOptions();
-                myOption.ShowMode = isTransient ? FlyoutShowMode.Transient : FlyoutShowMode.Standard;
-                myOption.Placement = FlyoutPlacementMode.RightEdgeAlignedTop;
+                FlyoutShowOptions myOption = new FlyoutShowOptions
+                {
+                    ShowMode = isTransient ? FlyoutShowMode.Transient : FlyoutShowMode.Standard,
+                    Placement = FlyoutPlacementMode.RightEdgeAlignedTop
+                };
                 CommandBarFlyout1.ShowAt(Image1, myOption);
             }
             else

--- a/XamlControlsGallery/ControlPages/CommandBarPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/CommandBarPage.xaml.cs
@@ -69,9 +69,11 @@ namespace AppUIBasics.ControlPages
 
             if (PrimaryCommandBar.SecondaryCommands.Count == 1)
             {
-                var newButton = new AppBarButton();
-                newButton.Icon = new SymbolIcon(Symbol.Add);
-                newButton.Label = "Button 1";
+                var newButton = new AppBarButton
+                {
+                    Icon = new SymbolIcon(Symbol.Add),
+                    Label = "Button 1"
+                };
                 newButton.KeyboardAccelerators.Add(new Windows.UI.Xaml.Input.KeyboardAccelerator()
                 {
                     Key = Windows.System.VirtualKey.N,
@@ -79,9 +81,11 @@ namespace AppUIBasics.ControlPages
                 });
                 PrimaryCommandBar.SecondaryCommands.Add(newButton);
 
-                newButton = new AppBarButton();
-                newButton.Icon = new SymbolIcon(Symbol.Delete);
-                newButton.Label = "Button 2";
+                newButton = new AppBarButton
+                {
+                    Icon = new SymbolIcon(Symbol.Delete),
+                    Label = "Button 2"
+                };
                 PrimaryCommandBar.SecondaryCommands.Add(newButton);
                 newButton.KeyboardAccelerators.Add(new Windows.UI.Xaml.Input.KeyboardAccelerator()
                 {
@@ -89,9 +93,11 @@ namespace AppUIBasics.ControlPages
                 });
                 PrimaryCommandBar.SecondaryCommands.Add(new AppBarSeparator());
 
-                newButton = new AppBarButton();
-                newButton.Icon = new SymbolIcon(Symbol.FontDecrease);
-                newButton.Label = "Button 3";
+                newButton = new AppBarButton
+                {
+                    Icon = new SymbolIcon(Symbol.FontDecrease),
+                    Label = "Button 3"
+                };
                 newButton.KeyboardAccelerators.Add(new Windows.UI.Xaml.Input.KeyboardAccelerator()
                 {
                     Key = Windows.System.VirtualKey.Subtract,
@@ -99,9 +105,11 @@ namespace AppUIBasics.ControlPages
                 });
                 PrimaryCommandBar.SecondaryCommands.Add(newButton);
 
-                newButton = new AppBarButton();
-                newButton.Icon = new SymbolIcon(Symbol.FontIncrease);
-                newButton.Label = "Button 4";
+                newButton = new AppBarButton
+                {
+                    Icon = new SymbolIcon(Symbol.FontIncrease),
+                    Label = "Button 4"
+                };
                 newButton.KeyboardAccelerators.Add(new Windows.UI.Xaml.Input.KeyboardAccelerator()
                 {
                     Key = Windows.System.VirtualKey.Add,

--- a/XamlControlsGallery/ControlPages/DataGridPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/DataGridPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
@@ -14,9 +14,11 @@ namespace AppUIBasics.ControlPages
         private async void LaunchToolkitButton_Click(object sender, RoutedEventArgs e)
         {
             // Set the recommended app
-            var options = new Windows.System.LauncherOptions();
-            options.PreferredApplicationPackageFamilyName = "Microsoft.UWPCommunityToolkitSampleApp_8wekyb3d8bbwe";
-            options.PreferredApplicationDisplayName = "Windows Community Toolkit";
+            var options = new Windows.System.LauncherOptions
+            {
+                PreferredApplicationPackageFamilyName = "Microsoft.UWPCommunityToolkitSampleApp_8wekyb3d8bbwe",
+                PreferredApplicationDisplayName = "Windows Community Toolkit"
+            };
 
             await Windows.System.Launcher.LaunchUriAsync(new Uri("uwpct://controls?sample=datagrid"), options);
         }

--- a/XamlControlsGallery/ControlPages/ItemsRepeaterPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ItemsRepeaterPage.xaml.cs
@@ -43,24 +43,28 @@ namespace AppUIBasics.ControlPages
             BarItems.Add(new Bar(25, this.MaxLength));
             BarItems.Add(new Bar(175, this.MaxLength));
 
-            List<object> basicData = new List<object>();
-            basicData.Add(64);
-            basicData.Add("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.");
-            basicData.Add(128);
-            basicData.Add("Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.");
-            basicData.Add(256);
-            basicData.Add("Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.");
-            basicData.Add(512);
-            basicData.Add("Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.");
-            basicData.Add(1024);
+            List<object> basicData = new List<object>
+            {
+                64,
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+                128,
+                "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+                256,
+                "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
+                512,
+                "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+                1024
+            };
             MixedTypeRepeater.ItemsSource = basicData;
 
-            List<NestedCategory> nestedCategories = new List<NestedCategory>();
+            List<NestedCategory> nestedCategories = new List<NestedCategory>
+            {
+                new NestedCategory("Fruits", GetFruits()),
+                new NestedCategory("Vegetables", GetVegetables()),
+                new NestedCategory("Grains", GetGrains()),
+                new NestedCategory("Proteins", GetProteins())
+            };
 
-            nestedCategories.Add(new NestedCategory("Fruits", GetFruits()));
-            nestedCategories.Add(new NestedCategory("Vegetables", GetVegetables()));
-            nestedCategories.Add(new NestedCategory("Grains", GetGrains()));
-            nestedCategories.Add(new NestedCategory("Proteins", GetProteins()));
 
             outerRepeater.ItemsSource = nestedCategories;
 

--- a/XamlControlsGallery/ControlPages/ItemsRepeaterPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ItemsRepeaterPage.xaml.cs
@@ -101,7 +101,7 @@ namespace AppUIBasics.ControlPages
 
         private ObservableCollection<string> GetVegetables()
         {
-            return new ObservableCollection<string>{"Broccoli","Spinach","Sweet potato","Cauliflower","Onion", "Brussel sprouts","Carrots"};
+            return new ObservableCollection<string>{"Broccoli","Spinach","Sweet potato","Cauliflower","Onion", "Brussels sprouts","Carrots"};
         }
         private ObservableCollection<string> GetGrains()
         {
@@ -519,10 +519,7 @@ namespace AppUIBasics.ControlPages
                 inner.AddRange(collection);
             }
 
-            if (CollectionChanged != null)
-            {
-                CollectionChanged(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
-            }
+            CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
         }
 
         #region IReadOnlyList<T>

--- a/XamlControlsGallery/ControlPages/NumberBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/NumberBoxPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿//*********************************************************
+//*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
 // THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
@@ -24,14 +24,18 @@ namespace AppUIBasics.ControlPages
 
         private void SetNumberBoxNumberFormatter()
         {
-            IncrementNumberRounder rounder = new IncrementNumberRounder();
-            rounder.Increment = 0.25;
-            rounder.RoundingAlgorithm = RoundingAlgorithm.RoundHalfUp;
+            IncrementNumberRounder rounder = new IncrementNumberRounder
+            {
+                Increment = 0.25,
+                RoundingAlgorithm = RoundingAlgorithm.RoundHalfUp
+            };
 
-            DecimalFormatter formatter = new DecimalFormatter();
-            formatter.IntegerDigits = 1;
-            formatter.FractionDigits = 2;
-            formatter.NumberRounder = rounder;
+            DecimalFormatter formatter = new DecimalFormatter
+            {
+                IntegerDigits = 1,
+                FractionDigits = 2,
+                NumberRounder = rounder
+            };
             FormattedNumberBox.NumberFormatter = formatter;
         }
 

--- a/XamlControlsGallery/ControlPages/ProgressBarPage.xaml
+++ b/XamlControlsGallery/ControlPages/ProgressBarPage.xaml
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
 //*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
@@ -46,8 +46,8 @@
             <StackPanel x:Name="Control2" Orientation="Horizontal">
                 <muxc:ProgressBar Width="130" x:Name="ProgressBar2"/>
                 <TextBlock x:Name="Control2Output" Style="{ThemeResource OutputTextBlockStyle}" Width="60" TextAlignment="Center" />
-                <TextBlock x:Name="ProgresLabel"  Text="Progress" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                <muxc:NumberBox x:Name="ProgressValue" AutomationProperties.LabeledBy="{Binding ElementName=ProgresLabel}" Minimum="0" Maximum="100" SpinButtonPlacementMode="Inline" ValueChanged="ProgressValue_ValueChanged"/>
+                <TextBlock x:Name="ProgressLabel"  Text="Progress" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                <muxc:NumberBox x:Name="ProgressValue" AutomationProperties.LabeledBy="{Binding ElementName=ProgressLabel}" Minimum="0" Maximum="100" SpinButtonPlacementMode="Inline" ValueChanged="ProgressValue_ValueChanged"/>
             </StackPanel>
             <local:ControlExample.Xaml>
                 <x:String>

--- a/XamlControlsGallery/ControlPages/PullToRefreshPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/PullToRefreshPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using AppUIBasics.Common;
+using AppUIBasics.Common;
 using System;
 using System.Collections.ObjectModel;
 using Windows.Foundation;
@@ -76,12 +76,14 @@ namespace AppUIBasics.ControlPages
                 rv2.Content = ptrImage;
                 rc2.Visualizer = rv2;
 
-                ListView lv2 = new ListView();
-                lv2.Width = 200;
-                lv2.Height = 200;
-                lv2.BorderThickness = new Thickness(1);
-                lv2.HorizontalAlignment = HorizontalAlignment.Center;
-                lv2.BorderBrush = (Brush)Application.Current.Resources["TextControlBorderBrush"];
+                ListView lv2 = new ListView
+                {
+                    Width = 200,
+                    Height = 200,
+                    BorderThickness = new Thickness(1),
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    BorderBrush = (Brush)Application.Current.Resources["TextControlBorderBrush"]
+                };
 
 
                 rc2.Content = lv2;

--- a/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
@@ -40,8 +40,10 @@ namespace AppUIBasics.ControlPages
             CommandBarFlyout myFlyout = sender as CommandBarFlyout;
             if (myFlyout.Target == REBCustom)
             {
-                AppBarButton myButton = new AppBarButton();
-                myButton.Command = new StandardUICommand(StandardUICommandKind.Share);
+                AppBarButton myButton = new AppBarButton
+                {
+                    Command = new StandardUICommand(StandardUICommandKind.Share)
+                };
                 myFlyout.PrimaryCommands.Add(myButton);
             }
         }
@@ -49,10 +51,10 @@ namespace AppUIBasics.ControlPages
         private async void OpenButton_Click(object sender, RoutedEventArgs e)
         {
             // Open a text file.
-            Windows.Storage.Pickers.FileOpenPicker open =
-                new Windows.Storage.Pickers.FileOpenPicker();
-            open.SuggestedStartLocation =
-                Windows.Storage.Pickers.PickerLocationId.DocumentsLibrary;
+            Windows.Storage.Pickers.FileOpenPicker open = new Windows.Storage.Pickers.FileOpenPicker
+            {
+                SuggestedStartLocation = Windows.Storage.Pickers.PickerLocationId.DocumentsLibrary
+            };
             open.FileTypeFilter.Add(".rtf");
 
             Windows.Storage.StorageFile file = await open.PickSingleFileAsync();
@@ -70,8 +72,10 @@ namespace AppUIBasics.ControlPages
 
         private async void SaveButton_Click(object sender, RoutedEventArgs e)
         {
-            FileSavePicker savePicker = new FileSavePicker();
-            savePicker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
+            FileSavePicker savePicker = new FileSavePicker
+            {
+                SuggestedStartLocation = PickerLocationId.DocumentsLibrary
+            };
 
             // Dropdown of file types the user can save the file as
             savePicker.FileTypeChoices.Add("Rich Text", new List<string>() { ".rtf" });

--- a/XamlControlsGallery/ControlPages/TabViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/TabViewPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Controls;
@@ -51,10 +51,11 @@ namespace AppUIBasics.ControlPages
 
         private TabViewItem CreateNewTab(int index)
         {
-            TabViewItem newItem = new TabViewItem();
-
-            newItem.Header = $"Document {index}";
-            newItem.IconSource = new Microsoft.UI.Xaml.Controls.SymbolIconSource() { Symbol = Symbol.Document };
+            TabViewItem newItem = new TabViewItem
+            {
+                Header = $"Document {index}",
+                IconSource = new Microsoft.UI.Xaml.Controls.SymbolIconSource() { Symbol = Symbol.Document }
+            };
 
             // The content of the tab is often a frame that contains a page, though it could be any UIElement.
             Frame frame = new Frame();
@@ -91,9 +92,11 @@ namespace AppUIBasics.ControlPages
 
         private MyData CreateNewMyData(int index)
         {
-            var newData = new MyData();
-            newData.DataHeader = $"MyData Doc {index}";
-            newData.DataIconSource = new Microsoft.UI.Xaml.Controls.SymbolIconSource() { Symbol = Symbol.Placeholder };
+            var newData = new MyData
+            {
+                DataHeader = $"MyData Doc {index}",
+                DataIconSource = new Microsoft.UI.Xaml.Controls.SymbolIconSource() { Symbol = Symbol.Placeholder }
+            };
 
             Frame frame = new Frame();
 

--- a/XamlControlsGallery/SamplePages/SamplePage2.xaml.cs
+++ b/XamlControlsGallery/SamplePages/SamplePage2.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Windows.Foundation.Metadata;
+using Windows.Foundation.Metadata;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media.Animation;
 using Windows.UI.Xaml.Navigation;
@@ -36,8 +36,7 @@ namespace AppUIBasics.SamplePages
 
         private void AddContentPanelAnimations()
         {
-            ContentPanel.Transitions = new TransitionCollection();
-            ContentPanel.Transitions.Add(new EntranceThemeTransition());
+            ContentPanel.Transitions = new TransitionCollection {new EntranceThemeTransition()};
         }
     }
 }


### PR DESCRIPTION
This PR resolves all violations of the following rules:

- IDE0017: Use object initializers
- IDE0028: Use collection initializers

Two new violations of rules IDE0018 & IDE1005 were resolved.

Two spelling mistake regressions were also reapplied.

## Description
### IDE0017: Use object initializers

Recommendation:

> Both object and collection initializers should be used, regardless of how many elements are being set.

Rationale: https://styleascode.net/ID/IDE0017

Instances resolved: 20

### IDE0028: Use collection initializers

Recommendation:

> Both object and collection initializers should be used, regardless of how many elements are being set.

Rationale: https://styleascode.net/ID/IDE0028

Instances resolved: 3

## Motivation and Context
See #331 & #363.

## How Has This Been Tested?
Tests were not run. Solution does compile & run without errors.

## Types of changes
- [X] Code quality
