### PR TITLE
Syntax typo in XAML example text in ItemsRepeaterPage.xaml

### DIFF
--- a/XamlControlsGallery/ControlPages/ItemsRepeaterPage.xaml
+++ b/XamlControlsGallery/ControlPages/ItemsRepeaterPage.xaml
@@ -143,7 +143,7 @@
         ItemsSource="{x:Bind BarItems}"
         Layout="{StaticResource $(Layout)}"
         ItemTemplate="{StaticResource $(ElementGenerator)}" /&gt;
-&lt;ScrollViewer/&gt;
+&lt;/ScrollViewer&gt;
                     
 &lt;!-- The Layout specifications used: --&gt;
                     


### PR DESCRIPTION
Dash is on the wrong end of the closing tag. Only affects the displayed example code. XAML was correct in the functional code.

## Description
`<!-- The ItemsRepeater and ScrollViewer used: -->
<ScrollViewer HorizontalScrollBarVisibility="Auto" 
        HorizontalScrollMode="Auto" 
        IsVerticalScrollChainingEnabled="False"
        MaxHeight="500">
    <muxc:ItemsRepeater
        ItemsSource="{x:Bind BarItems}"
        Layout="{StaticResource $(Layout)}"
        ItemTemplate="{StaticResource $(ElementGenerator)}" />
<ScrollViewer/>`

Dash is in the wrong end of closing tag

## Motivation and Context
When implementing the example in the readers code, they would copy and paste this example, which results in invalid XAML.

## How Has This Been Tested?
The change was required to make code functional and valid XAML. Tested the code in my own app.

I did not run any official tests, but this is not functional code for the application, rather just a text content for an example.

## Screenshots (if appropriate):
![tag](https://user-images.githubusercontent.com/7784183/150655130-1a429ef4-a35a-4ada-a2bf-5d16a30c06d4.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
