### PR TITLE
Fix issue with state being lost when switching between compact/standa…

### DIFF
--- a/XamlControlsGallery/ControlPages/CompactSizingPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/CompactSizingPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media.Animation;
 using AppUIBasics.SamplePages;
@@ -20,12 +20,28 @@ namespace AppUIBasics.ControlPages
 
         private void Standard_Checked(object sender, RoutedEventArgs e)
         {
+            var oldPage = ContentFrame.Content as SampleCompactSizingPage;
+
             ContentFrame.Navigate(typeof(SampleStandardSizingPage), null, new SuppressNavigationTransitionInfo());
+
+            if (oldPage != null)
+            {
+                var page = ContentFrame.Content as SampleStandardSizingPage;
+                page.CopyState(oldPage);
+            }
         }
 
         private void Compact_Checked(object sender, RoutedEventArgs e)
         {
+            var oldPage = ContentFrame.Content as SampleStandardSizingPage;
+
             ContentFrame.Navigate(typeof(SampleCompactSizingPage), null, new SuppressNavigationTransitionInfo());
+
+            if (oldPage != null)
+            {
+                var page = ContentFrame.Content as SampleCompactSizingPage;
+                page.CopyState(oldPage);
+            }
         }
     }
 }

--- a/XamlControlsGallery/SamplePages/SampleCompactSizingPage.xaml
+++ b/XamlControlsGallery/SamplePages/SampleCompactSizingPage.xaml
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
 //*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
@@ -24,11 +24,11 @@
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <StackPanel Spacing="4">
             <TextBlock x:Name="HeaderBlock" Text="Compact Size" FontSize="18"/>
-            <TextBox Header="First Name:" x:Name="txtfirstName" />
-            <TextBox Header="Last Name:" x:Name="txtLastName"  />
-            <PasswordBox Header="Password:" />
-            <PasswordBox Header="Confirm Password:" />
-            <DatePicker Header="Pick a date" />
+            <TextBox Header="First Name:" x:Name="firstName" />
+            <TextBox Header="Last Name:" x:Name="lastName"  />
+            <PasswordBox Header="Password:" x:Name="password"/>
+            <PasswordBox Header="Confirm Password:" x:Name="confirmPassword"/>
+            <DatePicker Header="Pick a date" x:Name="chosenDate"/>
         </StackPanel>
     </Grid>
 </Page>

--- a/XamlControlsGallery/SamplePages/SampleCompactSizingPage.xaml.cs
+++ b/XamlControlsGallery/SamplePages/SampleCompactSizingPage.xaml.cs
@@ -4,9 +4,24 @@ namespace AppUIBasics.SamplePages
 {
     public sealed partial class SampleCompactSizingPage : Page
     {
+        public TextBox FirstName => firstName;
+        public TextBox LastName => lastName;
+        public PasswordBox Password => password;
+        public PasswordBox ConfirmPassword => confirmPassword;
+        public DatePicker ChosenDate => chosenDate;
+
         public SampleCompactSizingPage()
         {
             this.InitializeComponent();
+        }
+
+        public void CopyState(SampleStandardSizingPage page)
+        {
+            FirstName.Text = page.FirstName.Text;
+            LastName.Text = page.LastName.Text;
+            Password.Password = page.Password.Password;
+            ConfirmPassword.Password = page.ConfirmPassword.Password;
+            ChosenDate.Date = page.ChosenDate.Date;
         }
     }
 }

--- a/XamlControlsGallery/SamplePages/SampleStandardSizingPage.xaml
+++ b/XamlControlsGallery/SamplePages/SampleStandardSizingPage.xaml
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
 //*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
@@ -19,12 +19,12 @@
 
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <StackPanel x:Name="CompactPanel" Spacing="16">
-            <TextBlock x:Name="HeaderBlock" Text="Standard Size" FontSize="18"/>
-            <TextBox Header="First Name:" x:Name="txtfirstName" />
-            <TextBox Header="Last Name:" x:Name="txtLastName"  />
-            <PasswordBox Header="Password:" />
-            <PasswordBox Header="Confirm Password:" />
-            <DatePicker Header="Pick a date" />
+            <TextBlock x:Name="HeaderBlock" Text="Compact Size" FontSize="18"/>
+            <TextBox Header="First Name:" x:Name="firstName" />
+            <TextBox Header="Last Name:" x:Name="lastName"  />
+            <PasswordBox Header="Password:" x:Name="password"/>
+            <PasswordBox Header="Confirm Password:" x:Name="confirmPassword"/>
+            <DatePicker Header="Pick a date" x:Name="chosenDate"/>
         </StackPanel>
     </Grid>
 </Page>

--- a/XamlControlsGallery/SamplePages/SampleStandardSizingPage.xaml.cs
+++ b/XamlControlsGallery/SamplePages/SampleStandardSizingPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -17,9 +17,24 @@ namespace AppUIBasics.SamplePages
 {
     public sealed partial class SampleStandardSizingPage : Page
     {
+        public TextBox FirstName => firstName;
+        public TextBox LastName => lastName;
+        public PasswordBox Password => password;
+        public PasswordBox ConfirmPassword => confirmPassword;
+        public DatePicker ChosenDate => chosenDate;
+
         public SampleStandardSizingPage()
         {
             this.InitializeComponent();
+        }
+
+        public void CopyState(SampleCompactSizingPage page)
+        {
+            FirstName.Text = page.FirstName.Text;
+            LastName.Text = page.LastName.Text;
+            Password.Password = page.Password.Password;
+            ConfirmPassword.Password = page.ConfirmPassword.Password;
+            ChosenDate.Date = page.ChosenDate.Date;
         }
     }
 }


### PR DESCRIPTION
…rd sizing in standard sizing page

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When switching pages, the new page looks at the state of the old page, and copies it into its own controls.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #228 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by switching between compact and standard sizing with content being present. The content did get copied over as expected.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
