### PR TITLE
Fix indentation on SemanticZoomPage.xaml

### DIFF
--- a/XamlControlsGallery/ControlPages/SemanticZoomPage.xaml
+++ b/XamlControlsGallery/ControlPages/SemanticZoomPage.xaml
@@ -47,7 +47,7 @@
             <SemanticZoom x:Name="Control1" Height="500">
                 <SemanticZoom.ZoomedInView>
                     <GridView ItemsSource="{x:Bind cvsGroups.View}" ScrollViewer.IsHorizontalScrollChainingEnabled="False" SelectionMode="None" GotFocus="List_GotFocus"
-                        ItemTemplate="{StaticResource ZoomedInTemplate}">
+                              ItemTemplate="{StaticResource ZoomedInTemplate}">
                         <GridView.GroupStyle>
                             <GroupStyle HeaderTemplate="{StaticResource ZoomedInGroupHeaderTemplate}" />
                         </GridView.GroupStyle>


### PR DESCRIPTION
## Description
Add properly indentation to `ItemTemplate` property in `SemanticZoom.ZoomedView` at `SemanticZoomPage.xaml`

## Motivation and Context
I took a look at SemanticZoom and found this annoying indentation error 😅

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
