### PR TITLE
Updating link for WebView2 page

### DIFF
--- a/XamlControlsGallery/DataModel/ControlInfoData.json
+++ b/XamlControlsGallery/DataModel/ControlInfoData.json
@@ -1694,7 +1694,7 @@
             },
             {
               "Title": "Guidelines",
-              "Uri": "https://github.com/microsoft/microsoft-ui-xaml-specs/blob/master/active/WebView2/WebView2_spec.md"
+              "Uri": "https://docs.microsoft.com/en-us/microsoft-edge/webview2/gettingstarted/winui"
             },
             {
               "Title": "Examples",

--- a/XamlControlsGallery/DataModel/ControlInfoData.json
+++ b/XamlControlsGallery/DataModel/ControlInfoData.json
@@ -1694,7 +1694,7 @@
             },
             {
               "Title": "Guidelines",
-              "Uri": "https://docs.microsoft.com/en-us/microsoft-edge/webview2/gettingstarted/winui"
+              "Uri": "https://docs.microsoft.com/microsoft-edge/webview2/gettingstarted/winui"
             },
             {
               "Title": "Examples",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The WebView2 team recently published an official guidelines doc for using WebView2 with WinUI 3, so I'm updating a bunch of WinUI resources/docs to point to this new article. Changed the "Guidelines" link on the WebView2 page for the preview branch. 

## Motivation and Context
WebView2 guidelines link was outdated.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Just opened the app and tested if the link opens to the right page.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
