### PR TITLE
Update ListView Drop handler to be more generalizable

### DIFF
--- a/XamlControlsGallery/ControlPages/ListViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ListViewPage.xaml.cs
@@ -152,36 +152,37 @@ namespace AppUIBasics.ControlPages
                     // Find the insertion index:
                     Windows.Foundation.Point pos = e.GetPosition(target.ItemsPanelRoot);
 
-                    // Find which ListView is the target, find height of first item
-                    ListViewItem sampleItem;
-                    if (target.Name == "DragDropListView")
+                    // If the target ListView has items in it, use the heigh of the first item
+                    //      to find the insertion index.
+                    int index = 0;
+                    if (target.Items.Count != 0)
                     {
-                        sampleItem = (ListViewItem)DragDropListView2.ContainerFromIndex(0);
+                        // Get a reference to the first item in the ListView
+                        ListViewItem sampleItem = (ListViewItem)target.ContainerFromIndex(0);
+
+                        // Adjust itemHeight for margins
+                        double itemHeight = sampleItem.ActualHeight + sampleItem.Margin.Top + sampleItem.Margin.Bottom;
+
+                        // Find index based on dividing number of items by height of each item
+                        index = Math.Min(target.Items.Count - 1, (int)(pos.Y / itemHeight));
+
+                        // Find the item being dropped on top of.
+                        ListViewItem targetItem = (ListViewItem)target.ContainerFromIndex(index);
+
+                        // If the drop position is more than half-way down the item being dropped on
+                        //      top of, increment the insertion index so the dropped item is inserted
+                        //      below instead of above the item being dropped on top of.
+                        Windows.Foundation.Point positionInItem = e.GetPosition(targetItem);
+                        if (positionInItem.Y > itemHeight / 2)
+                        {
+                            index++;
+                        }
+
+                        // Don't go out of bounds
+                        index = Math.Min(target.Items.Count, index);
                     }
-                    // Only other case is target = DragDropListView2
-                    else
-                    {
-                        sampleItem = (ListViewItem)DragDropListView.ContainerFromIndex(0);
-                    }
-
-                    // Adjust ItemHeight for margins
-                    double itemHeight = sampleItem.ActualHeight + sampleItem.Margin.Top + sampleItem.Margin.Bottom;
-
-                    // Find index based on dividing number of items by height of each item
-                    int index = Math.Min(target.Items.Count - 1, (int)(pos.Y / itemHeight));
-
-                    // Find the item that we want to drop
-                    ListViewItem targetItem = (ListViewItem)target.ContainerFromIndex(index); ;
-
-                    // Figure out if to insert above or below
-                    Windows.Foundation.Point positionInItem = e.GetPosition(targetItem);
-                    if (positionInItem.Y > itemHeight / 2)
-                    {
-                        index++;
-                    }
-
-                    // Don't go out of bounds
-                    index = Math.Min(target.Items.Count, index);
+                    // Only other case is if the target ListView has no items (the dropped item will be
+                    //      the first). In that case, the insertion index will remain zero.
 
                     // Find correct source list
                     if (target.Name == "DragDropListView")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Modified the "ListViews with Drag, Drop, and Reordering Support" sample to make it more generalizable from the specific setup in this app. Also increased clarity in comments, and removed a typo.

## Description
<!--- Describe your changes in detail -->
Modified the Drop handler for the "ListViews with Drag, Drop, and Reordering Support" sample's two ListViews. The insertion index is now initialized to zero. Only if there are items in the target ListView, does the calculation of the insertion index proceed. Otherwise the calculation is skipped and the index retains its initial value of zero. Also updated the comments to remove some ambiguity in describing what the code is doing. Finally, corrected a typo by removing an excess semicolon at the end of what was line 174 (now is line 170).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Previous version assumed height of ListViewItems in both source and target ListViews were identical. A sample ListViewItem (sampleItem) was selected from the source ListView. The height of this sampleItem was then measured to calculate the insertion index for the dropped items. If the item heights in the two ListViews were different, the insertion index would be incorrectly calculated, resulting in the item being inserted in the wrong place, possibly off-screen and possibly confusing the user.

Came across this issue when trying to follow the sample to implement this drag and drop functionality between two ListViews. The ListViews in this case did not have identical ListViewItem heights.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Copied the ContactListViewTemplate DataTemplate in the Page.Resources and modified the copy to assign a different height to the Grid.. Assigned this modified DataTemplate to the ItemTemplate property on DragDropListView2. Built and ran the code. Dragged and dropped items between the DragDropListView and DragDropListView2, in both directions. Items were not inserted at the correct positions.

Repeated the same procedure with the changes made in this pull request to the Drop event handler for the two ListViews. Items were now inserted at the correct positions, regardless of size differences between the two ListViews' item templates.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using Visual Studio 2019 Version 16.10.0 on a 2017 Surface Pro. Confirmed the only two references to the changed function were the two ListViews (DragDropListView and DragDropListView2), so no other area of the code should be affected.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
