### PR TITLE
Add override for ButtonBackgroundPointerOver in high contrast

### DIFF
--- a/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml
+++ b/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
 //*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
@@ -49,11 +49,19 @@
                               HorizontalContentAlignment="Stretch" VerticalAlignment="Top">
             <RelativePanel Margin="0,0,0,20" HorizontalAlignment="Stretch">
                 <RelativePanel.Resources>
-                    <Style TargetType="Button">
-                        <Setter Property="BorderThickness" Value="0" />
-                        <Setter Property="Background" Value="Transparent"/>
-                        <Setter Property="Margin" Value="0,0,8,0" />
-                    </Style>
+                    <ResourceDictionary>
+                        <Style TargetType="Button">
+                            <Setter Property="BorderThickness" Value="0" />
+                            <Setter Property="Background" Value="Transparent"/>
+                            <Setter Property="Margin" Value="0,0,8,0" />
+                        </Style>
+                    
+                        <ResourceDictionary.ThemeDictionaries>
+                            <ResourceDictionary x:Key="HighContrast">
+                                <StaticResource x:Key="ButtonBackgroundPointerOver" ResourceKey="SystemColorHighlightColor" />
+                            </ResourceDictionary>
+                        </ResourceDictionary.ThemeDictionaries>
+                    </ResourceDictionary>
                 </RelativePanel.Resources>
                 <Button x:Name="openFileButton" Click="OpenButton_Click" AutomationProperties.Name="Open file" ToolTipService.ToolTip="Open file">
                     <Button.Content>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add theme resource override to highligh buttons in high contrast correctly
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #461
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually:

![gif](https://user-images.githubusercontent.com/16122379/86062730-a3c2b380-ba69-11ea-8a57-a698169bc7cf.gif)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
