### PR TITLE
Clean up page navigation animations

### DIFF
--- a/XamlControlsGallery/ControlExample.xaml
+++ b/XamlControlsGallery/ControlExample.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+<UserControl
     x:Class="AppUIBasics.ControlExample"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -47,15 +47,6 @@
                 </VisualState>
             </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
-
-        <Interactivity:Interaction.Behaviors>
-            <Core:EventTriggerBehavior EventName="Loaded">
-                <Media:ControlStoryboardAction Storyboard="{StaticResource PopInStoryboard}" />
-            </Core:EventTriggerBehavior>
-            <Core:EventTriggerBehavior EventName="Unloaded">
-                <Media:ControlStoryboardAction Storyboard="{StaticResource PopOutStoryboard}" />
-            </Core:EventTriggerBehavior>
-        </Interactivity:Interaction.Behaviors>
 
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />

--- a/XamlControlsGallery/ItemPage.xaml
+++ b/XamlControlsGallery/ItemPage.xaml
@@ -21,14 +21,6 @@
     x:Name="pageRoot"
     mc:Ignorable="d">
 
-    <Page.Resources>
-        <Storyboard x:Name="PopOutStoryboard">
-            <PopOutThemeAnimation SpeedRatio="2" TargetName="seeAlsoPanel" />
-        </Storyboard>
-        <Storyboard x:Name="PopInStoryboard">
-            <PopInThemeAnimation FromVerticalOffset="150" SpeedRatio=".3" TargetName="seeAlsoPanel" />
-        </Storyboard>
-    </Page.Resources>
 
     <!--
         This grid acts as a root panel for the page that defines two rows:

--- a/XamlControlsGallery/ItemPage.xaml.cs
+++ b/XamlControlsGallery/ItemPage.xaml.cs
@@ -160,11 +160,11 @@ namespace AppUIBasics
                 NavigationRootPage.Current.NavigationView.Header = item?.Title;
                 if (item.IsNew && NavigationRootPage.Current.CheckNewControlSelected())
                 {
-                    PlayConnectedAnimation();
+                    //PlayConnectedAnimation();
                     return;
                 }
 
-                PlayConnectedAnimation();
+                //PlayConnectedAnimation();
             }
 
             base.OnNavigatedTo(e);

--- a/XamlControlsGallery/ItemPage.xaml.cs
+++ b/XamlControlsGallery/ItemPage.xaml.cs
@@ -158,37 +158,9 @@ namespace AppUIBasics
                 }
 
                 NavigationRootPage.Current.NavigationView.Header = item?.Title;
-                if (item.IsNew && NavigationRootPage.Current.CheckNewControlSelected())
-                {
-                    //PlayConnectedAnimation();
-                    return;
-                }
-
-                //PlayConnectedAnimation();
             }
 
             base.OnNavigatedTo(e);
-        }
-
-        void PlayConnectedAnimation()
-        {
-            if (NavigationRootPage.Current.PageHeader != null)
-            {
-                var connectedAnimation = ConnectedAnimationService.GetForCurrentView().GetAnimation("controlAnimation");
-
-                if (connectedAnimation != null)
-                {
-                    var target = NavigationRootPage.Current.PageHeader.TitlePanel;
-
-                    // Setup the "basic" configuration if the API is present. 
-                    if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 7))
-                    {
-                        connectedAnimation.Configuration = new BasicConnectedAnimationConfiguration();
-                    }
-
-                    connectedAnimation.TryStart(target, new UIElement[] { descriptionText });
-                }
-            }
         }
 
         protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
@@ -202,14 +174,6 @@ namespace AppUIBasics
         {
             NavigationRootPage.Current.PageHeader.TopCommandBar.Visibility = Visibility.Collapsed;
             NavigationRootPage.Current.PageHeader.ToggleThemeAction = null;
-
-            // Disable temporarily while investigating this crash.
-            //Reverse Connected Animation
-            //if (e.SourcePageType != typeof(ItemPage))
-            //{
-            //    var target = NavigationRootPage.Current.PageHeader.TitlePanel;
-            //    ConnectedAnimationService.GetForCurrentView().PrepareToAnimate("controlAnimation", target);
-            //}
 
             // We use reflection to call the OnNavigatedFrom function the user leaves this page
             // See this PR for more information: https://github.com/microsoft/Xaml-Controls-Gallery/pull/145

--- a/XamlControlsGallery/ItemsPageBase.cs
+++ b/XamlControlsGallery/ItemsPageBase.cs
@@ -63,7 +63,7 @@ namespace AppUIBasics
                 //gridView.PrepareConnectedAnimation("controlAnimation", item, "controlRoot");
             }
 
-            this.Frame.Navigate(typeof(ItemPage), _itemId);
+            this.Frame.Navigate(typeof(ItemPage), _itemId, new DrillInNavigationTransitionInfo());
         }
 
         protected void OnItemGridViewKeyDown(object sender, KeyRoutedEventArgs e)

--- a/XamlControlsGallery/ItemsPageBase.cs
+++ b/XamlControlsGallery/ItemsPageBase.cs
@@ -1,4 +1,4 @@
-﻿//*********************************************************
+//*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
 // THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
@@ -60,7 +60,7 @@ namespace AppUIBasics
 
             if (gridView.ContainerFromItem(item) is GridViewItem)
             {
-                gridView.PrepareConnectedAnimation("controlAnimation", item, "controlRoot");
+                //gridView.PrepareConnectedAnimation("controlAnimation", item, "controlRoot");
             }
 
             this.Frame.Navigate(typeof(ItemPage), _itemId);

--- a/XamlControlsGallery/ItemsPageBase.cs
+++ b/XamlControlsGallery/ItemsPageBase.cs
@@ -58,11 +58,6 @@ namespace AppUIBasics
 
             _itemId = item.UniqueId;
 
-            if (gridView.ContainerFromItem(item) is GridViewItem)
-            {
-                //gridView.PrepareConnectedAnimation("controlAnimation", item, "controlRoot");
-            }
-
             this.Frame.Navigate(typeof(ItemPage), _itemId, new DrillInNavigationTransitionInfo());
         }
 
@@ -96,19 +91,6 @@ namespace AppUIBasics
                     if (NavigationRootPage.Current.IsFocusSupported)
                     {
                         ((GridViewItem)gridView.ContainerFromItem(item))?.Focus(FocusState.Programmatic);
-                    }
-
-                    ConnectedAnimation animation = ConnectedAnimationService.GetForCurrentView().GetAnimation("controlAnimation");
-
-                    if (animation != null)
-                    {
-                        // Setup the "basic" configuration if the API is present. 
-                        if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 7))
-                        {
-                            animation.Configuration = new BasicConnectedAnimationConfiguration();
-                        }
-
-                        await gridView.TryStartConnectedAnimationAsync(animation, item, "controlRoot");
                     }
                 }
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This change removes several competing animations when the user navigates between pages. This change removes the connected animations between the GridView and each page, the custom animations on **each individual sample** and updates the page navigation transition to use DrillIn, which is consistent with the [animation guidance](https://docs.microsoft.com/en-us/windows/uwp/design/motion/page-transitions). 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #423 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manual testing.

## Screenshots (if appropriate):

**Before**:
![XCGAnimation_Before](https://user-images.githubusercontent.com/25991996/81367752-e76cf280-90a2-11ea-9773-b19a0d404385.gif)

**After**:
![XCGAnimation_After](https://user-images.githubusercontent.com/25991996/81367742-e1771180-90a2-11ea-92b4-c565565755f7.gif)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
