### PR TITLE
Prevent crashes on ImplicitAnimation page by checking for NaN

### DIFF
--- a/XamlControlsGallery/ControlPages/ImplicitTransitionPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ImplicitTransitionPage.xaml.cs
@@ -46,7 +46,7 @@ namespace AppUIBasics.ControlPages
 
             RotationRectangle.CenterPoint = new System.Numerics.Vector3((float)RotationRectangle.ActualWidth / 2, (float)RotationRectangle.ActualHeight / 2, 0f);
 
-            RotationRectangle.Rotation = (float)EnsureValueIsNumber(RotationNumberBox);
+            RotationRectangle.Rotation = EnsureValueIsNumber(RotationNumberBox);
         }
         private void ScaleButton_Click(object sender, RoutedEventArgs e)
         {
@@ -67,7 +67,7 @@ namespace AppUIBasics.ControlPages
             }
             else
             {
-                customValue = (float)EnsureValueIsNumber(ScaleNumberBox);
+                customValue = EnsureValueIsNumber(ScaleNumberBox);
             }
 
             ScaleRectangle.Scale = new Vector3(customValue);
@@ -92,7 +92,7 @@ namespace AppUIBasics.ControlPages
             }
             else
             {
-                customValue = (float)EnsureValueIsNumber(TranslationNumberBox);
+                customValue = EnsureValueIsNumber(TranslationNumberBox);
             }
 
             TranslateRectangle.Translation = new Vector3(customValue);
@@ -137,13 +137,13 @@ namespace AppUIBasics.ControlPages
             }
         }
 
-        private double EnsureValueIsNumber(NumberBox numberBox)
+        private float EnsureValueIsNumber(NumberBox numberBox)
         {
             if(double.IsNaN(numberBox.Value))
             {
                 numberBox.Value = 0;
             }
-            return numberBox.Value;
+            return (float)numberBox.Value;
         }
 
         private void ThemeButton_Click(object sender, RoutedEventArgs e)

--- a/XamlControlsGallery/ControlPages/ImplicitTransitionPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ImplicitTransitionPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls;
 using System;
 using System.Numerics;
 using Windows.Foundation.Metadata;
@@ -35,7 +35,7 @@ namespace AppUIBasics.ControlPages
         {
             // If the implicit animation API is not present, simply no-op. 
             if (!(ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 7))) return;
-            var customValue = OpacityNumberBox.Value;
+            var customValue = EnsureValueIsNumber(OpacityNumberBox);
             OpacityRectangle.Opacity = customValue;
             OpacityValue.Value = customValue;
         }
@@ -46,7 +46,7 @@ namespace AppUIBasics.ControlPages
 
             RotationRectangle.CenterPoint = new System.Numerics.Vector3((float)RotationRectangle.ActualWidth / 2, (float)RotationRectangle.ActualHeight / 2, 0f);
 
-            RotationRectangle.Rotation = (float)RotationNumberBox.Value;
+            RotationRectangle.Rotation = (float)EnsureValueIsNumber(RotationNumberBox);
         }
         private void ScaleButton_Click(object sender, RoutedEventArgs e)
         {
@@ -67,7 +67,7 @@ namespace AppUIBasics.ControlPages
             }
             else
             {
-                customValue = (float)ScaleNumberBox.Value;
+                customValue = (float)EnsureValueIsNumber(ScaleNumberBox);
             }
 
             ScaleRectangle.Scale = new Vector3(customValue);
@@ -92,7 +92,7 @@ namespace AppUIBasics.ControlPages
             }
             else
             {
-                customValue = (float)TranslationNumberBox.Value;
+                customValue = (float)EnsureValueIsNumber(TranslationNumberBox);
             }
 
             TranslateRectangle.Translation = new Vector3(customValue);
@@ -135,6 +135,15 @@ namespace AppUIBasics.ControlPages
             {
                 BrushPresenter.Background = new SolidColorBrush(Windows.UI.Colors.Blue);
             }
+        }
+
+        private double EnsureValueIsNumber(NumberBox numberBox)
+        {
+            if(double.IsNaN(numberBox.Value))
+            {
+                numberBox.Value = 0;
+            }
+            return numberBox.Value;
         }
 
         private void ThemeButton_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The page crashed when setting the opacity and other values in samples on the page since a cleared NumberBox will report double.NaN as its value which is not a valid value for those cases. This is now fixed by wrapping the "get call" and setting the NumberBox value to 0 if its NaN.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #475 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by clearing the NumberBox values and clicking the "set value buttons" on the samples.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
