### PR TITLE
Fix issue for markers on whats new page in high contrast

### DIFF
--- a/XamlControlsGallery/ItemTemplates.xaml
+++ b/XamlControlsGallery/ItemTemplates.xaml
@@ -75,7 +75,7 @@
                     CornerRadius="{StaticResource ControlCornerRadius}"
                     Visibility="{x:Bind BadgeString, Converter={StaticResource nullToVisibilityConverter}}" >
 
-                    <Ellipse Fill="{ThemeResource AccentFillColorDefaultBrush}" Width="12" Height="12"/>
+                    <Ellipse Fill="{ThemeResource SystemAccentColorDark1}" Width="12" Height="12"/>
                 </Grid>
             </Grid>
         </UserControl>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The brush we were using was using an not optimal value in high contrast. Instead we are using the brush it is based on in non high contrast which also has a good fallback value in high contrast.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #849
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually.

## Screenshots (if appropriate):
![Screenshot of whats new page in high contrast](https://user-images.githubusercontent.com/16122379/151597248-8357c32e-a8fb-4ea0-9519-f8d23efddd28.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
