### PR TITLE
Added determinate mode for progress ring

### DIFF
--- a/XamlControlsGallery/ControlPages/ProgressRingPage.xaml
+++ b/XamlControlsGallery/ControlPages/ProgressRingPage.xaml
@@ -20,7 +20,7 @@
     mc:Ignorable="d">
     <StackPanel>
         <local:ControlExample HeaderText="An indeterminate progress ring.">
-            <muxc:ProgressRing IsActive="{x:Bind ProgressToggle.IsOn, Mode=OneWay}" Height="130" Width="130" VerticalAlignment="Top" Margin="10,10,0,0"/>
+            <muxc:ProgressRing IsActive="{x:Bind ProgressToggle.IsOn, Mode=OneWay}" Height="60" Width="60" VerticalAlignment="Top" Margin="10,10,0,0"/>
             <local:ControlExample.Options>
                 <StackPanel>
                     <ToggleSwitch x:Name="ProgressToggle" Header="Toggle work" OffContent="Do work" OnContent="Working" IsOn="True" />
@@ -37,7 +37,7 @@
         </local:ControlExample>
         <local:ControlExample HeaderText="A determinate progress ring.">
             <StackPanel x:Name="Control2" Orientation="Horizontal">
-                <muxc:ProgressRing Width="130" x:Name="ProgressRing2" IsIndeterminate="False"/>
+                <muxc:ProgressRing Width="60" x:Name="ProgressRing2" IsIndeterminate="False"/>
                 <TextBlock x:Name="Control2Output" Style="{ThemeResource OutputTextBlockStyle}" Width="60" TextAlignment="Center" />
                 <TextBlock x:Name="ProgressLabel"  Text="Progress" VerticalAlignment="Center" Margin="0,0,10,0"/>
                 <muxc:NumberBox x:Name="ProgressValue" AutomationProperties.LabeledBy="{Binding ElementName=ProgressLabel}" Minimum="0" Maximum="100" SpinButtonPlacementMode="Inline" ValueChanged="ProgressValue_ValueChanged" VerticalAlignment="Center"/>

--- a/XamlControlsGallery/ControlPages/ProgressRingPage.xaml
+++ b/XamlControlsGallery/ControlPages/ProgressRingPage.xaml
@@ -20,10 +20,10 @@
     mc:Ignorable="d">
     <StackPanel>
         <local:ControlExample HeaderText="An indeterminate progress ring.">
-            <muxc:ProgressRing IsActive="{x:Bind ProgressToggle.IsOn, Mode=OneWay}" Height="60" Width="60" VerticalAlignment="Top" Margin="10,10,0,0"/>
+            <muxc:ProgressRing IsActive="{x:Bind ProgressToggle.IsOn, Mode=OneWay}" AutomationProperties.Name="Progress image" Height="60" Width="60" VerticalAlignment="Top" Margin="10,10,0,0"/>
             <local:ControlExample.Options>
                 <StackPanel>
-                    <ToggleSwitch x:Name="ProgressToggle" Header="Toggle work" OffContent="Do work" OnContent="Working" IsOn="True" />
+                    <ToggleSwitch x:Name="ProgressToggle" AutomationProperties.Name="Progress options" Header="Toggle work" OffContent="Do work" OnContent="Working" IsOn="True" />
                 </StackPanel>
             </local:ControlExample.Options>
             <local:ControlExample.Xaml>
@@ -37,8 +37,7 @@
         </local:ControlExample>
         <local:ControlExample HeaderText="A determinate progress ring.">
             <StackPanel x:Name="Control2" Orientation="Horizontal">
-                <muxc:ProgressRing Width="60" x:Name="ProgressRing2" IsIndeterminate="False"/>
-                <TextBlock x:Name="Control2Output" Style="{ThemeResource OutputTextBlockStyle}" Width="60" TextAlignment="Center" />
+                <muxc:ProgressRing Width="60" x:Name="ProgressRing2" AutomationProperties.Name="Progress image" IsIndeterminate="False" Margin="0,0,60,0"/>
                 <muxc:NumberBox x:Name="ProgressValue" AutomationProperties.Name="Progress amount" Value="0"
                                 Minimum="0" Maximum="100" SpinButtonPlacementMode="Inline" Header="Progress" ValueChanged="ProgressValue_ValueChanged" VerticalAlignment="Center"/>
             </StackPanel>

--- a/XamlControlsGallery/ControlPages/ProgressRingPage.xaml
+++ b/XamlControlsGallery/ControlPages/ProgressRingPage.xaml
@@ -20,9 +20,7 @@
     mc:Ignorable="d">
     <StackPanel>
         <local:ControlExample HeaderText="An indeterminate progress ring.">
-
             <muxc:ProgressRing IsActive="{x:Bind ProgressToggle.IsOn, Mode=OneWay}" Height="130" Width="130" VerticalAlignment="Top" Margin="10,10,0,0"/>
-
             <local:ControlExample.Options>
                 <StackPanel>
                     <ToggleSwitch x:Name="ProgressToggle" Header="Toggle work" OffContent="Do work" OnContent="Working" IsOn="True" />
@@ -36,7 +34,6 @@
             <local:ControlExample.Substitutions>
                 <local:ControlExampleSubstitution Key="IsActive" Value="{x:Bind ProgressToggle.IsOn, Mode=OneWay}" />
             </local:ControlExample.Substitutions>
-
         </local:ControlExample>
         <local:ControlExample HeaderText="A determinate progress ring.">
             <StackPanel x:Name="Control2" Orientation="Horizontal">

--- a/XamlControlsGallery/ControlPages/ProgressRingPage.xaml
+++ b/XamlControlsGallery/ControlPages/ProgressRingPage.xaml
@@ -21,14 +21,13 @@
     <StackPanel>
         <local:ControlExample HeaderText="An indeterminate progress ring.">
 
-            <muxc:ProgressRing IsActive="{x:Bind ProgressToggle.IsOn, Mode=OneWay}" Height="60" Width="60" VerticalAlignment="Top" Margin="10,10,0,0"/>
+            <muxc:ProgressRing IsActive="{x:Bind ProgressToggle.IsOn, Mode=OneWay}" Height="130" Width="130" VerticalAlignment="Top" Margin="10,10,0,0"/>
 
             <local:ControlExample.Options>
                 <StackPanel>
                     <ToggleSwitch x:Name="ProgressToggle" Header="Toggle work" OffContent="Do work" OnContent="Working" IsOn="True" />
                 </StackPanel>
             </local:ControlExample.Options>
-
             <local:ControlExample.Xaml>
                 <x:String>
                     &lt;muxc:ProgressRing IsActive="$(IsActive)" /&gt;
@@ -39,6 +38,13 @@
             </local:ControlExample.Substitutions>
 
         </local:ControlExample>
+        <local:ControlExample HeaderText="A determinate progress ring.">
+            <StackPanel x:Name="Control2" Orientation="Horizontal">
+                <muxc:ProgressRing Width="130" x:Name="ProgressRing2" IsIndeterminate="False"/>
+                <TextBlock x:Name="Control2Output" Style="{ThemeResource OutputTextBlockStyle}" Width="60" TextAlignment="Center" />
+                <TextBlock x:Name="ProgressLabel"  Text="Progress" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                <muxc:NumberBox x:Name="ProgressValue" AutomationProperties.LabeledBy="{Binding ElementName=ProgressLabel}" Minimum="0" Maximum="100" SpinButtonPlacementMode="Inline" ValueChanged="ProgressValue_ValueChanged" VerticalAlignment="Center"/>
+            </StackPanel>
             <local:ControlExample.Xaml>
                 <x:String>
                     &lt;muxc:ProgressRing Width="130" Value="$(DeterminateProgressValue)" /&gt;

--- a/XamlControlsGallery/ControlPages/ProgressRingPage.xaml
+++ b/XamlControlsGallery/ControlPages/ProgressRingPage.xaml
@@ -39,5 +39,14 @@
             </local:ControlExample.Substitutions>
 
         </local:ControlExample>
+            <local:ControlExample.Xaml>
+                <x:String>
+                    &lt;muxc:ProgressRing Width="130" Value="$(DeterminateProgressValue)" /&gt;
+                </x:String>
+            </local:ControlExample.Xaml>
+            <local:ControlExample.Substitutions>
+                <local:ControlExampleSubstitution Key="DeterminateProgressValue" Value="{x:Bind ProgressRing2.Value, Mode=OneWay}" />
+            </local:ControlExample.Substitutions>
+        </local:ControlExample>
     </StackPanel>
 </Page>

--- a/XamlControlsGallery/ControlPages/ProgressRingPage.xaml
+++ b/XamlControlsGallery/ControlPages/ProgressRingPage.xaml
@@ -39,11 +39,12 @@
             <StackPanel x:Name="Control2" Orientation="Horizontal">
                 <muxc:ProgressRing Width="60" x:Name="ProgressRing2" IsIndeterminate="False"/>
                 <TextBlock x:Name="Control2Output" Style="{ThemeResource OutputTextBlockStyle}" Width="60" TextAlignment="Center" />
-                <muxc:NumberBox x:Name="ProgressValue" AutomationProperties.LabeledBy="{Binding ElementName=ProgressLabel}" Minimum="0" Maximum="100" SpinButtonPlacementMode="Inline" Header="Progress" ValueChanged="ProgressValue_ValueChanged" VerticalAlignment="Center"/>
+                <muxc:NumberBox x:Name="ProgressValue" AutomationProperties.Name="Progress amount" Value="0"
+                                Minimum="0" Maximum="100" SpinButtonPlacementMode="Inline" Header="Progress" ValueChanged="ProgressValue_ValueChanged" VerticalAlignment="Center"/>
             </StackPanel>
             <local:ControlExample.Xaml>
                 <x:String>
-                    &lt;muxc:ProgressRing Width="130" Value="$(DeterminateProgressValue)" /&gt;
+                    &lt;muxc:ProgressRing Width="130" Value="$(DeterminateProgressValue)" "IsIndeterminate="False"/&gt;
                 </x:String>
             </local:ControlExample.Xaml>
             <local:ControlExample.Substitutions>

--- a/XamlControlsGallery/ControlPages/ProgressRingPage.xaml
+++ b/XamlControlsGallery/ControlPages/ProgressRingPage.xaml
@@ -39,8 +39,7 @@
             <StackPanel x:Name="Control2" Orientation="Horizontal">
                 <muxc:ProgressRing Width="60" x:Name="ProgressRing2" IsIndeterminate="False"/>
                 <TextBlock x:Name="Control2Output" Style="{ThemeResource OutputTextBlockStyle}" Width="60" TextAlignment="Center" />
-                <TextBlock x:Name="ProgressLabel"  Text="Progress" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                <muxc:NumberBox x:Name="ProgressValue" AutomationProperties.LabeledBy="{Binding ElementName=ProgressLabel}" Minimum="0" Maximum="100" SpinButtonPlacementMode="Inline" ValueChanged="ProgressValue_ValueChanged" VerticalAlignment="Center"/>
+                <muxc:NumberBox x:Name="ProgressValue" AutomationProperties.LabeledBy="{Binding ElementName=ProgressLabel}" Minimum="0" Maximum="100" SpinButtonPlacementMode="Inline" Header="Progress" ValueChanged="ProgressValue_ValueChanged" VerticalAlignment="Center"/>
             </StackPanel>
             <local:ControlExample.Xaml>
                 <x:String>

--- a/XamlControlsGallery/ControlPages/ProgressRingPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ProgressRingPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿//*********************************************************
+//*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
 // THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
@@ -29,6 +29,18 @@ namespace AppUIBasics.ControlPages
         public ProgressRingPage()
         {
             this.InitializeComponent();
+        }
+
+        private void ProgressValue_ValueChanged(Microsoft.UI.Xaml.Controls.NumberBox sender, Microsoft.UI.Xaml.Controls.NumberBoxValueChangedEventArgs args)
+        {
+            if (!sender.Value.IsNaN())
+            {
+                ProgressRing2.Value = sender.Value;
+            }
+            else
+            {
+                sender.Value = 0;
+            }
         }
 
     }

--- a/XamlControlsGallery/DataModel/ControlInfoData.json
+++ b/XamlControlsGallery/DataModel/ControlInfoData.json
@@ -1045,9 +1045,9 @@
         {
           "UniqueId": "ProgressRing",
           "Title": "ProgressRing",
-          "Subtitle": "Shows that the app is performing ongoing work that blocks user interaction.",
+          "Subtitle": "Shows the apps progress on a task, or that the app is performing ongoing work that does block user interaction.",
           "ImagePath": "ms-appx:///Assets/ProgressRing.png",
-          "Description": "Use a ProgressRing to show that the app is performing ongoing work that blocks user interaction.",
+          "Description": "The ProgressRing has two different visual representations:\nIndeterminate - shows that a task is ongoing, but blocks user interaction.\nDeterminate - shows how much progress has been made on a known amount of work.",
           "Content": "<p>Look at the <i>ProgressRingPage.xaml</i> file in Visual Studio to see the full code for this page.</p>",
           "IsNew": true,
           "Docs": [


### PR DESCRIPTION
Added determinate mode example to the progress ring page. 

## Description
Added an example of how to set the IsIndeterminate property to change the progress ring in to a determinate mode progress ring that fills based on the value property. 

## How Has This Been Tested?
Ran on my local machine using the 2.5 pre-release package. 

## Types of changes
New feature
