### PR TITLE
Fix issue with ConnectedAnimation crashing due to selection being null

### DIFF
--- a/XamlControlsGallery/ControlPages/ConnectedAnimationPage.xaml
+++ b/XamlControlsGallery/ControlPages/ConnectedAnimationPage.xaml
@@ -29,8 +29,8 @@
                     <Button Content="Navigate" Click="NavigateButton_Click" HorizontalAlignment="Stretch" />
 
                     <contract7Present:TextBlock Text="Configurations" Style="{ThemeResource BaseTextBlockStyle}" Margin="0,6" />
-                    <muxccontract7Present:RadioButtons x:Name="ConfigurationPanel">
-                        <contract7Present:RadioButton Content="Default" IsChecked="True" />
+                    <muxccontract7Present:RadioButtons x:Name="ConfigurationPanel" SelectedIndex="0">
+                        <contract7Present:RadioButton Content="Default" />
                         <contract7Present:RadioButton Content="Gravity" />
                         <contract7Present:RadioButton Content="Direct" />
                         <contract7Present:RadioButton Content="Basic" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The sample crashed as on a freshly loaded page, the selecteditem of the RadioButtons was null. By setting SelectedIndex in XAML, the RadioButtons now always know the selected item, and thus fixing the crash.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #494 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Opened ConnectedAnimationPage and pressed the "Navigate" button. App did not crash.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
