### PR TITLE
Fix issue with compact NavView InfoBadge sample

### DIFF
--- a/XamlControlsGallery/ControlPages/InfoBadgePage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/InfoBadgePage.xaml.cs
@@ -32,7 +32,7 @@ namespace AppUIBasics.ControlPages
 
                 case "LeftCompact":
                     nvSample1.PaneDisplayMode = Microsoft.UI.Xaml.Controls.NavigationViewPaneDisplayMode.LeftCompact;
-                    nvSample1.IsPaneOpen = true;
+                    nvSample1.IsPaneOpen = false;
                     break;
 
                 case "Top":


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The navview sample would try to reopen the pane when switching to left compact which created rendering artifacts. Since switching to left compact and opening the pane does not look any different than left expanded, I've updated the code to leave the pane open.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #843 
## How Has This Been Tested?

Tested manually.

![Video showing NavigationView opening and closing correctly](https://user-images.githubusercontent.com/16122379/150594826-73a25217-2c51-4167-bd06-c4c3c7529407.gif)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
