### PR TITLE
Added names to menu bars so they can easily be identified in UI tests

### DIFF
--- a/XamlControlsGallery/ControlPages/MenuBarPage.xaml
+++ b/XamlControlsGallery/ControlPages/MenuBarPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page x:Class="AppUIBasics.ControlPages.MenuBarPage" 
+<Page x:Class="AppUIBasics.ControlPages.MenuBarPage" 
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
       xmlns:local="using:AppUIBasics"
@@ -14,7 +14,7 @@
                               XamlSource="MenuBar\MenuBarSample1.txt">
             <StackPanel>
                 <TextBlock x:Name="SelectedOptionText" Text="" />
-                <muxc:MenuBar>
+                <muxc:MenuBar x:Name="Example1">
                     <muxc:MenuBarItem Title="File">
                         <MenuFlyoutItem x:Name="o1" Text="New" Click="OnElementClicked"/>
                         <MenuFlyoutItem x:Name="o2" Text="Open" Click="OnElementClicked"/>
@@ -40,7 +40,7 @@
                               XamlSource="Menubar\MenuBarSample3.txt">
             <StackPanel>
                 <TextBlock x:Name="SelectedOptionText1" Text="" />
-                <muxc:MenuBar>
+                <muxc:MenuBar x:Name="Example2">
                     <muxc:MenuBarItem Title="File">
                         <MenuFlyoutItem x:Name ="t2" Text="New" Click="OnElementClicked">
                             <MenuFlyoutItem.KeyboardAccelerators>
@@ -103,7 +103,7 @@
                               XamlSource="MenuBar\MenuBarSample2.txt">
             <StackPanel>
                 <TextBlock x:Name="SelectedOptionText2" Text="" />
-                <muxc:MenuBar>
+                <muxc:MenuBar x:Name="Example3">
                     <muxc:MenuBarItem Title="File">
                         <MenuFlyoutSubItem Text="New">
                             <MenuFlyoutItem x:Name="z1" Text="Plain Text Document" Click="OnElementClicked"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Changes have been made to the `MenuBarPage` sample to provide unique identifiable names to the `MenuBar` elements to make it easier to interact with them in automated UI tests.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Looking to build a wrapper element for the `MenuBar` WinUI control in the [Legerity UI test framework](https://github.com/MADE-Apps/legerity/issues/6) but finding the correct `MenuBar` to interact with is difficult due to there being no automation ID on the controls. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested the change by inspecting the UI automation tree to ensure the Automation ID property is set to the name of the control.

## Screenshots (if appropriate):

- N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
