### PR TITLE
Hide unused scrollbars in RadioButtonsPage

### DIFF
--- a/XamlControlsGallery/ControlPages/RadioButtonPage.xaml
+++ b/XamlControlsGallery/ControlPages/RadioButtonPage.xaml
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
 //*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
@@ -46,7 +46,9 @@
                 RelativePanel.Below="Example1">
             <StackPanel x:Name="Control2" Grid.Row="4">
                 <StackPanel>
-                    <ScrollViewer VerticalScrollMode="Disabled" HorizontalScrollMode="Auto"
+                    <ScrollViewer VerticalScrollMode="Disabled"
+                            VerticalScrollBarVisibility="Hidden"
+                            HorizontalScrollMode="Auto"
                             HorizontalScrollBarVisibility="Hidden">
                         <muxc:RadioButtons MaxColumns="4" Header="Background">
                             <RadioButton Content="Green" Tag="Green" Checked="BGRadioButton_Checked" />
@@ -59,7 +61,9 @@
                     </ScrollViewer>
                 </StackPanel>
                 <StackPanel>
-                    <ScrollViewer VerticalScrollMode="Disabled" HorizontalScrollMode="Auto"
+                    <ScrollViewer VerticalScrollMode="Disabled"
+                            VerticalScrollBarVisibility="Hidden"
+                            HorizontalScrollMode="Auto"
                             HorizontalScrollBarVisibility="Hidden">
                         <muxc:RadioButtons MaxColumns="4" Header="BorderBrush">
                             <RadioButton Content="Green" Tag="Green"

--- a/XamlControlsGallery/ControlPages/RadioButtonPage.xaml
+++ b/XamlControlsGallery/ControlPages/RadioButtonPage.xaml
@@ -46,36 +46,23 @@
                 RelativePanel.Below="Example1">
             <StackPanel x:Name="Control2" Grid.Row="4">
                 <StackPanel>
-                    <ScrollViewer VerticalScrollMode="Disabled"
-                            VerticalScrollBarVisibility="Hidden"
-                            HorizontalScrollMode="Auto"
-                            HorizontalScrollBarVisibility="Hidden">
-                        <muxc:RadioButtons MaxColumns="4" Header="Background">
-                            <RadioButton Content="Green" Tag="Green" Checked="BGRadioButton_Checked" />
-                            <RadioButton Content="Yellow" Tag="Yellow" 
-                                    Checked="BGRadioButton_Checked" Margin="8,0"/>
-                            <RadioButton Content="Blue" Tag="Blue" Checked="BGRadioButton_Checked" />
-                            <RadioButton Content="White" Tag="White" Checked="BGRadioButton_Checked"
-                                    IsChecked="True" Margin="8,0"/>
-                        </muxc:RadioButtons>
-                    </ScrollViewer>
+                    <muxc:RadioButtons MaxColumns="4" Header="Background">
+                        <RadioButton Content="Green" Tag="Green" Checked="BGRadioButton_Checked" />
+                        <RadioButton Content="Yellow" Tag="Yellow" 
+                                Checked="BGRadioButton_Checked" Margin="8,0"/>
+                        <RadioButton Content="White" Tag="White" Checked="BGRadioButton_Checked"
+                                IsChecked="True" Margin="8,0"/>
+                    </muxc:RadioButtons>
                 </StackPanel>
                 <StackPanel>
-                    <ScrollViewer VerticalScrollMode="Disabled"
-                            VerticalScrollBarVisibility="Hidden"
-                            HorizontalScrollMode="Auto"
-                            HorizontalScrollBarVisibility="Hidden">
-                        <muxc:RadioButtons MaxColumns="4" Header="BorderBrush">
-                            <RadioButton Content="Green" Tag="Green"
-                                    Checked="BorderRadioButton_Checked" />
-                            <RadioButton Content="Yellow" Tag="Yellow"
-                                    Checked="BorderRadioButton_Checked" IsChecked="True" Margin="8,0"/>
-                            <RadioButton Content="Blue" Tag="Blue"
-                                    Checked="BorderRadioButton_Checked" />
-                            <RadioButton Content="White" Tag="White"
-                                    Checked="BorderRadioButton_Checked" Margin="8,0"/>
-                        </muxc:RadioButtons>
-                    </ScrollViewer>
+                    <muxc:RadioButtons MaxColumns="4" Header="BorderBrush">
+                        <RadioButton Content="Green" Tag="Green"
+                                Checked="BorderRadioButton_Checked" />
+                        <RadioButton Content="Yellow" Tag="Yellow"
+                                Checked="BorderRadioButton_Checked" IsChecked="True" Margin="8,0"/>
+                        <RadioButton Content="White" Tag="White"
+                                Checked="BorderRadioButton_Checked" Margin="8,0"/>
+                    </muxc:RadioButtons>
                 </StackPanel>
                 <Border x:Name="Control2Output" BorderThickness="10" BorderBrush="#FFFFD700" Background="#FFFFFFFF"
                         Height="50" Margin="0,10,0,10" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add `VerticalScrollBarVibility=Hidden` to hide the scrollbars.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #455 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually
## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/16122379/83296780-9f4c7600-a1f1-11ea-85ed-d80b627d1a88.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
