### PR TITLE
Make version number text in settings selectable

### DIFF
--- a/XamlControlsGallery/SettingsPage.xaml
+++ b/XamlControlsGallery/SettingsPage.xaml
@@ -106,7 +106,7 @@
                         <Run FontStyle="Italic">git clone https://github.com/Microsoft/Xaml-Controls-Gallery</Run>
                     </Paragraph>
                 </RichTextBlock>
-                <TextBlock Margin="0,10,0,0">
+                <TextBlock Margin="0,10,0,0" IsTextSelectionEnabled="True">
                     Version: 
                     <Run Text="{x:Bind Version}" FontWeight="Bold" />
                 </TextBlock>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Makes the version number text selectable to make it easier to copy-paste somewhere else, like the issue template.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It can be a bit annoying to have to manually copy the version number, having it selectable is more convenient.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manually

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/59544401/126860447-6d15ddc5-a83d-436a-8636-a2d329f6b5b7.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)