### PR TITLE
Updating XamlControlsGallery to Reunion 0.5.5

### DIFF
--- a/XamlControlsGallery/Directory.Build.props
+++ b/XamlControlsGallery/Directory.Build.props
@@ -10,6 +10,10 @@
        Determine if building standalone by conditioning on the MuxCustomBuildTasksPackageVersion property, which only exists in the WinUI repo -->
   <PropertyGroup Condition="'$(MuxCustomBuildTasksPackageVersion)' != ''">
     <IsInWinUIRepo>true</IsInWinUIRepo>
+
+    <!-- We want to binplace the XamlControlsGallery pdb to a subdirectory of Symbols\Test so that the UWP and Desktop versions don't 
+         overwrite each other. -->
+    <BinplaceSymbolsToSubdir>true</BinplaceSymbolsToSubdir>
   </PropertyGroup>
 
     <!--

--- a/XamlControlsGallery/XamlControlsGallery.DesktopWap.Package.wapproj
+++ b/XamlControlsGallery/XamlControlsGallery.DesktopWap.Package.wapproj
@@ -2,10 +2,6 @@
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '15.0'">
     <VisualStudioVersion>15.0</VisualStudioVersion>
-    <!-- Name of the certificate used to sign XamlControlsGallery for publishing in the store.
-           This obviously isn't checked in with the repo, but can be dropped into the folder
-           to light-up official publishing-->
-    <OfficialCert>testcert.pfx</OfficialCert>
   </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x86">
@@ -48,14 +44,10 @@
     <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
     <EntryPointProjectUniqueName>XamlControlsGallery.DesktopWap.csproj</EntryPointProjectUniqueName>
     <AppxBundleNameForOutput>XamlControlsGallery.DesktopWap</AppxBundleNameForOutput>
-    <PackageCertificateKeyFile>testcert.pfx</PackageCertificateKeyFile>
     <PathToXamlWinRTImplementations>XamlControlsGallery.DesktopWap\</PathToXamlWinRTImplementations>
   </PropertyGroup>
   <PropertyGroup Condition="'$(IsInWinUIRepo)' == 'true'">
     <PackageCertificateKeyFile>$(ProjectRoot)build\MSTest.pfx</PackageCertificateKeyFile>
-  </PropertyGroup>
-  <PropertyGroup Condition="Exists('$(OfficialCert)')">
-    <PackageCertificateKeyFile>$(OfficialCert)</PackageCertificateKeyFile>
   </PropertyGroup>
   <PropertyGroup>
     <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
@@ -114,9 +106,6 @@
     <PackageReference Include="Microsoft.ProjectReunion.WinUI" Version="[$(ProjectReunionWinUIPackageVersion)]" GeneratePathProperty="true">
       <ExcludeAssets>all</ExcludeAssets>
     </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="XamlControlsGallery.DesktopWap.Package_TemporaryKey.pfx" />
   </ItemGroup>
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.targets" />
   <Import Project="$(Microsoft_ProjectReunion_AppXReference_props)" Condition="'$(ProjectReunionPackageVersion)' != ''" />

--- a/XamlControlsGallery/XamlControlsGallery.DesktopWap.csproj
+++ b/XamlControlsGallery/XamlControlsGallery.DesktopWap.csproj
@@ -38,6 +38,12 @@
     addresses those vulnerabilites, we need to pull it in ourselves.
     -->
     <PackageReference Include="System.Private.Uri" />
+
+    <!-- 
+    Explicit C#/WinRT reference to get winrt.runtime v1.2.2; We didn't do SDK update with 
+    this version so users run the risk of getting version conflicts with winrt.runtime v1.1 
+    from .NET SDK Ref v.13 -->
+    <PackageReference Include="Microsoft.Windows.CsWinRT" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsInWinUIRepo)' != 'true'">
@@ -47,6 +53,8 @@
     <PackageReference Update="Microsoft.VCRTForwarders.140" Version="1.0.6" />
     <PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="3.8.0-4.20472.6" />
     <PackageReference Update="Microsoft.WinUI" Version="$(WinUIPackageVersion)" Condition="'$(WinUIPackageVersion)' != ''" />
+     <!-- Get latest WinRT.Runtime.dll from C#/WinRT -->
+    <PackageReference Update="Microsoft.Windows.CsWinRT" Version="$(MicrosoftCsWinRTPackageVersion)" />
     <PackageReference Update="System.Private.Uri" Version="4.3.2" />
   </ItemGroup>
 
@@ -66,7 +74,6 @@
     <Compile Remove="AnimatedVisuals\LottieLogo1.cs" />
     <Compile Remove="Behaviors\ImageScrollBehavior.cs" />
     <Compile Remove="ControlPages\MediaPlayerElementPage.xaml.cs" />
-    <Compile Remove="ControlPages\PivotPage.xaml.cs" />
     <Compile Remove="ControlPages\RevealFocusPage.xaml.cs" />
     <Compile Remove="ControlPages\RevealPage.xaml.cs" />
     <Compile Remove="ControlPages\ScrollViewer2Page.xaml.cs" />
@@ -75,11 +82,7 @@
     <Compile Remove="AnimatedVisuals\LottieLogo1.cs" />
     <Compile Remove="ControlPages\AnimatedVisualPlayerPage.xaml.cs" />
 
-    <!-- Disabled until Reunion builds Microsoft.WinUI.dll against CSWinRT 1.1.4 -->
-    <Compile Remove="ControlPages\XamlCompInteropPage.xaml.cs" />
-
     <Page Remove="ControlPages\MediaPlayerElementPage.xaml" />
-    <Page Remove="ControlPages\PivotPage.xaml" />
     <Page Remove="ControlPages\RevealFocusPage.xaml" />
     <Page Remove="ControlPages\RevealPage.xaml" />
     <Page Remove="ControlPages\ScrollViewer2Page.xaml" />
@@ -87,15 +90,17 @@
 
     <!-- Win2D.WinUI is not public yet, and AnimatedVisualPlayerPage.xaml depends on it -->
     <Page Remove="ControlPages\AnimatedVisualPlayerPage.xaml" />
-
-    <!-- Disabled until Reunion builds Microsoft.WinUI.dll against CSWinRT 1.1.4 -->
-    <Page Remove="ControlPages\XamlCompInteropPage.xaml" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="ControlPages\MediaPlayerElementPage.xaml" />
     <None Remove="ControlPages\RevealFocusPage.xaml" />
     <None Remove="ControlPages\RevealPage.xaml" />
     <Content Remove="@(Content)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IsInWinUIRepo)' != 'true'">
+    <Page Remove="ControlPages\PivotPage.xaml" />
+    <Compile Remove="ControlPages\PivotPage.xaml.cs" />
   </ItemGroup>
   <Import Project="ContentIncludes.props" />
 

--- a/XamlControlsGallery/standalone.props
+++ b/XamlControlsGallery/standalone.props
@@ -1,26 +1,23 @@
 <Project>
-    <PropertyGroup>
-            <!-- The NuGet versions of dependencies to build against. -->
-            <!-- <WinUIPackageVersion>3.0.0-preview4.*</WinUIPackageVersion> -->
-            <ProjectReunionPackageVersion>0.5.0</ProjectReunionPackageVersion>
-            <ProjectReunionWinUIPackageVersion>0.5.0</ProjectReunionWinUIPackageVersion>
-      
-            <MicrosoftNETCoreUniversalWindowsPlatformVersion>6.2.11</MicrosoftNETCoreUniversalWindowsPlatformVersion>
-            <Win2DWinUIVersion>0.1.0.3</Win2DWinUIVersion>
-            <ColorCodeVersion>2.0.5</ColorCodeVersion>
-            <MicrosoftCsWinRTPackageVersion>1.1.0</MicrosoftCsWinRTPackageVersion>
-
-            <!-- Where to place the files generated from CSWinRT from XamlControlsGallery.Desktop.-->
-            <GeneratedFilesDir>obj\generated</GeneratedFilesDir>
-
-            <!-- We have multiple projects in the same directory, which means we need to separate their output paths-->
-            <BaseIntermediateOutputPath>obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
-            <BaseOutputPath>bin\$(MSBuildProjectName)\</BaseOutputPath>
-
-            <!-- For Desktop, the .NET 5 SDK automatically includes every .cs file in the project directory.  It normally
-                 also excludes items under the obj/bin folders based on the value of BaseIntermediateOutputPath/BaseOutputPath.
-                 However, because we overwrite those to output to subdirectories, the outputs of the UWP XamlControlsGallery
-                 are erroneously included.  Explicitly exclude them here -->
-            <DefaultItemExcludes>obj\**;bin\**;$(DefaultItemExcludes)</DefaultItemExcludes>
-    </PropertyGroup>
+  <PropertyGroup>
+    <!-- The NuGet versions of dependencies to build against. -->
+    <ProjectReunionPackageVersion>0.5.5</ProjectReunionPackageVersion>
+    <ProjectReunionWinUIPackageVersion>0.5.5</ProjectReunionWinUIPackageVersion>
+    <MicrosoftNETCoreUniversalWindowsPlatformVersion>6.2.11</MicrosoftNETCoreUniversalWindowsPlatformVersion>
+    <Win2DWinUIVersion>0.1.0.3</Win2DWinUIVersion>
+    <ColorCodeVersion>2.0.5</ColorCodeVersion>
+    <MicrosoftCsWinRTPackageVersion>1.2.2</MicrosoftCsWinRTPackageVersion>
+    <!-- Where to place the files generated from CSWinRT from XamlControlsGallery.Desktop.-->
+    <GeneratedFilesDir>obj\generated</GeneratedFilesDir>
+    <!-- We have multiple projects in the same directory, which means we need to separate their output paths-->
+    <BaseIntermediateOutputPath>obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
+    <BaseOutputPath>bin\$(MSBuildProjectName)\</BaseOutputPath>
+    <!-- 
+         For Desktop, the .NET 5 SDK automatically includes every .cs file in the project directory.  It normally
+         also excludes items under the obj/bin folders based on the value of BaseIntermediateOutputPath/BaseOutputPath.
+         However, because we overwrite those to output to subdirectories, the outputs of the UWP XamlControlsGallery
+         are erroneously included.  Explicitly exclude them here
+    -->
+    <DefaultItemExcludes>obj\**;bin\**;$(DefaultItemExcludes)</DefaultItemExcludes>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This updates XamlControlsGallery to target the Reunion 0.5.5 servicing release.
