### PR TITLE
Disable evaluation purpose API warning

### DIFF
--- a/XamlControlsGallery/XamlControlsGallery.csproj
+++ b/XamlControlsGallery/XamlControlsGallery.csproj
@@ -107,6 +107,9 @@
     <Prefer32Bit>true</Prefer32Bit>
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
   </PropertyGroup>
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);8305</NoWarn>
+  </PropertyGroup>
   <PropertyGroup Condition="$(IsWinUIPrerelease) == 'True'">
     <DefineConstants>$DefineConstants;WINUI_PRERELEASE</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If you build the app right now, there are dozens of warning that say we are using preview APIs that are for evaluation purposes. Since the XCG is meant to show new features, we can ignore those warnings and make the app build produce less noise.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Make detecting relevant warnings easier.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually by building the app.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
