### PR TITLE
Improve reveal focus a11y, remove obsolete comments

### DIFF
--- a/XamlControlsGallery/ControlPages/RevealFocusPage.xaml
+++ b/XamlControlsGallery/ControlPages/RevealFocusPage.xaml
@@ -198,7 +198,6 @@
                             VerticalAlignment="Center"/>
                         <Button x:Name="primaryColorPickerButton"
                                 Grid.Column="1"
-                                AutomationProperties.Name="{x:Bind myPrimaryColorPicker.Color}"
                                 Background="{x:Bind local2:MyConverters.ColorToBrush(myPrimaryColorPicker.Color), Mode=OneWay}"
                                 Flyout="{StaticResource myPrimaryColorPickerFlyout}"
                                 Height="40"
@@ -211,7 +210,6 @@
                             VerticalAlignment="Center"/>
                         <Button x:Name="secondaryColorPickerButton" 
                                 Grid.Column="1" Grid.Row="1"
-                                AutomationProperties.Name="{x:Bind myPrimaryColorPicker.Color}"
                                 Background="{x:Bind local2:MyConverters.ColorToBrush(mySecondaryColorPicker.Color), Mode=OneWay}"
                                 Flyout="{StaticResource mySecondaryColorPickerFlyout}"
                                 Height="40"

--- a/XamlControlsGallery/ControlPages/RevealFocusPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RevealFocusPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿//*********************************************************
+//*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
 // THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
@@ -12,6 +12,7 @@ using Windows.Foundation.Metadata;
 using Windows.UI;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 
@@ -23,7 +24,6 @@ namespace AppUIBasics.ControlPages
         {
             this.InitializeComponent();
 
-            // DEMO ONLY: Initialize Color rectangles
             if (Spring2018 && Application.Current.FocusVisualKind == FocusVisualKind.Reveal)
             {
                 RevealFocus.IsChecked = true;
@@ -40,7 +40,6 @@ namespace AppUIBasics.ControlPages
             }
         }
 
-        // DEMO ONLY: Change focus visual mode to high visibility
         private void HighVisibility_Checked(object sender, RoutedEventArgs e)
         {
             if (exampleButton.ActualTheme == ElementTheme.Light)
@@ -61,7 +60,6 @@ namespace AppUIBasics.ControlPages
             FocusVisualKindSubstitution.Value = "HighVisibility";
         }
 
-        // DEMO ONLY: Change focus visual mode to reveal focus
         private void RevealFocus_Checked(object sender, RoutedEventArgs e)
         {
             if (Spring2018)
@@ -84,11 +82,14 @@ namespace AppUIBasics.ControlPages
 
         private void confirmColor_Click(object sender, RoutedEventArgs e)
         {
-            // DEMO ONLY: Set colors of the buttons to the selected color in ColorPicker
+            AutomationProperties.SetName(primaryColorPickerButton,
+                "Select primary color, currently selected: " + ColorHelper.ToDisplayName(myPrimaryColorPicker.Color) + " , " + myPrimaryColorPicker.Color.ToString());
+            AutomationProperties.SetName(secondaryColorPickerButton,
+                "Select secondary color, currently selected: " + ColorHelper.ToDisplayName(mySecondaryColorPicker.Color) + " , " + mySecondaryColorPicker.Color.ToString());
+
             primaryColorPickerButton.Background = new SolidColorBrush(myPrimaryColorPicker.Color);
             secondaryColorPickerButton.Background = new SolidColorBrush(mySecondaryColorPicker.Color);
 
-            // DEMO ONLY: Close the Flyout.
             primaryColorPickerButton.Flyout.Hide();
             secondaryColorPickerButton.Flyout.Hide();
         }
@@ -136,6 +137,5 @@ namespace AppUIBasics.ControlPages
         {
             return new SolidColorBrush(color);
         }
-
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR improves the a11y by providing a lot more descriptive UIA name for the color picker buttons.
In addition to this, we are also cleaning up some obsolete comments.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #584 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
