### PR TITLE
Fix issue with resizing having horrible performance

### DIFF
--- a/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
@@ -208,7 +208,10 @@ namespace AppUIBasics.ControlPages
 
         private void Editor_TextChanged(object sender, RoutedEventArgs e)
         {
-            editor.Document.Selection.CharacterFormat.ForegroundColor = currentColor;
+            if(editor.Document.Selection.CharacterFormat.ForegroundColor != currentColor)
+            {
+                editor.Document.Selection.CharacterFormat.ForegroundColor = currentColor;
+            }
         }
     }
 }

--- a/XamlControlsGallery/ControlPages/SplitButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/SplitButtonPage.xaml.cs
@@ -50,7 +50,10 @@ namespace AppUIBasics.ControlPages
 
         private void MyRichEditBox_TextChanged(object sender, RoutedEventArgs e)
         {
-            myRichEditBox.Document.Selection.CharacterFormat.ForegroundColor = currentColor;
+            if(myRichEditBox.Document.Selection.CharacterFormat.ForegroundColor != currentColor)
+            {
+                myRichEditBox.Document.Selection.CharacterFormat.ForegroundColor = currentColor;
+            }
         }
 
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The issue was that setting the foreground is very expensive, however changing it to the value it already is doesn't have any benefit for us.

Through performance debugger, I found out that we spend 60% of CPU time on these two lines when resizing the window. By adding this check, resizing the window now works as expected again.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #529 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested through resizing page and looking at perf log.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
