### PR TITLE
Make the RichEditBox to be able to use Microsoft::UI::Xaml::CommandBarFlyout

### DIFF
--- a/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
@@ -45,7 +45,7 @@ namespace AppUIBasics.ControlPages
             }
             else
             {
-                muxc::CommandBarFlyout muxFlyout = sender as muxc::CommandBarFlyout;
+                muxc.CommandBarFlyout muxFlyout = sender as muxc.CommandBarFlyout;
                 if (muxFlyout != null && muxFlyout.Target == REBCustom)
                 {
                     AppBarButton myButton = new AppBarButton

--- a/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
@@ -19,6 +19,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
+using Mux = Windows.UI.Xaml.Controls;
 
 namespace AppUIBasics.ControlPages
 {
@@ -34,7 +35,7 @@ namespace AppUIBasics.ControlPages
         private void Menu_Opening(object sender, object e)
         {
             CommandBarFlyout myFlyout = sender as CommandBarFlyout;
-            if (myFlyout.Target == REBCustom)
+            if (myFlyout != null && myFlyout.Target == REBCustom)
             {
                 AppBarButton myButton = new AppBarButton
                 {
@@ -42,6 +43,20 @@ namespace AppUIBasics.ControlPages
                 };
                 myFlyout.PrimaryCommands.Add(myButton);
             }
+            else
+            {
+                Mux::CommandBarFlyout muxFlyout = sender as Mux::CommandBarFlyout;
+
+                if (muxFlyout != null && muxFlyout.Target == REBCustom)
+                {
+                    AppBarButton myButton = new AppBarButton
+                    {
+                        Command = new StandardUICommand(StandardUICommandKind.Share)
+                    };
+                    muxFlyout.PrimaryCommands.Add(myButton);
+                }
+            }
+
         }
 
         private async void OpenButton_Click(object sender, RoutedEventArgs e)

--- a/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
@@ -19,7 +19,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
-using muxc = Windows.UI.Xaml.Controls;
+using muxc = Microsoft.UI.Xaml.Controls;
 
 namespace AppUIBasics.ControlPages
 {

--- a/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
@@ -19,7 +19,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
-using Mux = Windows.UI.Xaml.Controls;
+using muxc = Windows.UI.Xaml.Controls;
 
 namespace AppUIBasics.ControlPages
 {
@@ -45,8 +45,7 @@ namespace AppUIBasics.ControlPages
             }
             else
             {
-                Mux::CommandBarFlyout muxFlyout = sender as Mux::CommandBarFlyout;
-
+                muxc::CommandBarFlyout muxFlyout = sender as muxc::CommandBarFlyout;
                 if (muxFlyout != null && muxFlyout.Target == REBCustom)
                 {
                     AppBarButton myButton = new AppBarButton


### PR DESCRIPTION
When integrating with the latest WinUI, the sender is Microsoft::UI::Xaml::TextCommandBarFlyout other than Windows::UI::Xaml::CommandBarFlyout
It blocked the CommandBarFlyout pop up 