### PR TITLE
Fixed incorrect wording in description of TimePicker control

### DIFF
--- a/XamlControlsGallery/DataModel/ControlInfoData.json
+++ b/XamlControlsGallery/DataModel/ControlInfoData.json
@@ -602,7 +602,7 @@
           "Title": "TimePicker",
           "Subtitle": "A configurable control that lets a user pick a time value.",
           "ImagePath": "ms-appx:///Assets/TimePicker.png",
-          "Description": "Use a TimePicker to let users set a time in your app, for example to set a reminder. The TimePicker displays three controls for month, day, and and AM/PM. These controls are easy to use with touch or mouse, and they can be styled and configured in several different ways.",
+          "Description": "Use a TimePicker to let users set a time in your app, for example to set a reminder. The TimePicker displays three controls for hour, minute, and AM/PM. These controls are easy to use with touch or mouse, and they can be styled and configured in several different ways.",
           "Content": "<p>Look at the <i>TimePickerPage.xaml</i> file in Visual Studio to see the full code for this page.</p>",
           "IsNew": false,
           "Docs": [


### PR DESCRIPTION
## Description
The description text on how to use the `TimePicker` control shows the following wrong text:

> Use a TimePicker to let users set a time in your app, for example to set a reminder. The TimePicker displays three controls for **month, day, and** and AM/PM.

It seems to be an oversight when copying the same description from the `DateTime` control description.

## Motivation and Context
This fixes a minor help text issue that may confuse new users of the app.

## How Has This Been Tested?
Untested since it's a wording change.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
