### PR TITLE
Remove misleading, unused property "IsSelected" in TreeView sample

### DIFF
--- a/XamlControlsGallery/ControlPages/TreeViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/TreeViewPage.xaml.cs
@@ -199,22 +199,6 @@ namespace AppUIBasics.ControlPages
             }
         }
 
-        private bool m_isSelected;
-        public bool IsSelected
-        {
-            get { return m_isSelected; }
-
-            set
-            {
-                if (m_isSelected != value)
-                {
-                    m_isSelected = value;
-                    NotifyPropertyChanged("IsSelected");
-                }
-            }
-
-        }
-
         private void NotifyPropertyChanged(string propertyName)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));


### PR DESCRIPTION
## Description
This PR removes the `IsSelected` property, on a sample view model on the TreeView page. This was unused code before.

At least to me, the property strongly implies that it might be used with TreeView to bind to the `IsSelected` property of the TreeViewItem. This however, [does not work](https://github.com/microsoft/microsoft-ui-xaml/issues/125). So I think this is a bad sample property and should be removed.

## Motivation and Context
See description above

## How Has This Been Tested?
Tested manually, app still builds, runs and TreeView page still works.

## Screenshots (if appropriate):
none

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Minor
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
