### PR TITLE
Update samples that use the RichEditBox

### DIFF
--- a/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml
+++ b/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml
@@ -163,9 +163,8 @@
                              RelativePanel.Below="openFileButton" 
                              RelativePanel.AlignLeftWithPanel="True" 
                              RelativePanel.AlignRightWithPanel="True" 
-                             TextChanging="Editor_TextChanging"
-                             GotFocus="Editor_GotFocus"
-                             LosingFocus="Editor_LosingFocus"/>
+                             TextChanged="Editor_TextChanged"
+                             GotFocus="Editor_GotFocus"/>
                 <StackPanel Orientation="Horizontal" 
                             RelativePanel.Below="editor" 
                             RelativePanel.AlignLeftWith="editor" 

--- a/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml
+++ b/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml
@@ -149,11 +149,6 @@
                                         <Rectangle Fill="Gray"/>
                                     </Button.Content>
                                 </Button>
-                                <Button Click="ColorButton_Click" AutomationProperties.Name="Black">
-                                    <Button.Content>
-                                        <Rectangle Fill="Black"/>
-                                    </Button.Content>
-                                </Button>
                             </VariableSizedWrapGrid>
                         </Flyout>
                     </muxc:DropDownButton.Flyout>

--- a/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
@@ -24,7 +24,7 @@ namespace AppUIBasics.ControlPages
 {
     public sealed partial class RichEditBoxPage : Page
     {
-        private Color currentColor = Colors.Black;
+        private Color currentColor = Colors.Gray;
 
         public RichEditBoxPage()
         {
@@ -160,18 +160,12 @@ namespace AppUIBasics.ControlPages
         private void Editor_GotFocus(object sender, RoutedEventArgs e)
         {
             editor.Document.GetText(TextGetOptions.UseCrlf, out string currentRawText);
-            if (currentRawText.Length != LastRawTextLength)
-            {
-                // User used cut or paste from action command, skip the event
-                return;
-            }
             
             // reset colors to correct defaults for Focused state
             ITextRange documentRange = editor.Document.GetRange(0, TextConstants.MaxUnitCount);
             SolidColorBrush background = (SolidColorBrush)App.Current.Resources["TextControlBackgroundFocused"];
-            SolidColorBrush foreground = (SolidColorBrush)App.Current.Resources["TextControlForegroundFocused"];
 
-            if (background != null && foreground != null)
+            if (background != null)
             {
                 documentRange.CharacterFormat.BackgroundColor = background.Color;
             }

--- a/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿//*********************************************************
+//*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
 // THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
@@ -24,7 +24,7 @@ namespace AppUIBasics.ControlPages
 {
     public sealed partial class RichEditBoxPage : Page
     {
-        private Color currentColor = Colors.Gray;
+        private Color currentColor = Colors.Green;
 
         public RichEditBoxPage()
         {

--- a/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
@@ -1,4 +1,4 @@
-//*********************************************************
+﻿//*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
 // THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
@@ -25,10 +25,6 @@ namespace AppUIBasics.ControlPages
     public sealed partial class RichEditBoxPage : Page
     {
         private Color currentColor = Colors.Black;
-        // String used to restore the colors when the focus gets reenabled
-        // See #144 for more info https://github.com/microsoft/Xaml-Controls-Gallery/issues/144
-        private string LastFormattedText = "";
-        private int LastRawTextLength = 0;
 
         public RichEditBoxPage()
         {
@@ -175,38 +171,10 @@ namespace AppUIBasics.ControlPages
             SolidColorBrush background = (SolidColorBrush)App.Current.Resources["TextControlBackgroundFocused"];
             SolidColorBrush foreground = (SolidColorBrush)App.Current.Resources["TextControlForegroundFocused"];
 
-            editor.Document.ApplyDisplayUpdates();
-
             if (background != null && foreground != null)
             {
                 documentRange.CharacterFormat.BackgroundColor = background.Color;
             }
-            // saving selection span
-            var caretPosition = editor.Document.Selection.GetIndex(TextRangeUnit.Character) - 1;
-            if(caretPosition <= 0)
-            {
-                // User has not entered text, prevent invalid values and just set index to 1
-                caretPosition = 1;
-            }
-            var selectionLength = editor.Document.Selection.Length;
-            // restoring text styling, unintentionally sets caret position at beginning of text
-            editor.Document.SetText(TextSetOptions.FormatRtf, LastFormattedText);
-            // restoring selection position
-            editor.Document.Selection.SetIndex(TextRangeUnit.Character, caretPosition, false);
-            editor.Document.Selection.SetRange(caretPosition, caretPosition + selectionLength);
-            // Editor might have gained focus because user changed color.
-            // Change selection color
-            // Note that only way to regain with selection containing text is using the change color button
-            editor.Document.Selection.CharacterFormat.ForegroundColor = currentColor;
-        }
-
-        private void Editor_LosingFocus(object sender, RoutedEventArgs e)
-        {
-            // Save text length to determine text length change
-            editor.Document.GetText(TextGetOptions.UseCrlf, out string lastRawText);
-            LastRawTextLength = lastRawText.Length; 
-            
-            editor.Document.GetText(TextGetOptions.FormatRtf, out LastFormattedText);
         }
 
         private void Page_SizeChanged(object sender, SizeChangedEventArgs e)
@@ -244,13 +212,9 @@ namespace AppUIBasics.ControlPages
             }
         }
 
-        private void Editor_TextChanging(object sender, RichEditBoxTextChangingEventArgs e)
+        private void Editor_TextChanged(object sender, RoutedEventArgs e)
         {
-            // Fix bug where selected text would get colored when editor loses focus
-            if (FocusManager.GetFocusedElement() == editor)
-            {
-                editor.Document.Selection.CharacterFormat.ForegroundColor = currentColor;
-            }
+            editor.Document.Selection.CharacterFormat.ForegroundColor = currentColor;
         }
     }
 }

--- a/XamlControlsGallery/ControlPages/SplitButtonPage.xaml
+++ b/XamlControlsGallery/ControlPages/SplitButtonPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page x:Class="AppUIBasics.ControlPages.SplitButtonPage" 
+<Page x:Class="AppUIBasics.ControlPages.SplitButtonPage" 
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
       xmlns:local="using:AppUIBasics"
@@ -22,7 +22,7 @@
                 </Grid.ColumnDefinitions>
 
                 <muxc:SplitButton x:Name="myColorButton" AutomationProperties.Name="Font color" Padding="0" MinHeight="0" MinWidth="0" VerticalAlignment="Top" Click="myColorButton_Click">
-                    <Rectangle x:Name="CurrentColor" Width="{StaticResource SwatchSize}" Height="{StaticResource SwatchSize}" Fill="Gray" Margin="0"/>
+                    <Rectangle x:Name="CurrentColor" Width="{StaticResource SwatchSize}" Height="{StaticResource SwatchSize}" Fill="Green" Margin="0"/>
                     <muxc:SplitButton.Flyout>
                         <Flyout Placement="Bottom">
                             <VariableSizedWrapGrid Orientation="Horizontal" MaximumRowsOrColumns="3">

--- a/XamlControlsGallery/ControlPages/SplitButtonPage.xaml
+++ b/XamlControlsGallery/ControlPages/SplitButtonPage.xaml
@@ -22,7 +22,7 @@
                 </Grid.ColumnDefinitions>
 
                 <muxc:SplitButton x:Name="myColorButton" AutomationProperties.Name="Font color" Padding="0" MinHeight="0" MinWidth="0" VerticalAlignment="Top" Click="myColorButton_Click">
-                    <Rectangle x:Name="CurrentColor" Width="{StaticResource SwatchSize}" Height="{StaticResource SwatchSize}" Fill="Black" Margin="0"/>
+                    <Rectangle x:Name="CurrentColor" Width="{StaticResource SwatchSize}" Height="{StaticResource SwatchSize}" Fill="Gray" Margin="0"/>
                     <muxc:SplitButton.Flyout>
                         <Flyout Placement="Bottom">
                             <VariableSizedWrapGrid Orientation="Horizontal" MaximumRowsOrColumns="3">
@@ -78,11 +78,6 @@
                                         <Rectangle Fill="Gray"/>
                                     </Button.Content>
                                 </Button>
-                                <Button Click="ColorButton_Click" AutomationProperties.Name="Black">
-                                    <Button.Content>
-                                        <Rectangle Fill="Black"/>
-                                    </Button.Content>
-                                </Button>
                             </VariableSizedWrapGrid>
                         </Flyout>
                     </muxc:SplitButton.Flyout>
@@ -90,9 +85,7 @@
 
                 <RichEditBox x:Name="myRichEditBox" Grid.Column="1" MinWidth="240" MinHeight="96" 
                              PlaceholderText="Type something here" 
-                             GotFocus="MyRichEditBox_GotFocus"
-                             LosingFocus="MyRichEditBox_LosingFocus"
-                             TextChanging="MyRichEditBox_TextChanging"/>
+                             TextChanged="MyRichEditBox_TextChanged"/>
             </Grid>
         </local:ControlExample>
 

--- a/XamlControlsGallery/ControlPages/SplitButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/SplitButtonPage.xaml.cs
@@ -8,19 +8,14 @@ namespace AppUIBasics.ControlPages
 {
     public sealed partial class SplitButtonPage : Page
     {
-        private Color currentColor = Colors.Black;
-
-        // String used to restore the colors when the focus gets reenabled
-        // See #144 for more info https://github.com/microsoft/Xaml-Controls-Gallery/issues/144 
-        // (which also applies to this RichEditBox)
-        private string LastFormattedText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, " +
-                "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Tempor commodo ullamcorper a lacus.";
-        private int LastRawTextLength = 0;
+        private Color currentColor = Colors.Gray;
 
         public SplitButtonPage()
         {
             this.InitializeComponent();
-            myRichEditBox.Document.SetText(Windows.UI.Text.TextSetOptions.None,
+
+            myRichEditBox.Document.Selection.CharacterFormat.ForegroundColor = currentColor;
+            myRichEditBox.Document.Selection.SetText(Windows.UI.Text.TextSetOptions.None,
                 "Lorem ipsum dolor sit amet, consectetur adipiscing elit, " +
                 "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Tempor commodo ullamcorper a lacus.");
         }
@@ -53,64 +48,10 @@ namespace AppUIBasics.ControlPages
             currentColor = color;
         }
 
-        private void MyRichEditBox_TextChanging(object sender, RichEditBoxTextChangingEventArgs e)
+        private void MyRichEditBox_TextChanged(object sender, RoutedEventArgs e)
         {
-            // Hitting control+b and similar commands my overwrite the color,
-            // which result to black text on black background when losing focus on dark theme.
-            // Solution: check if text actually changed
-            if (e.IsContentChanging)
-            {
-                myRichEditBox.Document.Selection.CharacterFormat.ForegroundColor = currentColor;
-            }
-        }
-
-
-        private void MyRichEditBox_GotFocus(object sender, RoutedEventArgs e)
-        {
-            myRichEditBox.Document.GetText(TextGetOptions.UseCrlf, out string currentRawText);
-            if (currentRawText.Length != LastRawTextLength)
-            {
-                // User used cut or paste from action command, skip the event
-                return;
-            }
-            // reset colors to correct defaults for Focused state
-            ITextRange documentRange = myRichEditBox.Document.GetRange(0, TextConstants.MaxUnitCount);
-            SolidColorBrush background = (SolidColorBrush)App.Current.Resources["TextControlBackgroundFocused"];
-            SolidColorBrush foreground = (SolidColorBrush)App.Current.Resources["TextControlForegroundFocused"];
-
-            myRichEditBox.Document.ApplyDisplayUpdates();
-
-            if (background != null && foreground != null)
-            {
-                documentRange.CharacterFormat.BackgroundColor = background.Color;
-            }
-            // saving selection span
-            var caretPosition = myRichEditBox.Document.Selection.GetIndex(TextRangeUnit.Character) - 1;
-            if (caretPosition <= 0)
-            {
-                // User has not entered text, prevent invalid values and just set index to 1
-                caretPosition = 1;
-            }
-            var selectionLength = myRichEditBox.Document.Selection.Length;
-            // restoring text styling, unintentionally sets caret position at beginning of text
-            myRichEditBox.Document.SetText(TextSetOptions.FormatRtf, LastFormattedText);
-            // restoring selection position
-            myRichEditBox.Document.Selection.SetIndex(TextRangeUnit.Character, caretPosition, false);
-            myRichEditBox.Document.Selection.SetRange(caretPosition, caretPosition + selectionLength);
-            // Editor might have gained focus because user changed color.
-            // Change selection color
-            // Note that only way to regain with selection containing text is using the change color button
             myRichEditBox.Document.Selection.CharacterFormat.ForegroundColor = currentColor;
         }
 
-        private void MyRichEditBox_LosingFocus(object sender, RoutedEventArgs e)
-        {
-            // Save text length to determine text length change
-            myRichEditBox.Document.GetText(TextGetOptions.UseCrlf, out string lastRawText);
-            LastRawTextLength = lastRawText.Length;
-
-            // Save formatted to restore formatting upon regaining focus
-            myRichEditBox.Document.GetText(TextGetOptions.FormatRtf, out LastFormattedText);
-        }
     }
 }

--- a/XamlControlsGallery/ControlPages/SplitButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/SplitButtonPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Windows.UI;
+using Windows.UI;
 using Windows.UI.Text;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -8,7 +8,7 @@ namespace AppUIBasics.ControlPages
 {
     public sealed partial class SplitButtonPage : Page
     {
-        private Color currentColor = Colors.Gray;
+        private Color currentColor = Colors.Green;
 
         public SplitButtonPage()
         {

--- a/XamlControlsGallery/ControlPagesSampleCode/Text/RichEditBox/RichEditBoxSample3_cs.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/Text/RichEditBox/RichEditBoxSample3_cs.txt
@@ -112,19 +112,18 @@ private void FindBoxRemoveHighlights()
 private void Editor_GotFocus(object sender, RoutedEventArgs e)
 {
     editor.Document.GetText(TextGetOptions.UseCrlf, out string currentRawText);
-    if (currentRawText.Length != LastRawTextLength)
-    {
-        // User used cut or paste from action command, skip the event
-        return;
-    }
+            
     // reset colors to correct defaults for Focused state
     ITextRange documentRange = editor.Document.GetRange(0, TextConstants.MaxUnitCount);
     SolidColorBrush background = (SolidColorBrush)App.Current.Resources["TextControlBackgroundFocused"];
-    SolidColorBrush foreground = (SolidColorBrush)App.Current.Resources["TextControlForegroundFocused"];
 
-    if (background != null && foreground != null)
+    if (background != null)
     {
         documentRange.CharacterFormat.BackgroundColor = background.Color;
-        documentRange.CharacterFormat.ForegroundColor = foreground.Color;
     }
+}
+
+private void Editor_TextChanged(object sender, RoutedEventArgs e)
+{
+    editor.Document.Selection.CharacterFormat.ForegroundColor = currentColor;
 }

--- a/XamlControlsGallery/ControlPagesSampleCode/Text/RichEditBox/RichEditBoxSample3_cs.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/Text/RichEditBox/RichEditBoxSample3_cs.txt
@@ -1,7 +1,4 @@
-﻿private Color currentColor = Colors.Black;
-private string LastFormattedText = "";
-private int LastRawTextLength = 0;
-
+﻿
 private async void OpenButton_Click(object sender, RoutedEventArgs e)
 {
     // Open a text file.
@@ -81,7 +78,6 @@ private void ColorButton_Click(object sender, RoutedEventArgs e)
 
     fontColorButton.Flyout.Hide();
     editor.Focus(Windows.UI.Xaml.FocusState.Keyboard);
-    currentColor = color;
 }
 
 private void FindBoxHighlightMatches()
@@ -126,45 +122,9 @@ private void Editor_GotFocus(object sender, RoutedEventArgs e)
     SolidColorBrush background = (SolidColorBrush)App.Current.Resources["TextControlBackgroundFocused"];
     SolidColorBrush foreground = (SolidColorBrush)App.Current.Resources["TextControlForegroundFocused"];
 
-    editor.Document.ApplyDisplayUpdates();
-
     if (background != null && foreground != null)
     {
         documentRange.CharacterFormat.BackgroundColor = background.Color;
-    }
-    // saving selection span
-    var caretPosition = editor.Document.Selection.GetIndex(TextRangeUnit.Character) - 1;
-    if(caretPosition <= 0)
-    {
-        caretPosition = 1;
-    }
-    var selectionLength = editor.Document.Selection.Length;
-    // restoring text styling, unintentionally sets caret position at beginning of text
-    editor.Document.SetText(TextSetOptions.FormatRtf, LastFormattedText);
-    // restoring selection position
-    editor.Document.Selection.SetIndex(TextRangeUnit.Character, caretPosition, false);
-    editor.Document.Selection.SetRange(caretPosition, caretPosition + selectionLength);
-    // Editor might have gained focus because user changed color.
-    // Change selection color
-    // Note that only way to regain with selection containing text is using the change color button
-    editor.Document.Selection.CharacterFormat.ForegroundColor = currentColor;
-}
-
-private void Editor_LosingFocus(object sender, RoutedEventArgs e)
-{
-    // Save text length to determine text length change
-    editor.Document.GetText(TextGetOptions.UseCrlf, out string lastRawText);
-    LastRawTextLength = lastRawText.Length; 
-            
-    // Save formatted to restore formatting upon regaining focus
-    editor.Document.GetText(TextGetOptions.FormatRtf, out LastFormattedText);
-}
-
-private void Editor_TextChanging(object sender, RichEditBoxTextChangingEventArgs e)
-{
-    // Fix bug where selected text would get colored when editor loses focus
-    if (FocusManager.GetFocusedElement() == editor)
-    {
-        editor.Document.Selection.CharacterFormat.ForegroundColor = currentColor;
+        documentRange.CharacterFormat.ForegroundColor = foreground.Color;
     }
 }

--- a/XamlControlsGallery/ControlPagesSampleCode/Text/RichEditBox/RichEditBoxSample3_xaml.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/Text/RichEditBox/RichEditBoxSample3_xaml.txt
@@ -104,9 +104,7 @@
                  RelativePanel.Below="openFileButton" 
                  RelativePanel.AlignLeftWithPanel="True" 
                  RelativePanel.AlignRightWithPanel="True"
-                 TextChanging="Editor_TextChanging"
-                 GotFocus="Editor_GotFocus"
-                 LosingFocus="Editor_LosingFocus"/>
+                 GotFocus="Editor_GotFocus" />
     <StackPanel Orientation="Horizontal" 
                 RelativePanel.Below="editor" 
                 RelativePanel.AlignLeftWith="editor" 

--- a/XamlControlsGallery/ControlPagesSampleCode/Text/RichEditBox/RichEditBoxSample3_xaml.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/Text/RichEditBox/RichEditBoxSample3_xaml.txt
@@ -90,21 +90,17 @@
                             <Rectangle Fill="Gray"/>
                         </Button.Content>
                     </Button>
-                    <Button Click="ColorButton_Click" AutomationProperties.Name="Black">
-                        <Button.Content>
-                            <Rectangle Fill="Black"/>
-                        </Button.Content>
-                    </Button>
                 </VariableSizedWrapGrid>
             </Flyout>
         </muxc:DropDownButton.Flyout>
     </muxc:DropDownButton>
 
-    <RichEditBox x:Name="editor" Height="200" 
-                 RelativePanel.Below="openFileButton" 
-                 RelativePanel.AlignLeftWithPanel="True" 
-                 RelativePanel.AlignRightWithPanel="True"
-                 GotFocus="Editor_GotFocus" />
+    <RichEditBox x:Name="editor" Height="200" AutomationProperties.Name="Custom editor"
+                    RelativePanel.Below="openFileButton" 
+                    RelativePanel.AlignLeftWithPanel="True" 
+                    RelativePanel.AlignRightWithPanel="True" 
+                    TextChanged="Editor_TextChanged"
+                    GotFocus="Editor_GotFocus"/>
     <StackPanel Orientation="Horizontal" 
                 RelativePanel.Below="editor" 
                 RelativePanel.AlignLeftWith="editor" 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

A few changes:
- Remove code that reapplied rtf when switching focus
- Switch default color from black to gray

I am not happy with the default foreground being gray, however this is the easy approach to fix the issue with black text on black background in dark theme. Having those depend on the current theme will make the samples definitely more complex, that is why I opted out of doing this for now.
 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Update samples as the recent changes to the RichEditBox control broke them.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
