### PR TITLE
Fix missing Toggle Theme button

### DIFF
--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
@@ -41,7 +41,6 @@ namespace AppUIBasics
         public VirtualKey ArrowKey;
 
         private RootFrameNavigationHelper _navHelper;
-        private PageHeader _header;
         private bool _isGamePadConnected;
         private bool _isKeyboardConnected;
         private Microsoft.UI.Xaml.Controls.NavigationViewItem _allControlsMenuItem;
@@ -66,7 +65,7 @@ namespace AppUIBasics
         {
             get
             {
-                return _header ?? (_header = UIHelper.GetDescendantsOfType<PageHeader>(NavigationViewControl).FirstOrDefault());
+                return UIHelper.GetDescendantsOfType<PageHeader>(NavigationViewControl).FirstOrDefault();
             }
         }
 


### PR DESCRIPTION
Fix the missing Toggle Theme button. We were looking up the PageHeader in the tree and caching it. However, there are multiple PageHeaders - one in RootPage, NewControls and AllControls pages. Depending on the timing, we could end up caching the wrong one and never update it which caused us to be toggling visibility on the wrong page. Removing the cache and always getting the one in the tree fixes the issue.