### PR TITLE
Fix bug where header would be white on white in light theme

### DIFF
--- a/XamlControlsGallery/PageHeader.xaml
+++ b/XamlControlsGallery/PageHeader.xaml
@@ -61,7 +61,7 @@
                     Style="{StaticResource TitleTextBlockStyle}"
                     VerticalAlignment="Center"
                     FontSize="{Binding ElementName=headerControl, Path=FontSize}"
-                    Foreground="{Binding ElementName=headerControl, Path=Foreground}"
+                    Foreground="{ThemeResource SystemControlForegroundAltHighBrush}"
                     Text="{x:Bind Title, Mode=OneWay}"
                     TextTrimming="CharacterEllipsis"
                     TextWrapping="NoWrap" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use explicit resource for foreground color.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #710
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually.
## Screenshots (if appropriate):
![Screenshot of XAML Controls Galleries What's new page with black header on white background](https://user-images.githubusercontent.com/16122379/130670430-a6db1192-6745-42a4-b801-88633b587184.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
