### PR TITLE
Auto-hide scrollbars in first ItemsRepeater sample if not needed.

### DIFF
--- a/XamlControlsGallery/ControlPages/ItemsRepeaterPage.xaml
+++ b/XamlControlsGallery/ControlPages/ItemsRepeaterPage.xaml
@@ -101,7 +101,8 @@
 
     <StackPanel>
         <local:ControlExample HeaderText="Basic, non-interactive items laid out by ItemsRepeater">
-            <ScrollViewer HorizontalScrollBarVisibility="Auto" 
+            <ScrollViewer HorizontalScrollBarVisibility="Auto"
+                          VerticalScrollBarVisibility="Auto" 
                           HorizontalScrollMode="Auto" 
                           IsVerticalScrollChainingEnabled="False"
                           MaxHeight="500">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Set the value of `VerticalScrollBarVisibility` of the ScrollViewer containing the ItemsRepeater to `Auto` to hide the scrollbars when not needed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #615 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/25991996/103582115-1639a380-4e92-11eb-9dec-8aed42c6aa95.png)

![image](https://user-images.githubusercontent.com/25991996/103582156-2cdffa80-4e92-11eb-95bf-7dd67c073a70.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
