### PR TITLE
Fixed typo in TreeView sample

### DIFF
--- a/XamlControlsGallery/ControlPagesSampleCode/TreeView/TreeViewTemplateSelectorSample_xaml.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/TreeView/TreeViewTemplateSelectorSample_xaml.txt
@@ -20,11 +20,11 @@
         </muxc:TreeViewItem>
     </DataTemplate>
 
-    <controlpages:ExplorerItemTemplateSelector x:Key="ExpolrerItemTemplateSelector"
+    <controlpages:ExplorerItemTemplateSelector x:Key="ExplorerItemTemplateSelector"
         FolderTemplate="{StaticResource FolderTemplate}"
         FileTemplate="{StaticResource FileTemplate}" />
 </Page.Resources>
 
 <muxc:TreeView ItemsSource="{x:Bind DataSource}" 
-                   ItemTemplateSelector="{StaticResource ExpolrerItemTemplateSelector}" />
+                   ItemTemplateSelector="{StaticResource ExplorerItemTemplateSelector}" />
 


### PR DESCRIPTION
## Description
The example "A TreeView with ItemTemplateSelector" contains a typo in its `ExplorerItemTemplateSelector`:
The value of the property `x:key` was `ExpolrerItemTemplateSelector` and I changed it to `ExplorerItemTemplateSelector`.

## Motivation and Context
This change solves a typo.

## How Has This Been Tested?
No test required

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
