### PR TITLE
Add UIA name to TextBox for padding in screenshot mode

### DIFF
--- a/XamlControlsGallery/ControlExample.xaml
+++ b/XamlControlsGallery/ControlExample.xaml
@@ -175,8 +175,9 @@
 
                 <TextBlock x:Name="ScreenshotStatusTextBlock" VerticalAlignment="Center" Margin="0,0,0,1"/>
 
-                <TextBlock Text="Padding:" VerticalAlignment="Center" Margin="5,0,5,1"/>
-                <TextBox x:Name="ControlPaddingBox" Width="150" KeyUp="ControlPaddingBox_KeyUp" LostFocus="ControlPaddingBox_LostFocus"/>
+                <TextBlock x:Name="PaddingLabel" Text="Padding:" VerticalAlignment="Center" Margin="5,0,5,1"/>
+                <TextBox x:Name="ControlPaddingBox" AutomationProperties.LabeledBy="{x:Bind PaddingLabel}"
+                    Width="150" KeyUp="ControlPaddingBox_KeyUp" LostFocus="ControlPaddingBox_LostFocus"/>
             </StackPanel>
         </Grid>
     </Grid>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds LabeledBy property to TextBox to provide accessible name to padding textbox:

![Image showing Accessibility Insights app pointing out name of padding textbox](https://user-images.githubusercontent.com/16122379/102149228-3f0be180-3e6e-11eb-8885-0ac7214f87cd.png)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #609 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
