### PR TITLE
[ItemsRepeater page] Fix crash on layout selection

### DIFF
--- a/XamlControlsGallery/ControlPages/ItemsRepeaterPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ItemsRepeaterPage.xaml.cs
@@ -162,6 +162,11 @@ namespace AppUIBasics.ControlPages
         {
             string itemTemplateKey = string.Empty;
             var selected = (sender as Microsoft.UI.Xaml.Controls.RadioButtons).SelectedItem;
+            if(selected == null)
+            {
+                // No point in continuing if selected element is null
+                return;
+            }
             var layoutKey = ((FrameworkElement)selected).Tag as string;
 
             if (layoutKey.Equals(nameof(this.VerticalStackLayout))) // we used x:Name in the resources which both acts as the x:Key value and creates a member field by the same name


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The issue was that selecteditem was null when processing the layout selection change causing a nullreference exception
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #811
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
