### PR TITLE
Update MaxTestedVersion to >= Windows 11

### DIFF
--- a/XamlControlsGallery/Debug.appxmanifest
+++ b/XamlControlsGallery/Debug.appxmanifest
@@ -8,7 +8,7 @@
     <Logo>Assets\Tiles\StoreLogo-sdk.png</Logo>
   </Properties>
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.14393.0" MaxVersionTested="10.0.17763.0" />
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17134.0" MaxVersionTested="10.0.22200.0" />
   </Dependencies>
   <Resources>
     <Resource Language="x-generate" />

--- a/XamlControlsGallery/Package.appxmanifest
+++ b/XamlControlsGallery/Package.appxmanifest
@@ -8,7 +8,7 @@
     <Logo>Assets\Tiles\StoreLogo-sdk.png</Logo>
   </Properties>
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.14393.0" MaxVersionTested="10.0.17763.0" />
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17134.0" MaxVersionTested="10.0.22200.0" />
   </Dependencies>
   <Resources>
     <Resource Language="x-generate" />

--- a/XamlControlsGallery/XamlControlsGallery.csproj
+++ b/XamlControlsGallery/XamlControlsGallery.csproj
@@ -12,6 +12,8 @@
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17134.0</TargetPlatformMinVersion>
+    <AppxOSMinVersionReplaceManifestVersion>false</AppxOSMinVersionReplaceManifestVersion>
+    <AppxOSMaxVersionTestedReplaceManifestVersion>false</AppxOSMaxVersionTestedReplaceManifestVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <FileAlignment>512</FileAlignment>


### PR DESCRIPTION
There isn't an SDK for Windows 11 yet but we have tested the app on Windows 11 so set the MaxTestedVersion = 22200 so we get the latest behavior. We can remove/undo this when the SDK is available.