### PR TITLE
HC changes so controls look more accurate

### DIFF
--- a/XamlControlsGallery/AllControlsPage.xaml
+++ b/XamlControlsGallery/AllControlsPage.xaml
@@ -17,7 +17,8 @@
     xmlns:behavior="using:AppUIBasics.Behaviors"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:controls="using:Windows.UI.Xaml.Controls"
-    NavigationCacheMode="Enabled">
+    NavigationCacheMode="Enabled"
+    HighContrastAdjustment="None">
 
     <!--  This grid acts as a root panel for the page.  -->
     <Grid Background="{ThemeResource HomePageBackgroundBrush}">

--- a/XamlControlsGallery/App.xaml
+++ b/XamlControlsGallery/App.xaml
@@ -25,18 +25,24 @@
             <ResourceDictionary.ThemeDictionaries>
                 <ResourceDictionary x:Key="Light">
                     <StaticResource x:Key="HomePageBackgroundBrush" ResourceKey="ApplicationPageBackgroundThemeBrush" />
+                    <StaticResource x:Key="ControlExampleDisplayBrush" ResourceKey="SystemControlBackgroundAltHighBrush" />
                     <SolidColorBrush x:Key="SearchBoxBorderBrush" Color="Transparent" />
                     <Thickness x:Key="SearchBoxBorderThickness">0</Thickness>
+                    <Thickness x:Key="ControlExampleDisplayBorderThickness">0</Thickness>
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="Dark">
                     <StaticResource x:Key="HomePageBackgroundBrush" ResourceKey="ApplicationPageBackgroundThemeBrush" />
+                    <StaticResource x:Key="ControlExampleDisplayBrush" ResourceKey="SystemControlBackgroundAltHighBrush" />
                     <SolidColorBrush x:Key="SearchBoxBorderBrush" Color="Transparent" />
                     <Thickness x:Key="SearchBoxBorderThickness">0</Thickness>
+                    <Thickness x:Key="ControlExampleDisplayBorderThickness">0</Thickness>
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="HighContrast">
                     <SolidColorBrush x:Key="HomePageBackgroundBrush" Color="{ThemeResource SystemColorWindowColor}" />
+                    <SolidColorBrush x:Key="ControlExampleDisplayBrush" Color="{ThemeResource SystemColorWindowColor}" />
                     <SolidColorBrush x:Key="SearchBoxBorderBrush" Color="{ThemeResource SystemColorWindowTextColor}" />
                     <Thickness x:Key="SearchBoxBorderThickness">2</Thickness>
+                    <Thickness x:Key="ControlExampleDisplayBorderThickness">1</Thickness>
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
 

--- a/XamlControlsGallery/ControlExample.xaml
+++ b/XamlControlsGallery/ControlExample.xaml
@@ -89,7 +89,7 @@
                 x:FieldModifier="Public"
                 BorderBrush="{ThemeResource SystemControlBackgroundListLowBrush}"
                 BorderThickness="1"
-                Background="{ThemeResource SystemControlBackgroundAltHighBrush}">
+                Background="{ThemeResource ControlExampleDisplayBrush}">
                 <Grid.RowDefinitions>
                     <RowDefinition />
                     <RowDefinition Height="Auto" />
@@ -106,7 +106,9 @@
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Stretch"
                     Padding="12"
-                    Background="{ThemeResource SystemControlBackgroundAltHighBrush}"
+                    BorderBrush="{ThemeResource SystemControlBackgroundListLowBrush}"
+                    BorderThickness="{ThemeResource ControlExampleDisplayBorderThickness}"
+                    Background="{ThemeResource ControlExampleDisplayBrush}"
                     HorizontalContentAlignment="{x:Bind HorizontalContentAlignment}"
                     Content="{x:Bind Example}" />
 

--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml
@@ -14,7 +14,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
-    xmlns:local="using:AppUIBasics">
+    xmlns:local="using:AppUIBasics"
+    HighContrastAdjustment="None">
 
     <Page.Resources>
         <DataTemplate x:Key="NavigationViewHeaderTemplate">

--- a/XamlControlsGallery/NewControlsPage.xaml
+++ b/XamlControlsGallery/NewControlsPage.xaml
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
     //*********************************************************
     //
     // Copyright (c) Microsoft. All rights reserved.
@@ -16,7 +16,8 @@
     xmlns:local="using:AppUIBasics"
     xmlns:behavior="using:AppUIBasics.Behaviors"
     xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
-    NavigationCacheMode="Enabled">
+    NavigationCacheMode="Enabled"
+    HighContrastAdjustment="None">
 
     <Page.Resources>
         <CollectionViewSource x:Name="itemsCVS" IsSourceGrouped="true"/>

--- a/XamlControlsGallery/PageHeader.xaml
+++ b/XamlControlsGallery/PageHeader.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+<UserControl
     x:Class="AppUIBasics.PageHeader"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -8,7 +8,8 @@
     Padding="{x:Bind HeaderPadding, Mode=OneWay}"
     Background="Transparent"
     Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
-    FontSize="24">
+    FontSize="24"
+    HighContrastAdjustment="Auto">
 
     <Grid>
         <VisualStateManager.VisualStateGroups>


### PR DESCRIPTION
The app was showing a few high contrast colors that were muddying up the accuracy of the control's appearance. To make Xaml controls show a more accurate representation of themselves, made the following two changes.

- Changed HighContrastAdjustment to None. 
Before:
![HCAdjustment_Before](https://user-images.githubusercontent.com/13142665/104551729-46004e00-55ec-11eb-8ddf-aa6950efbcc8.png)
After: 
![HCAdjustment_Updated](https://user-images.githubusercontent.com/13142665/104552327-78f71180-55ed-11eb-9be6-346f28e1befb.png)


- Updated controls examples to stop drawing ButtonFace color.
After:
![ExampleControlPage_Updated](https://user-images.githubusercontent.com/13142665/104551792-6203ef80-55ec-11eb-8eda-b867d1264aeb.png)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually verified in regular and high contrast.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
