### PR TITLE
Replace controls XAML namespace in TeachingTip example with muxc

### DIFF
--- a/XamlControlsGallery/ControlPagesSampleCode/TeachingTip/TeachingTipSample1_xaml.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/TeachingTip/TeachingTipSample1_xaml.txt
@@ -1,10 +1,10 @@
 ﻿<Button Content="Show TeachingTip" Click="TestButtonClick1" />
 
-<muxc:TeachingTip x:Name="ToggleThemeTeachingTip1"                   
-	Target="{x:Bind ThemeButton}"
-	Title="Change themes without hassle"                                        
-	Subtitle="It's easier than ever to see control samples in both light and dark theme!">
-    <controls:TeachingTip.IconSource>
-        <controls:SymbolIconSource Symbol="Refresh" />
-    </controls:TeachingTip.IconSource>
+<muxc:TeachingTip x:Name="ToggleThemeTeachingTip1"
+    Target="{x:Bind ThemeButton}"
+    Title="Change themes without hassle"
+    Subtitle="It's easier than ever to see control samples in both light and dark theme!">
+    <muxc:TeachingTip.IconSource>
+        <muxc:SymbolIconSource Symbol="Refresh" />
+    </muxc:TeachingTip.IconSource>
 </muxc:TeachingTip>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change replaces `controls` XAML namespace with `muxc` to refer `Microsoft::UI::Xaml::Controls`. It also removes trailing spaces and tabs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change fixes #691. The current example uses both `controls` and `muxc` to refer the same namespace. It's confusing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I built and ran XamlControlsGallery (Debug x64) project using Visual Studio Enterprise 2019 Version 16.9.4 on Windows 10 Version 20H2 (OS Build 19042.985). I confirmed the first example was updated.

## Screenshots (if appropriate):
![A screenshot of XAML Controls Gallery with the updated TeachingTip example](https://user-images.githubusercontent.com/25241373/117409915-b5f46480-af4c-11eb-97c8-bd51f1bfdb57.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
