### PR TITLE
Fixed NavigationView PaneOpening Event Name

### DIFF
--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml
@@ -97,7 +97,7 @@
             HeaderTemplate="{StaticResource NavigationViewHeaderTemplate}"
             IsTabStop="False"
             IsTitleBarAutoPaddingEnabled="False"
-            PaneOpening="NavigationViewControl_PaneOpened"
+            PaneOpening="NavigationViewControl_PaneOpening"
             PaneClosing="NavigationViewControl_PaneClosing"
             DisplayModeChanged="NavigationViewControl_DisplayModeChanged"
             ItemInvoked="OnNavigationViewItemInvoked"

--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml
@@ -97,7 +97,7 @@
             HeaderTemplate="{StaticResource NavigationViewHeaderTemplate}"
             IsTabStop="False"
             IsTitleBarAutoPaddingEnabled="False"
-            PaneOpening="NavigationViewControl_PaneOpening"
+            PaneOpening="NavigationViewControl_PaneOpened"
             PaneClosing="NavigationViewControl_PaneClosing"
             DisplayModeChanged="NavigationViewControl_DisplayModeChanged"
             ItemInvoked="OnNavigationViewItemInvoked"

--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
@@ -472,7 +472,7 @@ namespace AppUIBasics
             UpdateAppTitleMargin(sender);
         }
 
-        private void NavigationViewControl_PaneOpened(Microsoft.UI.Xaml.Controls.NavigationView sender, object args)
+        private void NavigationViewControl_PaneOpening(Microsoft.UI.Xaml.Controls.NavigationView sender, object args)
         {
             UpdateAppTitleMargin(sender);
         }

--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
@@ -472,7 +472,7 @@ namespace AppUIBasics
             UpdateAppTitleMargin(sender);
         }
 
-        private void NavigationViewControl_PaneOpening(Microsoft.UI.Xaml.Controls.NavigationView sender, object args)
+        private void NavigationViewControl_PaneOpened(Microsoft.UI.Xaml.Controls.NavigationView sender, object args)
         {
             UpdateAppTitleMargin(sender);
         }


### PR DESCRIPTION
## Description
In the NavigationRootPage.xaml file the NavigationView Opening event had a misspelled name "_PaneOpened" instead of "_PaneOpening".

## Motivation and Context
The spelling mistake did not apparently cause any issue. But during the development of my own app, I was referring to the code from XAML Controls Gallery app and found out that this name spelling mistake caused confusion and I was not triggering the right event which wasted time.

## How Has This Been Tested?
The change has been tested locally on the computer. It does not break anything.
Testing Environment: Windows 11 22000. 
It does not affect any other areas of code. It was just a event spelling mistake not referenced by any other code.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
