### PR TITLE
Fix bug where user selection would change text and unset selection

### DIFF
--- a/XamlControlsGallery/ControlPages/AutoSuggestBoxPage.xaml
+++ b/XamlControlsGallery/ControlPages/AutoSuggestBoxPage.xaml
@@ -33,24 +33,29 @@ private List&lt;string&gt; Cats = new List&lt;string&gt;()
 // Handle text change and present suitable items
 private void AutoSuggestBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
 {
-    var suitableItems = new List&lt;string&gt;();
-    var splitText = sender.Text.ToLower().Split(" ");
-    foreach(var cat in Cats)
+    // Since selecting an item will also change the text,
+    // only listen to changes caused by user entering text.
+    if(args.Reason == AutoSuggestionBoxTextChangeReason.UserInput)
     {
-        var found = splitText.All((key)=>
+        var suitableItems = new List&lt;string&gt;();
+        var splitText = sender.Text.ToLower().Split(" ");
+        foreach(var cat in Cats)
         {
-            return cat.ToLower().Contains(key);
-        });
-        if(found)
-        {
-            suitableItems.Add(cat);
+            var found = splitText.All((key)=>
+            {
+                return cat.ToLower().Contains(key);
+            });
+            if(found)
+            {
+                suitableItems.Add(cat);
+            }
         }
+        if(suitableItems.Count == 0)
+        {
+            suitableItems.Add("No results found");
+        }
+        sender.ItemsSource = suitableItems;
     }
-    if(suitableItems.Count == 0)
-    {
-        suitableItems.Add("No results found");
-    }
-    sender.ItemsSource = suitableItems;
 }
 
 // Handle user selecting an item, in our case just output the selected item.

--- a/XamlControlsGallery/ControlPages/AutoSuggestBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AutoSuggestBoxPage.xaml.cs
@@ -133,24 +133,29 @@ namespace AppUIBasics.ControlPages
 
         private void AutoSuggestBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
         {
-            var suitableItems = new List<string>();
-            var splitText = sender.Text.ToLower().Split(" ");
-            foreach(var cat in Cats)
+            // Since selecting an item will also change the text,
+            // only listen to changes caused by user entering text.
+            if(args.Reason == AutoSuggestionBoxTextChangeReason.UserInput)
             {
-                var found = splitText.All((key)=>
+                var suitableItems = new List<string>();
+                var splitText = sender.Text.ToLower().Split(" ");
+                foreach(var cat in Cats)
                 {
-                    return cat.ToLower().Contains(key);
-                });
-                if(found)
-                {
-                    suitableItems.Add(cat);
+                    var found = splitText.All((key)=>
+                    {
+                        return cat.ToLower().Contains(key);
+                    });
+                    if(found)
+                    {
+                        suitableItems.Add(cat);
+                    }
                 }
+                if(suitableItems.Count == 0)
+                {
+                    suitableItems.Add("No results found");
+                }
+                sender.ItemsSource = suitableItems;
             }
-            if(suitableItems.Count == 0)
-            {
-                suitableItems.Add("No results found");
-            }
-            sender.ItemsSource = suitableItems;
         }
 
         private void AutoSuggestBox_SuggestionChosen(AutoSuggestBox sender, AutoSuggestBoxSuggestionChosenEventArgs args)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We were not checking who caused the text selection and as such, ended up unsetting the selection with our text selection handler.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #759 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
