### PR TITLE
Fix faulty RadialGradientBrush sample code

### DIFF
--- a/XamlControlsGallery/ControlPagesSampleCode/Brushes/RadialGradientBrushSample_xaml.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/Brushes/RadialGradientBrushSample_xaml.txt
@@ -3,7 +3,8 @@
         <media:RadialGradientBrush
                 MappingMode="$(MappingMode)"
                 Center="$(CenterX),$(CenterY)"
-                RadiusX="$(RadiusX),$(RadiusY)"
+                RadiusX="$(RadiusX)"
+                RadiusY="$(RadiusY)"
                 GradientOrigin="$(OriginX),$(OriginY)"
                 SpreadMethod="$(SpreadMethod)">
             <GradientStop Color="Yellow" Offset="0.0" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The current API of RadialGradientBrush is RadiusX and RadiusY. The sample however says that RadiusX is a point, which would cause compiler errors.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Keep sample up to date.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
