### PR TITLE
Allowing keyboard input for the ScrollViewer

### DIFF
--- a/XamlControlsGallery/ControlPages/ScrollViewerPage.xaml
+++ b/XamlControlsGallery/ControlPages/ScrollViewerPage.xaml
@@ -18,7 +18,7 @@
     <StackPanel>
         <local:ControlExample x:Name="Example1" HeaderText="Content inside of a ScrollViewer.">
 
-            <ScrollViewer x:Name="Control1" Height="270" ZoomMode="Disabled" IsVerticalScrollChainingEnabled="True"
+            <ScrollViewer x:Name="Control1" Height="270" ZoomMode="Disabled" IsTabStop="True" IsVerticalScrollChainingEnabled="True"
                     ManipulationCompleted="Control1_ManipulationCompleted" VerticalAlignment="Top"
                     HorizontalAlignment="Left">
                 <Image Source="ms-appx:///Assets/SampleMedia/cliff.jpg" Stretch="None" HorizontalAlignment="Left"
@@ -103,7 +103,7 @@
             <local:ControlExample.Xaml>
                 <x:String xml:space="preserve">
 &lt;ScrollViewer Height="270" ZoomMode="$(ZoomMode)"
-            IsVerticalScrollChainingEnabled="True"
+            IsTabStop="True" IsVerticalScrollChainingEnabled="True"
             ManipulationCompleted="Control1_ManipulationCompleted"
             HorizontalScrollMode="$(HorizontalScrollMode)" HorizontalScrollBarVisibility="$(HorizontalScrollBarVisibility)"
             VerticalScrollMode="$(VerticalScrollMode)" VerticalScrollBarVisibility="$(VerticalScrollBarVisibility)"&gt;


### PR DESCRIPTION
User could not use Ctrl +/- to zoom in and out of the ScrollViewer in the ScrollViewer sample page.
Arrows, PageUp, PageDown, etc did not work either to scroll its Image. The IsTabStop=True setting allows the control to take focus & keyboard input works now.

This is for internal bug 26337703 - Cannot set focus to ScrollViewer.

## Testing
Ad-hoc testing of the ScrollViewer sample page.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
