### PR TITLE
Fix bug where the first radiobutton wouldn't be checked on page start

### DIFF
--- a/XamlControlsGallery/ControlPages/RadioButtonPage.xaml
+++ b/XamlControlsGallery/ControlPages/RadioButtonPage.xaml
@@ -47,13 +47,11 @@
             <StackPanel x:Name="Control2" Grid.Row="4">
                 <StackPanel>
                 </StackPanel>
-                    <muxc:RadioButtons MaxColumns="4" Header="Background" SelectedIndex="3">
+                    <muxc:RadioButtons MaxColumns="4" Header="Background" SelectedIndex="2">
                         <RadioButton Content="Green" Tag="Green"
                                 Checked="BGRadioButton_Checked" />
                         <RadioButton Content="Yellow" Tag="Yellow" 
                                 Checked="BGRadioButton_Checked" Margin="8,0"/>
-                        <RadioButton Content="Blue" Tag="Blue"
-                                Checked="BGRadioButton_Checked" />
                         <RadioButton Content="White" Tag="White"
                                 Checked="BGRadioButton_Checked" Margin="8,0"/>
                     </muxc:RadioButtons>

--- a/XamlControlsGallery/ControlPages/RadioButtonPage.xaml
+++ b/XamlControlsGallery/ControlPages/RadioButtonPage.xaml
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
 //*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
@@ -48,13 +48,15 @@
                 <StackPanel>
                     <ScrollViewer VerticalScrollMode="Disabled" HorizontalScrollMode="Auto"
                             HorizontalScrollBarVisibility="Hidden">
-                        <muxc:RadioButtons MaxColumns="4" Header="Background">
-                            <RadioButton Content="Green" Tag="Green" Checked="BGRadioButton_Checked" />
+                        <muxc:RadioButtons MaxColumns="4" Header="Background" SelectedIndex="3">
+                            <RadioButton Content="Green" Tag="Green"
+                                    Checked="BGRadioButton_Checked" />
                             <RadioButton Content="Yellow" Tag="Yellow" 
                                     Checked="BGRadioButton_Checked" Margin="8,0"/>
-                            <RadioButton Content="Blue" Tag="Blue" Checked="BGRadioButton_Checked" />
-                            <RadioButton Content="White" Tag="White" Checked="BGRadioButton_Checked"
-                                    IsChecked="True" Margin="8,0"/>
+                            <RadioButton Content="Blue" Tag="Blue"
+                                    Checked="BGRadioButton_Checked" />
+                            <RadioButton Content="White" Tag="White"
+                                    Checked="BGRadioButton_Checked" Margin="8,0"/>
                         </muxc:RadioButtons>
                     </ScrollViewer>
                 </StackPanel>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As the title says. Instead of using the checked property of the individual RadioButton items, we use selectedIndex.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #445 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

@stmoy @ranjeshj Should the is checked work in that scenario or is it expected that it didn't work previously (to this PR)? Could this be an issue with the RadioButtons control?