### PR TITLE
Update WinUI version to 2.5 prerelease

### DIFF
--- a/XamlControlsGallery/XamlControlsGallery.csproj
+++ b/XamlControlsGallery/XamlControlsGallery.csproj
@@ -30,7 +30,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <EnableTypeInfoReflection>false</EnableTypeInfoReflection>
-    <IsWinUIPrerelease>False</IsWinUIPrerelease>
+    <IsWinUIPrerelease>True</IsWinUIPrerelease>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
     <DebugSymbols>true</DebugSymbols>
@@ -1196,7 +1196,7 @@
       <Version>6.1.9</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
-      <Version>2.4.0</Version>
+      <Version>2.5.0-prerelease.200609001</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed">
       <Version>2.0.0</Version>


### PR DESCRIPTION
Updating WinUI version to latest [2.5 prerelease](https://www.nuget.org/packages/Microsoft.UI.Xaml/2.5.0-prerelease.200609001)