### PR TITLE
Fix issue with the related controls section overlapping

### DIFF
--- a/XamlControlsGallery/ItemPage.xaml
+++ b/XamlControlsGallery/ItemPage.xaml
@@ -69,7 +69,6 @@
                         <Setter Target="DocumentationPanel.(Grid.ColumnSpan)" Value="1" />
 
                         <Setter Target="RelatedControlsPanel.(Grid.Row)" Value="0" />
-                        <Setter Target="RelatedControlsPanel.(Grid.RowSpan)" Value="3" />
                         <Setter Target="RelatedControlsPanel.(Grid.Column)" Value="2" />
                         <Setter Target="RelatedControlsPanel.(Grid.ColumnSpan)" Value="1" />
 
@@ -93,7 +92,6 @@
                         <Setter Target="DocumentationPanel.(Grid.ColumnSpan)" Value="1" />
 
                         <Setter Target="RelatedControlsPanel.(Grid.Row)" Value="0" />
-                        <Setter Target="RelatedControlsPanel.(Grid.RowSpan)" Value="3" />
                         <Setter Target="RelatedControlsPanel.(Grid.Column)" Value="2" />
                         <Setter Target="RelatedControlsPanel.(Grid.ColumnSpan)" Value="1" />
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The RowSpan was set to 3, resulting in the overlap. Without that, the RelatedControls section does not overlaps with the feedback section.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #444 , Fixes #450 , Fixes #451 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually
## Screenshots (if appropriate):
Before:
![image](https://user-images.githubusercontent.com/16122379/82881707-53bf7100-9f40-11ea-86a0-21d159d22c26.png)

After:
![image](https://user-images.githubusercontent.com/16122379/82881625-38546600-9f40-11ea-8f2f-b4d08fa72c5b.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
