### PR TITLE
Increase height of page command bar to prevent cutoff

### DIFF
--- a/XamlControlsGallery/PageHeader.xaml
+++ b/XamlControlsGallery/PageHeader.xaml
@@ -46,7 +46,7 @@
         <Rectangle x:Name="NarrowBackground" Visibility="Collapsed" />
 
         <Rectangle x:Name="WideBackground" Fill="{Binding ElementName=headerControl, Path=Background}" Opacity="{Binding ElementName=headerControl, Path=BackgroundColorOpacity}" />
-        
+
         <Grid x:Name="headerRoot" Padding="{Binding ElementName=headerControl, Path=Padding}" VerticalAlignment="Top">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
@@ -54,7 +54,7 @@
             </Grid.ColumnDefinitions>
             <Grid x:Name="pageTitle"
                 Background="Transparent"
-                Height="40"
+                Height="44"
                 VerticalAlignment="Top">
                 <Canvas x:Name="ShadowHost" Opacity="{x:Bind ShadowOpacity, Mode=OneWay}"/>
                 <TextBlock x:Name="TitleTextBlock"
@@ -69,7 +69,7 @@
             <Border x:Name="commandBarBorder" Grid.Column="1" VerticalAlignment="Top">
                 <CommandBar
                     x:Name="topCommandBar"
-                    Height="40"
+                    Height="44"
                     Margin="0,0,12,0"
                     Background="Transparent"
                     ClosedDisplayMode="Compact"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
very minor fix.

## Description
<!--- Describe your changes in detail -->
Increases the height of commandBarBorder from 40px to 44px to prevent cut off, and increases the pageTitle grid to 44px to match commandBarBorder. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #739

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manually.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/59544401/126854421-7d80e42b-b932-432e-8557-ee289bcf76da.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
