### PR TITLE
Fix splitbutton keyboard accessability.

### DIFF
--- a/XamlControlsGallery/ControlPages/SplitButtonPage.xaml
+++ b/XamlControlsGallery/ControlPages/SplitButtonPage.xaml
@@ -18,7 +18,7 @@
                     <Border x:Name="CurrentColor" Width="{StaticResource SwatchSize}" Height="{StaticResource SwatchSize}" Background="Green" Margin="0" CornerRadius="4,0,0,4"/>
                     <muxc:SplitButton.Flyout>
                         <Flyout Placement="Bottom">
-                            <GridView>
+                            <GridView ItemClick="GridView_ItemClick" IsItemClickEnabled="True">
                                 <GridView.ItemsPanel>
                                     <ItemsPanelTemplate>
                                         <ItemsWrapGrid MaximumRowsOrColumns="3" Orientation="Horizontal"/>
@@ -31,55 +31,16 @@
                                         <Setter Property="RadiusX" Value="4"/>
                                         <Setter Property="RadiusY" Value="4"/>
                                     </Style>
-                                    <Style TargetType="Button">
-                                        <Setter Property="Padding" Value="0"/>
-                                        <Setter Property="MinWidth" Value="0"/>
-                                        <Setter Property="MinHeight" Value="0"/>
-                                        <Setter Property="Margin" Value="6"/>
-                                        <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}"/>
-                                    </Style>
                                 </GridView.Resources>
                                 <GridView.Items>
-                                    <Button Click="ColorButton_Click" AutomationProperties.Name="Red">
-                                        <Button.Content>
-                                            <Rectangle Fill="Red"/>
-                                        </Button.Content>
-                                    </Button>
-                                    <Button Click="ColorButton_Click" AutomationProperties.Name="Orange">
-                                        <Button.Content>
-                                            <Rectangle Fill="Orange"/>
-                                        </Button.Content>
-                                    </Button>
-                                    <Button Click="ColorButton_Click" AutomationProperties.Name="Yellow">
-                                        <Button.Content>
-                                            <Rectangle Fill="Yellow"/>
-                                        </Button.Content>
-                                    </Button>
-                                    <Button Click="ColorButton_Click" AutomationProperties.Name="Green">
-                                        <Button.Content>
-                                            <Rectangle Fill="Green"/>
-                                        </Button.Content>
-                                    </Button>
-                                    <Button Click="ColorButton_Click" AutomationProperties.Name="Blue">
-                                        <Button.Content>
-                                            <Rectangle Fill="Blue"/>
-                                        </Button.Content>
-                                    </Button>
-                                    <Button Click="ColorButton_Click" AutomationProperties.Name="Indigo">
-                                        <Button.Content>
-                                            <Rectangle Fill="Indigo"/>
-                                        </Button.Content>
-                                    </Button>
-                                    <Button Click="ColorButton_Click" AutomationProperties.Name="Violet">
-                                        <Button.Content>
-                                            <Rectangle Fill="Violet"/>
-                                        </Button.Content>
-                                    </Button>
-                                    <Button Click="ColorButton_Click" AutomationProperties.Name="Gray">
-                                        <Button.Content>
-                                            <Rectangle Fill="Gray"/>
-                                        </Button.Content>
-                                    </Button>
+                                    <Rectangle Fill="Red"/>
+                                    <Rectangle Fill="Orange"/>
+                                    <Rectangle Fill="Yellow"/>
+                                    <Rectangle Fill="Green"/>
+                                    <Rectangle Fill="Blue"/>
+                                    <Rectangle Fill="Indigo"/>
+                                    <Rectangle Fill="Violet"/>
+                                    <Rectangle Fill="Gray"/>
                                 </GridView.Items>
                             </GridView>
 

--- a/XamlControlsGallery/ControlPages/SplitButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/SplitButtonPage.xaml.cs
@@ -27,10 +27,6 @@ namespace AppUIBasics.ControlPages
             myRichEditBox.Document.Selection.CharacterFormat.ForegroundColor = color;
             CurrentColor.Background = new SolidColorBrush(color);
 
-            //if (myColorButton.Flyout.IsOpen)
-            //{
-            //    myColorButton.Flyout.Hide
-            //}
             myColorButton.Flyout.Hide();
             myRichEditBox.Focus(Windows.UI.Xaml.FocusState.Keyboard);
             currentColor = color;

--- a/XamlControlsGallery/ControlPages/SplitButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/SplitButtonPage.xaml.cs
@@ -2,6 +2,7 @@ using Windows.UI;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Shapes;
 
 namespace AppUIBasics.ControlPages
 {
@@ -19,16 +20,17 @@ namespace AppUIBasics.ControlPages
                 "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Tempor commodo ullamcorper a lacus.");
         }
 
-        private void ColorButton_Click(object sender, RoutedEventArgs e)
+        private void GridView_ItemClick(object sender, ItemClickEventArgs e)
         {
-            // Extract the color of the button that was clicked.
-            Button clickedColor = (Button)sender;
-            var rectangle = (Windows.UI.Xaml.Shapes.Rectangle)clickedColor.Content;
-            var color = ((Windows.UI.Xaml.Media.SolidColorBrush)rectangle.Fill).Color;
-
+            var rect = (Rectangle)e.ClickedItem;
+            var color = ((SolidColorBrush)rect.Fill).Color;
             myRichEditBox.Document.Selection.CharacterFormat.ForegroundColor = color;
             CurrentColor.Background = new SolidColorBrush(color);
 
+            //if (myColorButton.Flyout.IsOpen)
+            //{
+            //    myColorButton.Flyout.Hide
+            //}
             myColorButton.Flyout.Hide();
             myRichEditBox.Focus(Windows.UI.Xaml.FocusState.Keyboard);
             currentColor = color;


### PR DESCRIPTION
Fix a bug where the items in the split button drop down were not keyboard invokable, which was (inappropriately) being flagged as a sev 1 accessibility issue for Winui.