### PR TITLE
Button page: Fix issue with Narrator only announcing "Button" instead of content and control type

### DIFF
--- a/XamlControlsGallery/ControlPages/ButtonPage.xaml
+++ b/XamlControlsGallery/ControlPages/ButtonPage.xaml
@@ -70,11 +70,11 @@
         </local:ControlExample>
         <local:ControlExample HeaderText="Accent style applied to Button.">
             <local:ControlExample.Example>
-                <Button Style="{StaticResource AccentButtonStyle}" Content="Button"/>
+                <Button Style="{StaticResource AccentButtonStyle}" Content="Accent style button"/>
             </local:ControlExample.Example>
             <local:ControlExample.Xaml>
                 <x:String >
-                    &lt;Button Style="{StaticResource AccentButtonStyle}" Content="Button" /&gt;
+                    &lt;Button Style="{StaticResource AccentButtonStyle}" Content="Accent style button" /&gt;
                 </x:String>
             </local:ControlExample.Xaml>
         </local:ControlExample>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update content of button to be "Accent style button", which let's narrator announce "Accent style button, button".
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #554
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Navigated through Button page with narrator
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
