### PR TITLE
Fix issue with groups not having appropriate UIA name

### DIFF
--- a/XamlControlsGallery/NewControlsPage.xaml.cs
+++ b/XamlControlsGallery/NewControlsPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿//*********************************************************
+//*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
 // THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
@@ -81,6 +81,10 @@ namespace AppUIBasics
         public object Key { get; set; }
 
         public string Title { get; set; }
+
+        public override string ToString()
+        {
+            return Title;
+        }
     }
 }
- 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a ToString override which gets used by GridView/Accessibility Insights to provide an appropriate UIA name.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #326 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with accessibility insights
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
