### PR TITLE
Set focus on first listview on ListView page when page loads

### DIFF
--- a/XamlControlsGallery/ControlPages/ListViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ListViewPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿//*********************************************************
+//*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
 // THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
@@ -39,6 +39,14 @@ namespace AppUIBasics.ControlPages
             this.InitializeComponent();
             // Add first item to inverted list so it's not empty
             AddItemToEnd();
+            BaseExample.Loaded += BaseExample_Loaded;
+        }
+
+        private void BaseExample_Loaded(object sender, RoutedEventArgs e)
+        {
+            // Set focus so the first item of the listview has focus
+            // instead of some item which is not visible on page load
+            BaseExample.Focus(FocusState.Programmatic);
         }
 
         protected override async void OnNavigatedTo(NavigationEventArgs e)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When loading the page, we set the focus to the first listview, resulting in the first item of that listview to be selected.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #332 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by opening page and checking which item is focused.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
