### PR TITLE
Add Multi Window and Titlebar samples

### DIFF
--- a/XamlControlsGallery/AllControlsPage.xaml.cs
+++ b/XamlControlsGallery/AllControlsPage.xaml.cs
@@ -25,9 +25,11 @@ namespace AppUIBasics
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            var menuItem = (Microsoft.UI.Xaml.Controls.NavigationViewItem)NavigationRootPage.Current.NavigationView.MenuItems.ElementAt(1);
+            NavigationRootPageArgs args = (NavigationRootPageArgs)e.Parameter;
+
+            var menuItem = (Microsoft.UI.Xaml.Controls.NavigationViewItem)args.NavigationRootPage.NavigationView.MenuItems.ElementAt(1);
             menuItem.IsSelected = true;
-            NavigationRootPage.Current.NavigationView.Header = string.Empty;
+            args.NavigationRootPage.NavigationView.Header = string.Empty;
 
             Items = ControlInfoDataSource.Instance.Groups.SelectMany(g => g.Items).OrderBy(i => i.Title).ToList();
         }

--- a/XamlControlsGallery/App.xaml.cs
+++ b/XamlControlsGallery/App.xaml.cs
@@ -51,6 +51,8 @@ namespace AppUIBasics
             }
         }
 
+        public static UIElement appTitlebar = null;
+
         /// <summary>
         /// Initializes the singleton Application object.  This is the first line of authored code
         /// executed, and as such is the logical equivalent of main() or WinMain().

--- a/XamlControlsGallery/Common/Win32.cs
+++ b/XamlControlsGallery/Common/Win32.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace AppUIBasics
+{
+    internal static class Win32
+    {
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        public static extern IntPtr SendMessage(IntPtr hWnd, int Msg, int wParam, IntPtr lParam);
+
+        [DllImport("user32.dll")]
+        public static extern IntPtr LoadIcon(IntPtr hInstance, IntPtr lpIconName);
+
+        [DllImport("user32.dll")]
+        public static extern IntPtr GetActiveWindow();
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+        public static extern IntPtr GetModuleHandle(IntPtr moduleName);
+
+        public const int WM_ACTIVATE = 0x0006;
+        public const int WA_ACTIVE = 0x01;
+        //static int WA_CLICKACTIVE = 0x02;
+        public const int WA_INACTIVE = 0x00;
+
+        public const int WM_SETICON = 0x0080;
+        public const int ICON_SMALL = 0;
+        public const int ICON_BIG = 1;
+    }
+}

--- a/XamlControlsGallery/Common/WindowHelper.cs
+++ b/XamlControlsGallery/Common/WindowHelper.cs
@@ -1,0 +1,57 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+
+using Microsoft.UI.Xaml;
+using System.Collections.Generic;
+
+namespace AppUIBasics
+{
+    // Helper class to allow the app to find the Window that contains an
+    // arbitrary UIElement (GetWindowForElement).  To do this, we keep track
+    // of all active Windows.  The app code must call WindowHelper.CreateWindow
+    // rather than "new Window" so we can keep track of all the relevant
+    // windows.  In the future, we would like to support this in platform APIs.
+    public class WindowHelper
+    {
+        static public Window CreateWindow()
+        {
+            Window newWindow = new Window();
+            TrackWindow(newWindow);
+            return newWindow;
+        }
+
+        static public void TrackWindow(Window window)
+        {
+            window.Closed += (sender,args) => {
+                _activeWindows.Remove(window);
+            };
+            _activeWindows.Add(window);
+        }
+
+        static public Window GetWindowForElement(UIElement element)
+        {
+            if (element.XamlRoot != null)
+            {
+                foreach (Window window in _activeWindows)
+                {
+                    if (element.XamlRoot == window.Content.XamlRoot)
+                    {
+                        return window;
+                    }
+                }
+            }
+            return null;
+        }
+
+        static public List<Window> ActiveWindows { get { return _activeWindows; }}
+
+        static private List<Window> _activeWindows = new List<Window>();
+    }
+}

--- a/XamlControlsGallery/ContentIncludes.props
+++ b/XamlControlsGallery/ContentIncludes.props
@@ -259,6 +259,8 @@
     <Content Include="ControlPagesSampleCode\CommandBarFlyout\CommandBarFlyoutSample1_xaml.txt" />
     <Content Include="ControlPagesSampleCode\XamlUICommand\XamlUICommandSample1_cs.txt" />
     <Content Include="ControlPagesSampleCode\XamlUICommand\XamlUICommandSample1_xaml.txt" />
+    <Content Include="ControlPagesSampleCode\Window\CustomTitlebar\CustomTitlebarSample1.txt" />
+    <Content Include="ControlPagesSampleCode\Window\CustomTitlebar\CustomTitlebarSample2.txt" />
     <Content Include="Common\ReadMe.txt" />
     <Content Include="DataModel\ControlInfoData.json" />
   </ItemGroup>

--- a/XamlControlsGallery/ContentIncludes.props
+++ b/XamlControlsGallery/ContentIncludes.props
@@ -259,6 +259,7 @@
     <Content Include="ControlPagesSampleCode\CommandBarFlyout\CommandBarFlyoutSample1_xaml.txt" />
     <Content Include="ControlPagesSampleCode\XamlUICommand\XamlUICommandSample1_cs.txt" />
     <Content Include="ControlPagesSampleCode\XamlUICommand\XamlUICommandSample1_xaml.txt" />
+    <Content Include="ControlPagesSampleCode\Window\CreateWindowSample1.txt" />
     <Content Include="ControlPagesSampleCode\Window\CustomTitlebar\CustomTitlebarSample1.txt" />
     <Content Include="ControlPagesSampleCode\Window\CustomTitlebar\CustomTitlebarSample2.txt" />
     <Content Include="Common\ReadMe.txt" />

--- a/XamlControlsGallery/ControlPages/AcrylicPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AcrylicPage.xaml.cs
@@ -27,7 +27,7 @@ namespace AppUIBasics.ControlPages
         {
             //Rectangle shape = (sender == OpacitySliderInApp) ? CustomAcrylicShapeInApp : CustomAcrylicShape;
             Rectangle shape = CustomAcrylicShapeInApp;
-            if (sender == OpacitySliderLumin)
+            if ((Slider)sender == OpacitySliderLumin)
                 shape = CustomAcrylicShapeLumin;
 
             ((Microsoft.UI.Xaml.Media.AcrylicBrush)shape.Fill).TintOpacity = e.NewValue;

--- a/XamlControlsGallery/ControlPages/AppBarButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AppBarButtonPage.xaml.cs
@@ -28,7 +28,7 @@ namespace AppUIBasics.ControlPages
 
         private void AppBarButtonPage_Unloaded(object sender, RoutedEventArgs e)
         {
-            CommandBar appBar = NavigationRootPage.Current.PageHeader.TopCommandBar;
+            CommandBar appBar = NavigationRootPage.GetForElement(this).PageHeader.TopCommandBar;
             compactButton.Click -= CompactButton_Click;
             appBar.PrimaryCommands.Remove(compactButton);
             appBar.PrimaryCommands.Remove(separator);
@@ -39,7 +39,7 @@ namespace AppUIBasics.ControlPages
             // Add compact button to the command bar. It provides functionality specific
             // to this page, and is removed when leaving the page.
 
-            CommandBar appBar = NavigationRootPage.Current.PageHeader.TopCommandBar;
+            CommandBar appBar = NavigationRootPage.GetForElement(this).PageHeader.TopCommandBar;
             separator = new AppBarSeparator();
             appBar.PrimaryCommands.Insert(0, separator);
 

--- a/XamlControlsGallery/ControlPages/AppBarPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AppBarPage.xaml.cs
@@ -23,7 +23,7 @@ namespace AppUIBasics.ControlPages
 
         private void topAppBar_Opened(object sender, object e)
         {
-            CommandBar headerTopAppBar = NavigationRootPage.Current.PageHeader.TopCommandBar;
+            CommandBar headerTopAppBar = NavigationRootPage.GetForElement(this).PageHeader.TopCommandBar;
             headerTopAppBar.IsOpen = false;
         }
 
@@ -41,15 +41,16 @@ namespace AppUIBasics.ControlPages
         {
             ButtonBase b = (ButtonBase)sender;
 
-            if (App.CurrentWindow.Content is Frame rootFrame && b.Tag != null)
+            NavigationRootPage navigationRootPage = NavigationRootPage.GetForElement(this);
+            if (navigationRootPage != null && b.Tag != null)
             {
                 if (b.Tag.ToString() == "Home")
                 {
-                    rootFrame.Navigate(typeof(AppUIBasics.AllControlsPage));
+                    navigationRootPage.Navigate(typeof(AppUIBasics.AllControlsPage));
                 }
                 else
                 {
-                    rootFrame.Navigate(typeof(SectionPage), b.Tag.ToString());
+                    navigationRootPage.Navigate(typeof(SectionPage), b.Tag.ToString());
                 }
             }
         }

--- a/XamlControlsGallery/ControlPages/AppBarSeparatorPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AppBarSeparatorPage.xaml.cs
@@ -28,7 +28,7 @@ namespace AppUIBasics.ControlPages
 
         private void AppBarSeparatorPage_Unloaded(object sender, RoutedEventArgs e)
         {
-            CommandBar appBar = NavigationRootPage.Current.PageHeader.TopCommandBar;
+            CommandBar appBar = NavigationRootPage.GetForElement(this).PageHeader.TopCommandBar;
             compactButton.Click -= CompactButton_Click;
             appBar.PrimaryCommands.Remove(compactButton);
             appBar.PrimaryCommands.Remove(separator);
@@ -39,7 +39,7 @@ namespace AppUIBasics.ControlPages
             // Add compact button to the command bar. It provides functionality specific
             // to this page, and is removed when leaving the page.
 
-            CommandBar appBar = NavigationRootPage.Current.PageHeader.TopCommandBar;
+            CommandBar appBar = NavigationRootPage.GetForElement(this).PageHeader.TopCommandBar;
             separator = new AppBarSeparator();
             appBar.PrimaryCommands.Insert(0, separator);
 

--- a/XamlControlsGallery/ControlPages/AppBarToggleButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/AppBarToggleButtonPage.xaml.cs
@@ -28,7 +28,7 @@ namespace AppUIBasics.ControlPages
 
         private void AppBarToggleButtonPage_Unloaded(object sender, RoutedEventArgs e)
         {
-            CommandBar appBar = NavigationRootPage.Current.PageHeader.TopCommandBar;
+            CommandBar appBar = NavigationRootPage.GetForElement(this).PageHeader.TopCommandBar;
             compactButton.Click -= CompactButton_Click;
             appBar.PrimaryCommands.Remove(compactButton);
             appBar.PrimaryCommands.Remove(separator);
@@ -39,7 +39,7 @@ namespace AppUIBasics.ControlPages
             // Add compact button to the command bar. It provides functionality specific
             // to this page, and is removed when leaving the page.
 
-            CommandBar appBar = NavigationRootPage.Current.PageHeader.TopCommandBar;
+            CommandBar appBar = NavigationRootPage.GetForElement(this).PageHeader.TopCommandBar;
             separator = new AppBarSeparator();
             appBar.PrimaryCommands.Insert(0, separator);
 

--- a/XamlControlsGallery/ControlPages/CreateMultipleWindowsPage.cs
+++ b/XamlControlsGallery/ControlPages/CreateMultipleWindowsPage.cs
@@ -8,6 +8,7 @@
 //
 //*********************************************************
 using AppUIBasics.Data;
+using AppUIBasics.Helper;
 using System.Collections.Generic;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -49,7 +50,7 @@ namespace AppUIBasics.ControlPages
         {
             var newWindow = WindowHelper.CreateWindow();
             var rootPage = new NavigationRootPage();
-            rootPage.RequestedTheme = App.RootTheme;
+            rootPage.RequestedTheme = ThemeHelper.RootTheme;
             newWindow.Content = rootPage;
             newWindow.Activate();
 

--- a/XamlControlsGallery/ControlPages/CreateMultipleWindowsPage.cs
+++ b/XamlControlsGallery/ControlPages/CreateMultipleWindowsPage.cs
@@ -47,15 +47,15 @@ namespace AppUIBasics.ControlPages
 
         private void createNewWindow_Click(object sender, RoutedEventArgs e)
         {
-            var newWindow = new Window();
+            var newWindow = WindowHelper.CreateWindow();
             var rootPage = new NavigationRootPage();
+            rootPage.RequestedTheme = App.RootTheme;
             newWindow.Content = rootPage;
             newWindow.Activate();
 
             var targetPageType = typeof(NewControlsPage);
             string targetPageArguments = string.Empty;
-            var rootFrame = (Frame)rootPage.FindName("rootFrame");
-            rootFrame.Navigate(targetPageType, targetPageArguments);
+            rootPage.Navigate(targetPageType, targetPageArguments);
         }
     }
 }

--- a/XamlControlsGallery/ControlPages/CreateMultipleWindowsPage.cs
+++ b/XamlControlsGallery/ControlPages/CreateMultipleWindowsPage.cs
@@ -1,0 +1,61 @@
+﻿//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+using AppUIBasics.Data;
+using System.Collections.Generic;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace AppUIBasics.ControlPages
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class CreateMultipleWindowsPage : Page
+    {
+        private IEnumerable<ControlInfoDataGroup> _groups;
+
+        public CreateMultipleWindowsPage()
+        {
+            this.InitializeComponent();
+        }
+        public IEnumerable<ControlInfoDataGroup> Groups
+        {
+            get { return this._groups; }
+        }
+
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            base.OnNavigatedTo(e);
+
+            _groups = ControlInfoDataSource.Instance.Groups;
+        }
+
+        private void List_GotFocus(object sender, RoutedEventArgs e)
+        {
+            Control1.StartBringIntoView();
+        }
+
+        private void createNewWindow_Click(object sender, RoutedEventArgs e)
+        {
+            var newWindow = new Window();
+            var rootPage = new NavigationRootPage();
+            newWindow.Content = rootPage;
+            newWindow.Activate();
+
+            var targetPageType = typeof(NewControlsPage);
+            string targetPageArguments = string.Empty;
+            var rootFrame = (Frame)rootPage.FindName("rootFrame");
+            rootFrame.Navigate(targetPageType, targetPageArguments);
+        }
+    }
+}

--- a/XamlControlsGallery/ControlPages/CreateMultipleWindowsPage.cs
+++ b/XamlControlsGallery/ControlPages/CreateMultipleWindowsPage.cs
@@ -14,13 +14,8 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
 
-// The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=234238
-
 namespace AppUIBasics.ControlPages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class CreateMultipleWindowsPage : Page
     {
         private IEnumerable<ControlInfoDataGroup> _groups;

--- a/XamlControlsGallery/ControlPages/CreateMultipleWindowsPage.cs
+++ b/XamlControlsGallery/ControlPages/CreateMultipleWindowsPage.cs
@@ -18,22 +18,9 @@ namespace AppUIBasics.ControlPages
 {
     public sealed partial class CreateMultipleWindowsPage : Page
     {
-        private IEnumerable<ControlInfoDataGroup> _groups;
-
         public CreateMultipleWindowsPage()
         {
             this.InitializeComponent();
-        }
-        public IEnumerable<ControlInfoDataGroup> Groups
-        {
-            get { return this._groups; }
-        }
-
-        protected override void OnNavigatedTo(NavigationEventArgs e)
-        {
-            base.OnNavigatedTo(e);
-
-            _groups = ControlInfoDataSource.Instance.Groups;
         }
 
         private void List_GotFocus(object sender, RoutedEventArgs e)

--- a/XamlControlsGallery/ControlPages/CreateMultipleWindowsPage.xaml
+++ b/XamlControlsGallery/ControlPages/CreateMultipleWindowsPage.xaml
@@ -1,0 +1,28 @@
+﻿<!--
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+-->
+<Page
+    x:Class="AppUIBasics.ControlPages.CreateMultipleWindowsPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:AppUIBasics"
+    xmlns:data="using:AppUIBasics.Data"
+    xmlns:wuxdata="using:Microsoft.UI.Xaml.Data"
+    mc:Ignorable="d">
+   
+    <StackPanel>
+        <local:ControlExample HeaderText="Create single threaded Multiple Top level Windows(MTW).">
+            <Button x:Name="Control1" Click="createNewWindow_Click">Create new Window</Button>
+        </local:ControlExample>
+    </StackPanel>
+</Page>

--- a/XamlControlsGallery/ControlPages/CreateMultipleWindowsPage.xaml
+++ b/XamlControlsGallery/ControlPages/CreateMultipleWindowsPage.xaml
@@ -21,7 +21,8 @@
     mc:Ignorable="d">
    
     <StackPanel>
-        <local:ControlExample HeaderText="Create single threaded Multiple Top level Windows(MTW).">
+        <local:ControlExample HeaderText="Create single threaded Multiple Top level Windows(MTW)."
+                              CSharpSource="Window\CreateWindowSample1.txt">
             <Button x:Name="Control1" Click="createNewWindow_Click">Create new Window</Button>
         </local:ControlExample>
     </StackPanel>

--- a/XamlControlsGallery/ControlPages/CustomTitlebarPage.xaml
+++ b/XamlControlsGallery/ControlPages/CustomTitlebarPage.xaml
@@ -1,0 +1,212 @@
+<!--
+    //*********************************************************
+    //
+    // Copyright (c) Microsoft. All rights reserved.
+    // THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+    // ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+    // IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+    // PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+    //
+    //*********************************************************
+-->
+
+<Page
+    x:Class="AppUIBasics.ControlPages.CustomTitlebarPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="using:AppUIBasics"
+    xmlns:data="using:AppUIBasics.Data"
+    xmlns:wuxdata="using:Microsoft.UI.Xaml.Data"
+    mc:Ignorable="d">
+
+    <Page.Resources>
+        <x:Double x:Key="SwatchSize">32</x:Double>
+    </Page.Resources>
+    
+    <StackPanel>
+        <local:ControlExample HeaderText="User defined UIElement as custom titlebar for the window"
+                              CSharpSource="Window\CustomTitlebar\CustomTitlebarSample1.txt">
+            <local:ControlExample.Example>
+                <StackPanel Orientation="Vertical" Spacing="10">
+                    <TextBlock TextWrapping="WrapWholeWords">
+                        User can set a top-level UIElement (defined as appTitlebar here) as titlebar for the window. The system titlebar disappears and the chosen uielement starts acting like the titlebar. <LineBreak></LineBreak>
+                        The Background and Foreground Color dropdowns set the foreground and background of titlebar and caption buttons respectively.
+                    </TextBlock>
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" VerticalAlignment="Top" Spacing="10">
+                            <Button x:Name="customTitlebar" Click="customTitlebar_Click"></Button>
+                        <TextBlock> Background Color </TextBlock>
+                        <SplitButton x:Name="myBgColorButton" AutomationProperties.Name="Foreground color" Padding="0" MinHeight="0" MinWidth="0" VerticalAlignment="Top">
+                            <Border x:Name="CurrentBgColor" Width="{StaticResource SwatchSize}"
+                                    Height="{StaticResource SwatchSize}" Background="Transparent" Margin="0" CornerRadius="4,0,0,4"/>
+                            <SplitButton.Flyout>
+                                <Flyout Placement="Auto">
+                                    <GridView>
+                                        <GridView.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <ItemsWrapGrid MaximumRowsOrColumns="3" Orientation="Horizontal"/>
+                                            </ItemsPanelTemplate>
+                                        </GridView.ItemsPanel>
+                                        <GridView.Resources>
+                                            <Style TargetType="Rectangle">
+                                                <Setter Property="Width" Value="{StaticResource SwatchSize}"/>
+                                                <Setter Property="Height" Value="{StaticResource SwatchSize}"/>
+                                                <Setter Property="RadiusX" Value="4"/>
+                                                <Setter Property="RadiusY" Value="4"/>
+                                            </Style>
+                                            <Style TargetType="Button">
+                                                <Setter Property="Padding" Value="0"/>
+                                                <Setter Property="MinWidth" Value="0"/>
+                                                <Setter Property="MinHeight" Value="0"/>
+                                                <Setter Property="Margin" Value="6"/>
+                                                <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}"/>
+                                            </Style>
+                                        </GridView.Resources>
+                                        <GridView.Items>
+                                            <Button Click="BgColorButton_Click" AutomationProperties.Name="Transparent">
+                                                <Button.Content>
+                                                    <Rectangle Fill="Transparent"/>
+                                                </Button.Content>
+                                            </Button>
+                                            <Button Click="BgColorButton_Click" AutomationProperties.Name="Red">
+                                                <Button.Content>
+                                                    <Rectangle Fill="Red"/>
+                                                </Button.Content>
+                                            </Button>
+                                            <Button Click="BgColorButton_Click" AutomationProperties.Name="Orange">
+                                                <Button.Content>
+                                                    <Rectangle Fill="Orange"/>
+                                                </Button.Content>
+                                            </Button>
+                                            <Button Click="BgColorButton_Click" AutomationProperties.Name="Yellow">
+                                                <Button.Content>
+                                                    <Rectangle Fill="Yellow"/>
+                                                </Button.Content>
+                                            </Button>
+                                            <Button Click="BgColorButton_Click" AutomationProperties.Name="Green">
+                                                <Button.Content>
+                                                    <Rectangle Fill="Green"/>
+                                                </Button.Content>
+                                            </Button>
+                                            <Button Click="BgColorButton_Click" AutomationProperties.Name="Blue">
+                                                <Button.Content>
+                                                    <Rectangle Fill="Blue"/>
+                                                </Button.Content>
+                                            </Button>
+                                            <Button Click="BgColorButton_Click" AutomationProperties.Name="Indigo">
+                                                <Button.Content>
+                                                    <Rectangle Fill="White"/>
+                                                </Button.Content>
+                                            </Button>
+                                            <Button Click="BgColorButton_Click" AutomationProperties.Name="Violet">
+                                                <Button.Content>
+                                                    <Rectangle Fill="Black"/>
+                                                </Button.Content>
+                                            </Button>
+                                        </GridView.Items>
+                                    </GridView>
+
+                                </Flyout>
+                            </SplitButton.Flyout>
+                        </SplitButton>
+                         
+                        <TextBlock> Foreground Color</TextBlock>
+                        <SplitButton x:Name="myFgColorButton" AutomationProperties.Name="Background color" Padding="0" MinHeight="0" MinWidth="0" VerticalAlignment="Top">
+                            <Border x:Name="CurrentFgColor" Width="{StaticResource SwatchSize}" Height="{StaticResource SwatchSize}" Background="Black" Margin="0" CornerRadius="4,0,0,4"/>
+                            <SplitButton.Flyout>
+                                <Flyout Placement="Auto">
+                                    <GridView>
+                                        <GridView.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <ItemsWrapGrid MaximumRowsOrColumns="3" Orientation="Horizontal"/>
+                                            </ItemsPanelTemplate>
+                                        </GridView.ItemsPanel>
+                                        <GridView.Resources>
+                                            <Style TargetType="Rectangle">
+                                                <Setter Property="Width" Value="{StaticResource SwatchSize}"/>
+                                                <Setter Property="Height" Value="{StaticResource SwatchSize}"/>
+                                                <Setter Property="RadiusX" Value="4"/>
+                                                <Setter Property="RadiusY" Value="4"/>
+                                            </Style>
+                                            <Style TargetType="Button">
+                                                <Setter Property="Padding" Value="0"/>
+                                                <Setter Property="MinWidth" Value="0"/>
+                                                <Setter Property="MinHeight" Value="0"/>
+                                                <Setter Property="Margin" Value="6"/>
+                                                <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}"/>
+                                            </Style>
+                                        </GridView.Resources>
+                                        <GridView.Items>
+                                            <Button Click="FgColorButton_Click" AutomationProperties.Name="Transparent">
+                                                <Button.Content>
+                                                    <Rectangle Fill="Transparent"/>
+                                                </Button.Content>
+                                            </Button>
+                                            <Button Click="FgColorButton_Click" AutomationProperties.Name="Red">
+                                                <Button.Content>
+                                                    <Rectangle Fill="Red"/>
+                                                </Button.Content>
+                                            </Button>
+                                            <Button Click="FgColorButton_Click" AutomationProperties.Name="Orange">
+                                                <Button.Content>
+                                                    <Rectangle Fill="Orange"/>
+                                                </Button.Content>
+                                            </Button>
+                                            <Button Click="FgColorButton_Click" AutomationProperties.Name="Yellow">
+                                                <Button.Content>
+                                                    <Rectangle Fill="Yellow"/>
+                                                </Button.Content>
+                                            </Button>
+                                            <Button Click="FgColorButton_Click" AutomationProperties.Name="Green">
+                                                <Button.Content>
+                                                    <Rectangle Fill="Green"/>
+                                                </Button.Content>
+                                            </Button>
+                                            <Button Click="FgColorButton_Click" AutomationProperties.Name="Blue">
+                                                <Button.Content>
+                                                    <Rectangle Fill="Blue"/>
+                                                </Button.Content>
+                                            </Button>
+                                            <Button Click="FgColorButton_Click" AutomationProperties.Name="Indigo">
+                                                <Button.Content>
+                                                    <Rectangle Fill="White"/>
+                                                </Button.Content>
+                                            </Button>
+                                            <Button Click="FgColorButton_Click" AutomationProperties.Name="Violet">
+                                                <Button.Content>
+                                                    <Rectangle Fill="Black"/>
+                                                </Button.Content>
+                                            </Button>
+                                        </GridView.Items>
+                                    </GridView>
+
+                                </Flyout>
+                            </SplitButton.Flyout>
+                        </SplitButton>
+
+                    </StackPanel>
+                </StackPanel>
+                </local:ControlExample.Example>
+
+        </local:ControlExample>
+        <local:ControlExample HeaderText="Fallback titlebar when no user defined titlebar is set"
+                              CSharpSource="Window\CustomTitlebar\CustomTitlebarSample2.txt">
+            <local:ControlExample.Example>
+                <StackPanel Orientation="Vertical" Spacing="10">
+                    <TextBlock TextWrapping="WrapWholeWords">
+                        WinUI provides a fallback titlebar in case where user doesn't want to provide a uielement for setting the titlebar.
+                        A small horizontal section next to min/max/close caption buttons is chosen as the fallback titlebar.
+                         <LineBreak></LineBreak>
+                        It can be applied by just calling ExtendsContentIntoTitleBar api only and not calling SetTitlebar afterwards. It can also be manually triggered by calling SetTitlebar api with null arument.
+                        <LineBreak></LineBreak>
+                        Use the Color dropdown controls in the section above to change color of the fallback titlebar.
+                    </TextBlock>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" VerticalAlignment="Top" Spacing="20">
+                        <Button x:Name="defaultTitlebar" Click="defaultTitlebar_Click"></Button>
+                    </StackPanel>
+                </StackPanel>
+            </local:ControlExample.Example>
+        </local:ControlExample>
+    </StackPanel>
+</Page>

--- a/XamlControlsGallery/ControlPages/CustomTitlebarPage.xaml
+++ b/XamlControlsGallery/ControlPages/CustomTitlebarPage.xaml
@@ -37,8 +37,8 @@
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" VerticalAlignment="Top" Spacing="10">
                             <Button x:Name="customTitlebar" Click="customTitlebar_Click"></Button>
                         <TextBlock> Background Color </TextBlock>
-                        <SplitButton x:Name="myBgColorButton" AutomationProperties.Name="Foreground color" Padding="0" MinHeight="0" MinWidth="0" VerticalAlignment="Top">
-                            <Border x:Name="CurrentBgColor" Width="{StaticResource SwatchSize}"
+                        <SplitButton x:Name="myBgColorButton" AutomationProperties.Name="Background color" Padding="0" MinHeight="0" MinWidth="0" VerticalAlignment="Top">
+                            <Border x:Name="BackgroundColorElement" Width="{StaticResource SwatchSize}"
                                     Height="{StaticResource SwatchSize}" Background="Transparent" Margin="0" CornerRadius="4,0,0,4"/>
                             <SplitButton.Flyout>
                                 <Flyout Placement="Auto">
@@ -112,8 +112,8 @@
                         </SplitButton>
                          
                         <TextBlock> Foreground Color</TextBlock>
-                        <SplitButton x:Name="myFgColorButton" AutomationProperties.Name="Background color" Padding="0" MinHeight="0" MinWidth="0" VerticalAlignment="Top">
-                            <Border x:Name="CurrentFgColor" Width="{StaticResource SwatchSize}" Height="{StaticResource SwatchSize}" Background="Black" Margin="0" CornerRadius="4,0,0,4"/>
+                        <SplitButton x:Name="myFgColorButton" AutomationProperties.Name="Foreground color" Padding="0" MinHeight="0" MinWidth="0" VerticalAlignment="Top">
+                            <Border x:Name="ForegroundColorElement" Width="{StaticResource SwatchSize}" Height="{StaticResource SwatchSize}" Background="Black" Margin="0" CornerRadius="4,0,0,4"/>
                             <SplitButton.Flyout>
                                 <Flyout Placement="Auto">
                                     <GridView>

--- a/XamlControlsGallery/ControlPages/CustomTitlebarPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/CustomTitlebarPage.xaml.cs
@@ -96,7 +96,7 @@ namespace AppUIBasics.ControlPages
             var rectangle = (Microsoft.UI.Xaml.Shapes.Rectangle)clickedColor.Content;
             var color = ((Microsoft.UI.Xaml.Media.SolidColorBrush)rectangle.Fill).Color;
 
-            CurrentBgColor.Background = new SolidColorBrush(color);
+            BackgroundColorElement.Background = new SolidColorBrush(color);
 
             currentBgColor = color;
             UpdateTitlebarColor();
@@ -110,7 +110,7 @@ namespace AppUIBasics.ControlPages
             var rectangle = (Microsoft.UI.Xaml.Shapes.Rectangle)clickedColor.Content;
             var color = ((Microsoft.UI.Xaml.Media.SolidColorBrush)rectangle.Fill).Color;
 
-            CurrentFgColor.Background = new SolidColorBrush(color);
+            ForegroundColorElement.Background = new SolidColorBrush(color);
 
             currentFgColor = color;
             UpdateTitlebarColor();

--- a/XamlControlsGallery/ControlPages/CustomTitlebarPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/CustomTitlebarPage.xaml.cs
@@ -1,0 +1,154 @@
+//*********************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+// IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+// PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+//
+//*********************************************************
+using System;
+using Microsoft;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using WinRT;
+using System.Runtime.InteropServices;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace AppUIBasics.ControlPages
+{
+
+
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class CustomTitlebarPage : Page
+    {
+        private Windows.UI.Color currentBgColor = Colors.Transparent;
+        private Windows.UI.Color currentFgColor = Colors.Black;
+
+        public CustomTitlebarPage()
+        {
+            this.InitializeComponent();
+            UpdateTitlebarColor();
+            UpdateButtonText();
+        }
+
+
+        [ComImport, Guid("EECDBF0E-BAE9-4CB6-A68E-9598E1CB57BB"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        private interface IWindowNative
+        {
+            IntPtr WindowHandle { get; }
+        };
+
+        private void SetTitlebar(UIElement titlebar)
+        {
+            var window = App.StartupWindow;
+            if (!window.ExtendsContentIntoTitleBar)
+            {
+                window.ExtendsContentIntoTitleBar = true;
+                window.SetTitleBar(titlebar);
+            }
+            else
+            {
+                window.ExtendsContentIntoTitleBar = false;
+                window.SetTitleBar(null);
+
+            }
+            UpdateButtonText();
+            UpdateTitlebarColor();
+        }
+
+        private void UpdateButtonText()
+        {
+            var window = App.StartupWindow;
+            if (window.ExtendsContentIntoTitleBar)
+            {
+                customTitlebar.Content = "Reset to system Titlebar";
+                defaultTitlebar.Content = "Reset to system Titlebar";
+            }
+            else
+            {
+                customTitlebar.Content = "Set Custom Titlebar";
+                defaultTitlebar.Content = "Set Fallback Custom Titlebar";
+            }
+
+        }
+
+        private void BgColorButton_Click(object sender, RoutedEventArgs e)
+        {
+            // Extract the color of the button that was clicked.
+            Button clickedColor = (Button)sender;
+            var rectangle = (Microsoft.UI.Xaml.Shapes.Rectangle)clickedColor.Content;
+            var color = ((Microsoft.UI.Xaml.Media.SolidColorBrush)rectangle.Fill).Color;
+
+            CurrentBgColor.Background = new SolidColorBrush(color);
+
+            currentBgColor = color;
+            UpdateTitlebarColor();
+
+        }
+
+        private void FgColorButton_Click(object sender, RoutedEventArgs e)
+        {
+            // Extract the color of the button that was clicked.
+            Button clickedColor = (Button)sender;
+            var rectangle = (Microsoft.UI.Xaml.Shapes.Rectangle)clickedColor.Content;
+            var color = ((Microsoft.UI.Xaml.Media.SolidColorBrush)rectangle.Fill).Color;
+
+            CurrentFgColor.Background = new SolidColorBrush(color);
+
+            currentFgColor = color;
+            UpdateTitlebarColor();
+
+        }
+
+
+        private void UpdateTitlebarColor()
+        {
+            var res = Microsoft.UI.Xaml.Application.Current.Resources;
+            res["WindowCaptionBackground"] = currentBgColor;
+            //res["WindowCaptionBackgroundDisabled"] = currentBgColor;
+            res["WindowCaptionForeground"] = currentFgColor;
+            //res["WindowCaptionForegroundDisabled"] = currentFgColor;
+
+            // to trigger repaint tracking task id 38044406
+            var native = App.StartupWindow.As<IWindowNative>();
+            var hwnd = native.WindowHandle;
+            var activeWindow = Win32.GetActiveWindow();
+            if (hwnd == activeWindow)
+            {
+                Win32.SendMessage(hwnd, Win32.WM_ACTIVATE, Win32.WA_INACTIVE, IntPtr.Zero);
+                Win32.SendMessage(hwnd, Win32.WM_ACTIVATE, Win32.WA_ACTIVE, IntPtr.Zero);
+            }
+            else
+            {
+                Win32.SendMessage(hwnd, Win32.WM_ACTIVATE, Win32.WA_ACTIVE, IntPtr.Zero);
+                Win32.SendMessage(hwnd, Win32.WM_ACTIVATE, Win32.WA_INACTIVE, IntPtr.Zero);
+            }
+        }
+
+        private void customTitlebar_Click(object sender, RoutedEventArgs e)
+        {
+            SetTitlebar(App.appTitlebar);
+        }
+        private void defaultTitlebar_Click(object sender, RoutedEventArgs e)
+        {
+            SetTitlebar(null);
+        }
+    }
+}

--- a/XamlControlsGallery/ControlPages/HyperlinkButtonPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/HyperlinkButtonPage.xaml.cs
@@ -21,7 +21,7 @@ namespace AppUIBasics.ControlPages
 
         private void GoToHyperlinkButton_Click(object sender, RoutedEventArgs e)
         {
-            NavigationRootPage.RootFrame.Navigate(typeof(ItemPage), "ToggleButton");
+            NavigationRootPage.GetForElement(this).Frame.Navigate(typeof(ItemPage), "ToggleButton");
         }
     }
 }

--- a/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/RichEditBoxPage.xaml.cs
@@ -79,7 +79,7 @@ namespace AppUIBasics.ControlPages
 
 #if !UNIVERSAL
             // When running on win32, FileOpenPicker needs to know the top-level hwnd via IInitializeWithWindow::Initialize.
-            if (App.CurrentWindow == null)
+            if (Window.Current == null)
             {
                 IInitializeWithWindow initializeWithWindowWrapper = open.As<IInitializeWithWindow>();
                 IntPtr hwnd = GetActiveWindow();
@@ -115,7 +115,7 @@ namespace AppUIBasics.ControlPages
 
 #if !UNIVERSAL
             // When running on win32, FileSavePicker needs to know the top-level hwnd via IInitializeWithWindow::Initialize.
-            if (App.CurrentWindow == null)
+            if (Window.Current == null)
             {
                 IInitializeWithWindow initializeWithWindowWrapper = savePicker.As<IInitializeWithWindow>();
                 IntPtr hwnd = GetActiveWindow();

--- a/XamlControlsGallery/ControlPages/SplitViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/SplitViewPage.xaml.cs
@@ -42,7 +42,8 @@ namespace AppUIBasics.ControlPages
 
         private void togglePaneButton_Click(object sender, RoutedEventArgs e)
         {
-            if (App.CurrentWindow.Bounds.Width >= 640)
+            Window window = WindowHelper.GetWindowForElement(this);
+            if (window.Bounds.Width >= 640)
             {
                 if (splitView.IsPaneOpen)
                 {

--- a/XamlControlsGallery/ControlPages/TabViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/TabViewPage.xaml.cs
@@ -262,9 +262,9 @@ namespace AppUIBasics.ControlPages
             {
                 Frame frame = new Frame();
                 frame.Navigate(typeof(TabViewWindowingSamplePage), null);
-                App.CurrentWindow.Content = frame;
+                Window.Current.Content = frame;
                 // You have to activate the window in order to show it later.
-                App.CurrentWindow.Activate();
+                Window.Current.Activate();
 
                 newViewId = ApplicationView.GetForCurrentView().Id;
             });
@@ -273,6 +273,13 @@ namespace AppUIBasics.ControlPages
 #else
         private void TabViewWindowingButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
+            var newWindow = WindowHelper.CreateWindow();
+
+            Frame frame = new Frame();
+            frame.RequestedTheme = ThemeHelper.RootTheme;
+            frame.Navigate(typeof(TabViewWindowingSamplePage), null);
+            newWindow.Content = frame;
+            newWindow.Activate();
         }
 #endif
     }

--- a/XamlControlsGallery/ControlPages/TeachingTipPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/TeachingTipPage.xaml.cs
@@ -22,25 +22,25 @@ namespace AppUIBasics.ControlPages
 
         private void TestButtonClick1(object sender, RoutedEventArgs e)
         {
-            if (NavigationRootPage.Current?.PageHeader != null)
+            if (NavigationRootPage.GetForElement(this)?.PageHeader != null)
             {
-                NavigationRootPage.Current.PageHeader.TeachingTip1.IsOpen = true;
+                NavigationRootPage.GetForElement(this).PageHeader.TeachingTip1.IsOpen = true;
             }
         }
 
         private void TestButtonClick2(object sender, RoutedEventArgs e)
         {
-            if (NavigationRootPage.Current?.PageHeader != null)
+            if (NavigationRootPage.GetForElement(this)?.PageHeader != null)
             {
-                NavigationRootPage.Current.PageHeader.TeachingTip2.IsOpen = true;
+                NavigationRootPage.GetForElement(this).PageHeader.TeachingTip2.IsOpen = true;
             }
         }
 
         private void TestButtonClick3(object sender, RoutedEventArgs e)
         {
-            if (NavigationRootPage.Current?.PageHeader != null)
+            if (NavigationRootPage.GetForElement(this)?.PageHeader != null)
             {
-                NavigationRootPage.Current.PageHeader.TeachingTip3.IsOpen = true;
+                NavigationRootPage.GetForElement(this).PageHeader.TeachingTip3.IsOpen = true;
             }
         }
 
@@ -49,7 +49,7 @@ namespace AppUIBasics.ControlPages
             // The non-light dismiss Teaching tips do not handle the escape key, however we do not want the page to navigate away while they are open, so we will mark these key events as
 
             // handled while these tips are open.
-            if (e.Key == Windows.System.VirtualKey.Escape && (NavigationRootPage.Current.PageHeader.TeachingTip3.IsOpen || NavigationRootPage.Current.PageHeader.TeachingTip1.IsOpen))
+            if (e.Key == Windows.System.VirtualKey.Escape && (NavigationRootPage.GetForElement(this).PageHeader.TeachingTip3.IsOpen || NavigationRootPage.GetForElement(this).PageHeader.TeachingTip1.IsOpen))
             {
                 e.Handled = true;
             }

--- a/XamlControlsGallery/ControlPages/XamlCompInteropPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/XamlCompInteropPage.xaml.cs
@@ -17,7 +17,7 @@ namespace AppUIBasics.ControlPages
             this.InitializeComponent();
         }
 
-        Compositor _compositor = App.CurrentWindow.Compositor;
+        Compositor _compositor = Microsoft.UI.Xaml.Media.CompositionTarget.GetCompositorForCurrentThread();
         private SpringVector3NaturalMotionAnimation _springAnimation;
 
         private void NaturalMotionExample_Loaded(object sender, RoutedEventArgs e)

--- a/XamlControlsGallery/ControlPagesSampleCode/Window/CreateWindowSample1.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/Window/CreateWindowSample1.txt
@@ -1,0 +1,11 @@
+﻿// C# code to create a new window
+var newWindow = WindowHelper.CreateWindow();
+var rootPage = new NavigationRootPage();
+rootPage.RequestedTheme = ThemeHelper.RootTheme;
+newWindow.Content = rootPage;
+newWindow.Activate();
+
+// C# code to navigate in the new window
+var targetPageType = typeof(NewControlsPage);
+string targetPageArguments = string.Empty;
+rootPage.Navigate(targetPageType, targetPageArguments);

--- a/XamlControlsGallery/ControlPagesSampleCode/Window/CustomTitlebar/CustomTitlebarSample1.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/Window/CustomTitlebar/CustomTitlebarSample1.txt
@@ -1,0 +1,9 @@
+﻿// UIElement set as titlebar
+<Border x:Name="AppTitleBar" Grid.Column="1" VerticalAlignment="Top">
+    <TextBlock x:Name="AppTitle" Text="WinUI 3 Controls Gallery" VerticalAlignment="Top" Margin="0,8,0,0" />
+</Border>
+
+// C# code to set AppTitleBar uielement as titlebar
+Window window = App.MainWindow;
+window.ExtendsContentIntoTitleBar = true;  // enable custom titlebar
+window.SetTitleBar(AppTitleBar);      // set user ui element as titlebar

--- a/XamlControlsGallery/ControlPagesSampleCode/Window/CustomTitlebar/CustomTitlebarSample2.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/Window/CustomTitlebar/CustomTitlebarSample2.txt
@@ -1,0 +1,4 @@
+﻿// no UIElement is set for titlebar, fallback titlebar is created
+Window window = App.MainWindow;
+window.ExtendsContentIntoTitleBar = true;
+window.SetTitleBar(null);  // this line is optional as by it is null by default

--- a/XamlControlsGallery/Controls/ControlExample.xaml.cs
+++ b/XamlControlsGallery/Controls/ControlExample.xaml.cs
@@ -291,7 +291,7 @@ namespace AppUIBasics
                             var decoder = await BitmapDecoder.CreateAsync(stream);
 
                             // Find the control in the picture
-                            GeneralTransform t = ControlPresenter.TransformToVisual(App.CurrentWindow.Content);
+                            GeneralTransform t = ControlPresenter.TransformToVisual(Window.Current.Content);
                             Point pos = t.TransformPoint(new Point(0, 0));
 
                             if (!CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBar)

--- a/XamlControlsGallery/DataModel/ControlInfoData.json
+++ b/XamlControlsGallery/DataModel/ControlInfoData.json
@@ -2455,6 +2455,37 @@
           ]
         }
       ]
+    },
+    {
+      "UniqueId": "MultipleWindows",
+      "Title": "Windows",
+      "Subtitle": "",
+      "ImagePath": "ms-appx:///Assets/DefaultIcon.png",
+      "Description": "",
+      "Items": [
+        {
+          "UniqueId": "CreateMultipleWindows",
+          "Title": "Create Multiple Windows",
+          "Subtitle": "",
+          "ImagePath": "ms-appx:///Assets/DefaultIcon.png",
+          "Description": "With Windows App SDK 1.0 we are allowing creation of single threaded multiple top level Xaml windows in Desktop apps",
+          "Content": "<p>Look at the <i>CreateMultipleWindows.xaml</i> file in Visual Studio to see the full code for this page.</p>",
+          "IsNew": false,
+          "IsUpdated": false,
+          "Docs": [
+            {
+              "Title": "MultipleWindow - API",
+              "Uri": "https://docs.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.window?view=winui-3.0-preview"
+            },
+            {
+              "Title": "Guidance",
+              "Uri": "https://docs.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.window?view=winui-3.0-preview"
+            }
+          ],
+          "RelatedControls": [           
+          ]
+        }
+      ]
     }
   ]
 }

--- a/XamlControlsGallery/DataModel/ControlInfoData.json
+++ b/XamlControlsGallery/DataModel/ControlInfoData.json
@@ -2469,7 +2469,7 @@
           "Subtitle": "",
           "ImagePath": "ms-appx:///Assets/DefaultIcon.png",
           "Description": "With Windows App SDK 1.0 we are allowing creation of single threaded multiple top level Xaml windows in Desktop apps",
-          "Content": "<p>Look at the <i>CreateMultipleWindows.xaml</i> file in Visual Studio to see the full code for this page.</p>",
+          "Content": "<p>Look at the <i>CreateMultipleWindowsPage.xaml</i> file in Visual Studio to see the full code for this page.</p>",
           "IsNew": false,
           "IsUpdated": false,
           "Docs": [
@@ -2478,11 +2478,33 @@
               "Uri": "https://docs.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.window?view=winui-3.0-preview"
             },
             {
-              "Title": "Guidance",
+              "Title": "Guidelines",
               "Uri": "https://docs.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.window?view=winui-3.0-preview"
             }
           ],
-          "RelatedControls": [           
+          "RelatedControls": [
+          ]
+        },
+        {
+          "UniqueId": "CustomTitlebar",
+          "Title": "Titlebar",
+          "Subtitle": "",
+          "ImagePath": "ms-appx:///Assets/DefaultIcon.png",
+          "Description": "This sample shows how to use a custom UIElement as titlebar for app's window.",
+          "Content": "<p>Look at the <i>CustomTitlebarPage.xaml</i> file in Visual Studio to see the full code for this page.</p>",
+          "IsNew": true,
+          "IsUpdated": false,
+          "Docs": [
+            {
+              "Title": "Titlebar - API",
+              "Uri": "https://docs.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.window.extendscontentintotitlebar?view=winui-3.0"
+            },
+            {
+              "Title": "Guidelines",
+              "Uri": "https://docs.microsoft.com/en-us/windows/winui/api/microsoft.ui.xaml.window?view=winui-3.0-preview"
+            }
+          ],
+          "RelatedControls": [
           ]
         }
       ]

--- a/XamlControlsGallery/DataModel/ControlInfoData.json
+++ b/XamlControlsGallery/DataModel/ControlInfoData.json
@@ -2466,11 +2466,11 @@
         {
           "UniqueId": "CreateMultipleWindows",
           "Title": "Create Multiple Windows",
-          "Subtitle": "",
+          "Subtitle": "An example showing the creation of single-threaded top level Xaml windows.",
           "ImagePath": "ms-appx:///Assets/DefaultIcon.png",
-          "Description": "With Windows App SDK 1.0 we are allowing creation of single threaded multiple top level Xaml windows in Desktop apps",
+          "Description": "With Windows App SDK 1.0 we are allowing creation of single-threaded multiple top level Xaml windows in Desktop apps",
           "Content": "<p>Look at the <i>CreateMultipleWindowsPage.xaml</i> file in Visual Studio to see the full code for this page.</p>",
-          "IsNew": false,
+          "IsNew": true,
           "IsUpdated": false,
           "Docs": [
             {
@@ -2488,7 +2488,7 @@
         {
           "UniqueId": "CustomTitlebar",
           "Title": "Titlebar",
-          "Subtitle": "",
+          "Subtitle": "An example showing a custom UIElement used as the titlebar for the app's window.",
           "ImagePath": "ms-appx:///Assets/DefaultIcon.png",
           "Description": "This sample shows how to use a custom UIElement as titlebar for app's window.",
           "Content": "<p>Look at the <i>CustomTitlebarPage.xaml</i> file in Visual Studio to see the full code for this page.</p>",

--- a/XamlControlsGallery/Helper/NavigationOrientationHelper.cs
+++ b/XamlControlsGallery/Helper/NavigationOrientationHelper.cs
@@ -20,27 +20,24 @@ namespace AppUIBasics.Helper
 
         private const string IsLeftModeKey = "NavigationIsOnLeftMode";
 
-        public static bool IsLeftMode
+        public static bool IsLeftMode()
         {
-            get
+            var valueFromSettings = ApplicationData.Current.LocalSettings.Values[IsLeftModeKey];
+            if(valueFromSettings == null)
             {
-                var valueFromSettings = ApplicationData.Current.LocalSettings.Values[IsLeftModeKey];
-                if(valueFromSettings == null)
-                {
-                    ApplicationData.Current.LocalSettings.Values[IsLeftModeKey] = true;
-                    valueFromSettings = true;
-                }
-                return (bool)valueFromSettings;
+                ApplicationData.Current.LocalSettings.Values[IsLeftModeKey] = true;
+                valueFromSettings = true;
             }
-
-            set
-            {
-                UpdateTitleBar(value);
-                ApplicationData.Current.LocalSettings.Values[IsLeftModeKey] = value;
-            }
+            return (bool)valueFromSettings;
         }
 
-        public static void UpdateTitleBar(bool isLeftMode)
+        public static void IsLeftModeForElement(bool isLeftMode, UIElement element)
+        {
+            UpdateTitleBarForElement(isLeftMode, element);
+            ApplicationData.Current.LocalSettings.Values[IsLeftModeKey] = isLeftMode;
+        }
+
+        public static void UpdateTitleBarForElement(bool isLeftMode, UIElement element)
         {
 #if UNIVERSAL
             CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBar = isLeftMode;
@@ -49,7 +46,7 @@ namespace AppUIBasics.Helper
 #endif
             if (isLeftMode)
             {
-                NavigationRootPage.Current.NavigationView.PaneDisplayMode = Microsoft.UI.Xaml.Controls.NavigationViewPaneDisplayMode.Auto;
+                NavigationRootPage.GetForElement(element).NavigationView.PaneDisplayMode = Microsoft.UI.Xaml.Controls.NavigationViewPaneDisplayMode.Auto;
 #if UNIVERSAL
                 titleBar.ButtonBackgroundColor = Colors.Transparent;
                 titleBar.ButtonInactiveBackgroundColor = Colors.Transparent;
@@ -57,7 +54,7 @@ namespace AppUIBasics.Helper
             }
             else
             {
-                NavigationRootPage.Current.NavigationView.PaneDisplayMode = Microsoft.UI.Xaml.Controls.NavigationViewPaneDisplayMode.Top;
+                NavigationRootPage.GetForElement(element).NavigationView.PaneDisplayMode = Microsoft.UI.Xaml.Controls.NavigationViewPaneDisplayMode.Top;
 #if UNIVERSAL
                 var userSettings = new UISettings();
                 titleBar.ButtonBackgroundColor = userSettings.GetColorValue(UIColorType.Accent);

--- a/XamlControlsGallery/Helper/ThemeHelper.cs
+++ b/XamlControlsGallery/Helper/ThemeHelper.cs
@@ -30,11 +30,14 @@ namespace AppUIBasics.Helper
         {
             get
             {
-                if (App.CurrentWindow.Content is FrameworkElement rootElement)
+                foreach (Window window in WindowHelper.ActiveWindows)
                 {
-                    if (rootElement.RequestedTheme != ElementTheme.Default)
+                    if (window.Content is FrameworkElement rootElement)
                     {
-                        return rootElement.RequestedTheme;
+                        if (rootElement.RequestedTheme != ElementTheme.Default)
+                        {
+                            return rootElement.RequestedTheme;
+                        }
                     }
                 }
 
@@ -49,18 +52,24 @@ namespace AppUIBasics.Helper
         {
             get
             {
-                if (App.CurrentWindow.Content is FrameworkElement rootElement)
+                foreach (Window window in WindowHelper.ActiveWindows)
                 {
-                    return rootElement.RequestedTheme;
+                    if (window.Content is FrameworkElement rootElement)
+                    {
+                        return rootElement.RequestedTheme;
+                    }
                 }
 
                 return ElementTheme.Default;
             }
             set
             {
-                if (App.CurrentWindow.Content is FrameworkElement rootElement)
+                foreach (Window window in WindowHelper.ActiveWindows)
                 {
-                    rootElement.RequestedTheme = value;
+                    if (window.Content is FrameworkElement rootElement)
+                    {
+                        rootElement.RequestedTheme = value;
+                    }
                 }
 
                 ApplicationData.Current.LocalSettings.Values[SelectedAppThemeKey] = value.ToString();
@@ -70,15 +79,16 @@ namespace AppUIBasics.Helper
 
         public static void Initialize()
         {
+#if !UNPACKAGED
             // Save reference as this might be null when the user is in another app
-            CurrentApplicationWindow = App.CurrentWindow;
+            CurrentApplicationWindow = App.StartupWindow;
             string savedTheme = ApplicationData.Current.LocalSettings.Values[SelectedAppThemeKey]?.ToString();
 
             if (savedTheme != null)
             {
                 RootTheme = AppUIBasics.App.GetEnum<ElementTheme>(savedTheme);
             }
-
+#endif
 #if UNIVERSAL
             // Registering to color changes, thus we notice when user changes theme system wide
             uiSettings = new UISettings();

--- a/XamlControlsGallery/IdleSynchronizer.cs
+++ b/XamlControlsGallery/IdleSynchronizer.cs
@@ -350,9 +350,12 @@ namespace AppUIBasics
                     DispatcherQueuePriority.Normal,
                     new DispatcherQueueHandler(() =>
                     {
-                        if (App.CurrentWindow != null && App.CurrentWindow.Content != null)
+                        foreach (Window window in WindowHelper.ActiveWindows)
                         {
-                            App.CurrentWindow.Content.UpdateLayout();
+                            if (window.Content != null)
+                            {
+                                window.Content.UpdateLayout();
+                            }
                         }
 
                         layoutUpdatedEvent.Set();

--- a/XamlControlsGallery/ItemsPageBase.cs
+++ b/XamlControlsGallery/ItemsPageBase.cs
@@ -68,7 +68,7 @@ namespace AppUIBasics
 
             _itemId = item.UniqueId;
 
-            this.Frame.Navigate(typeof(ItemPage), _itemId, new DrillInNavigationTransitionInfo());
+            NavigationRootPage.GetForElement(this).Navigate(typeof(ItemPage), _itemId, new DrillInNavigationTransitionInfo());
         }
 
         protected void OnItemGridViewKeyDown(object sender, KeyRoutedEventArgs e)
@@ -78,7 +78,7 @@ namespace AppUIBasics
                 var nextElement = FocusManager.FindNextElement(FocusNavigationDirection.Up);
                 if (nextElement?.GetType() == typeof(Microsoft.UI.Xaml.Controls.NavigationViewItem))
                 {
-                    NavigationRootPage.Current.PageHeader.Focus(FocusState.Programmatic);
+                    NavigationRootPage.GetForElement(this).PageHeader.Focus(FocusState.Programmatic);
                 }
                 else
                 {
@@ -98,7 +98,7 @@ namespace AppUIBasics
                 {
                     gridView.ScrollIntoView(item);
 
-                    if (NavigationRootPage.Current.IsFocusSupported)
+                    if (NavigationRootPage.GetForElement(this).IsFocusSupported)
                     {
                         ((GridViewItem)gridView.ContainerFromItem(item))?.Focus(FocusState.Programmatic);
                     }

--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml
@@ -55,7 +55,6 @@
                 Grid.Column="1"
                 IsHitTestVisible="True"
                 VerticalAlignment="Top"
-                Background="Transparent"
                 Height="{Binding ElementName=NavigationViewControl, Path=CompactPaneLength}"
                 Canvas.ZIndex="1">
             <TextBlock x:Name="AppTitle"
@@ -96,7 +95,6 @@
 
         <!-- Don't set IsTitleBarAutoPaddingEnabled, since it should only be set false when we're using Window.SetTitleBar(), which isn't currently available.
              Restore by re-applying https://github.com/microsoft/Xaml-Controls-Gallery/pull/198 -->
-
         <NavigationView
             Canvas.ZIndex="0"
             x:Name="NavigationViewControl"

--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
@@ -135,6 +135,7 @@ namespace AppUIBasics
             };
 
             NavigationViewControl.RegisterPropertyChangedCallback(NavigationView.PaneDisplayModeProperty, new DependencyPropertyChangedCallback(OnPaneDisplayModeChanged));
+            App.appTitlebar = AppTitleBar;
         }
 
         private void OnPaneDisplayModeChanged(DependencyObject sender, DependencyProperty dp)
@@ -148,11 +149,6 @@ namespace AppUIBasics
             //ensure the custom title bar does not overlap window caption controls
             Thickness currMargin = AppTitleBar.Margin;
             AppTitleBar.Margin = new Thickness(currMargin.Left, currMargin.Top, coreTitleBar.SystemOverlayRightInset, currMargin.Bottom);
-        }
-
-        public string GetAppTitleFromSystem()
-        {
-            return Windows.ApplicationModel.Package.Current.DisplayName;
         }
 
         public bool CheckNewControlSelected()

--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
@@ -36,16 +36,25 @@ namespace AppUIBasics
 {
     public sealed partial class NavigationRootPage : Page
     {
-        public static NavigationRootPage Current;
-        public static Frame RootFrame = null;
-
         public Windows.System.VirtualKey ArrowKey;
+        public Frame RootFrame { get { return rootFrame; }}
 
         private RootFrameNavigationHelper _navHelper;
         private bool _isGamePadConnected;
         private bool _isKeyboardConnected;
         private Microsoft.UI.Xaml.Controls.NavigationViewItem _allControlsMenuItem;
         private Microsoft.UI.Xaml.Controls.NavigationViewItem _newControlsMenuItem;
+
+        public static NavigationRootPage GetForElement(object obj)
+        {
+            UIElement element = (UIElement)obj;
+            Window window = WindowHelper.GetWindowForElement(element);
+            if (window != null)
+            {
+                return (NavigationRootPage)window.Content;
+            }
+            return null;
+        }
 
         public Microsoft.UI.Xaml.Controls.NavigationView NavigationView
         {
@@ -96,8 +105,6 @@ namespace AppUIBasics
 
             SetDeviceFamily();
             AddNavigationMenuItems();
-            Current = this;
-            RootFrame = rootFrame;
 
             this.GotFocus += (object sender, RoutedEventArgs e) =>
             {
@@ -121,8 +128,10 @@ namespace AppUIBasics
             // This is done when the app is loaded since before that the actual theme that is used is not "determined" yet
             Loaded += delegate (object sender, RoutedEventArgs e)
             {
-                NavigationOrientationHelper.UpdateTitleBar(NavigationOrientationHelper.IsLeftMode);
-
+                NavigationOrientationHelper.UpdateTitleBarForElement(NavigationOrientationHelper.IsLeftMode(), this);
+#if !UNIVERSAL
+                WindowHelper.GetWindowForElement(this).Title = AppTitleText;
+#endif
             };
 
             NavigationViewControl.RegisterPropertyChangedCallback(NavigationView.PaneDisplayModeProperty, new DependencyPropertyChangedCallback(OnPaneDisplayModeChanged));
@@ -131,7 +140,7 @@ namespace AppUIBasics
         private void OnPaneDisplayModeChanged(DependencyObject sender, DependencyProperty dp)
         {
             var navigationView = sender as NavigationView;
-            NavigationRootPage.Current.AppTitleBar.Visibility = navigationView.PaneDisplayMode == NavigationViewPaneDisplayMode.Top ? Visibility.Collapsed : Visibility.Visible;
+            NavigationRootPage.GetForElement(this).AppTitleBar.Visibility = navigationView.PaneDisplayMode == NavigationViewPaneDisplayMode.Top ? Visibility.Collapsed : Visibility.Visible;
         }
 
         void UpdateAppTitle(CoreApplicationViewTitleBar coreTitleBar)
@@ -149,6 +158,19 @@ namespace AppUIBasics
         public bool CheckNewControlSelected()
         {
             return _newControlsMenuItem.IsSelected;
+        }
+
+        // Wraps a call to RootFrame.Navigate to give the Page a way to know which NavigationRootPage is navigating.
+        // Please call this function rather than RootFrame.Navigate to navigate the RootFrame.
+        public void Navigate(
+            Type pageType,
+            object targetPageArguments = null,
+            Microsoft.UI.Xaml.Media.Animation.NavigationTransitionInfo navigationTransitionInfo = null)
+        {
+            NavigationRootPageArgs args = new NavigationRootPageArgs();
+            args.NavigationRootPage = this;
+            args.Parameter = targetPageArguments;
+            rootFrame.Navigate(pageType, args, navigationTransitionInfo);
         }
 
         public void EnsureNavigationSelection(string id)
@@ -291,7 +313,7 @@ namespace AppUIBasics
             {
                 if (rootFrame.CurrentSourcePageType != typeof(SettingsPage))
                 {
-                    rootFrame.Navigate(typeof(SettingsPage));
+                    Navigate(typeof(SettingsPage));
                 }
             }
             else
@@ -302,14 +324,14 @@ namespace AppUIBasics
                 {
                     if (rootFrame.CurrentSourcePageType != typeof(AllControlsPage))
                     {
-                        rootFrame.Navigate(typeof(AllControlsPage));
+                        Navigate(typeof(AllControlsPage));
                     }
                 }
                 else if (selectedItem == _newControlsMenuItem)
                 {
                     if (rootFrame.CurrentSourcePageType != typeof(NewControlsPage))
                     {
-                        rootFrame.Navigate(typeof(NewControlsPage));
+                        Navigate(typeof(NewControlsPage));
                     }
                 }
                 else
@@ -317,12 +339,12 @@ namespace AppUIBasics
                     if (selectedItem.DataContext is ControlInfoDataGroup)
                     {
                         var itemId = ((ControlInfoDataGroup)selectedItem.DataContext).UniqueId;
-                        rootFrame.Navigate(typeof(SectionPage), itemId);
+                        Navigate(typeof(SectionPage), itemId);
                     }
                     else if (selectedItem.DataContext is ControlInfoDataItem)
                     {
                         var item = (ControlInfoDataItem)selectedItem.DataContext;
-                        rootFrame.Navigate(typeof(ItemPage), item.UniqueId);
+                        Navigate(typeof(ItemPage), item.UniqueId);
                     }
 
                 }
@@ -354,10 +376,10 @@ namespace AppUIBasics
 
         private void CloseTeachingTips()
         {
-            if (Current?.PageHeader != null)
+            if (PageHeader != null)
             {
-                Current.PageHeader.TeachingTip1.IsOpen = false;
-                Current.PageHeader.TeachingTip3.IsOpen = false;
+                PageHeader.TeachingTip1.IsOpen = false;
+                PageHeader.TeachingTip3.IsOpen = false;
             }
         }
 
@@ -409,11 +431,11 @@ namespace AppUIBasics
             if (args.ChosenSuggestion != null && args.ChosenSuggestion is ControlInfoDataItem)
             {
                 var itemId = (args.ChosenSuggestion as ControlInfoDataItem).UniqueId;
-                NavigationRootPage.RootFrame.Navigate(typeof(ItemPage), itemId);
+                Navigate(typeof(ItemPage), itemId);
             }
             else if (!string.IsNullOrEmpty(args.QueryText))
             {
-                NavigationRootPage.RootFrame.Navigate(typeof(SearchResultsPage), args.QueryText);
+                Navigate(typeof(SearchResultsPage), args.QueryText);
             }
         }
 
@@ -577,6 +599,12 @@ namespace AppUIBasics
         private static extern void DebugBreak();
 
         #endregion
+    }
+
+    public class NavigationRootPageArgs
+    {
+        public NavigationRootPage NavigationRootPage;
+        public object Parameter;
     }
 
     public enum DeviceType

--- a/XamlControlsGallery/NewControlsPage.xaml.cs
+++ b/XamlControlsGallery/NewControlsPage.xaml.cs
@@ -27,9 +27,10 @@ namespace AppUIBasics
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            var menuItem = (Microsoft.UI.Xaml.Controls.NavigationViewItem)NavigationRootPage.Current.NavigationView.MenuItems.First();
+            NavigationRootPageArgs args = (NavigationRootPageArgs)e.Parameter;
+            var menuItem = (Microsoft.UI.Xaml.Controls.NavigationViewItem)args.NavigationRootPage.NavigationView.MenuItems.First();
             menuItem.IsSelected = true;
-            NavigationRootPage.Current.NavigationView.Header = string.Empty;
+            args.NavigationRootPage.NavigationView.Header = string.Empty;
 
             Items = ControlInfoDataSource.Instance.Groups.SelectMany(g => g.Items.Where(i => i.BadgeString != null)).OrderBy(i => i.Title).ToList();
             itemsCVS.Source = FormatData();

--- a/XamlControlsGallery/PageHeader.xaml.cs
+++ b/XamlControlsGallery/PageHeader.xaml.cs
@@ -133,7 +133,7 @@ namespace AppUIBasics
 
         private void ToggleThemeTeachingTip2_ActionButtonClick(Microsoft.UI.Xaml.Controls.TeachingTip sender, object args)
         {
-            NavigationRootPage.Current.PageHeader.ToggleThemeAction?.Invoke();
+            NavigationRootPage.GetForElement(this).PageHeader.ToggleThemeAction?.Invoke();
         }
 
         /// <summary>

--- a/XamlControlsGallery/SearchResultsPage.xaml.cs
+++ b/XamlControlsGallery/SearchResultsPage.xaml.cs
@@ -50,11 +50,12 @@ namespace AppUIBasics
         {
             base.OnNavigatedTo(e);
 
-            var queryText = e.Parameter?.ToString().ToLower();
+            NavigationRootPageArgs args = (NavigationRootPageArgs)e.Parameter;
+            var queryText = args.Parameter?.ToString().ToLower();
 
             BuildFilterList(queryText);
 
-            NavigationRootPage.Current.NavigationView.Header = "Search";
+            args.NavigationRootPage.NavigationView.Header = "Search";
         }
 
         protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
@@ -119,7 +120,7 @@ namespace AppUIBasics
                 {
                     // Display informational text when there are no search results.
                     VisualStateManager.GoToState(this, "NoResultsFound", false);
-                    var textbox = NavigationRootPage.Current.PageHeader?.GetDescendantsOfType<AutoSuggestBox>().FirstOrDefault();
+                    var textbox = NavigationRootPage.GetForElement(this).PageHeader?.GetDescendantsOfType<AutoSuggestBox>().FirstOrDefault();
                     textbox?.Focus(FocusState.Programmatic);
                 }
                 else

--- a/XamlControlsGallery/SectionPage.xaml.cs
+++ b/XamlControlsGallery/SectionPage.xaml.cs
@@ -27,11 +27,13 @@ namespace AppUIBasics
         protected override async void OnNavigatedTo(NavigationEventArgs e)
         {
             base.OnNavigatedTo(e);
-            var group = await ControlInfoDataSource.Instance.GetGroupAsync((string)e.Parameter);
+            NavigationRootPageArgs args = (NavigationRootPageArgs)e.Parameter;
+            NavigationRootPage navigationRootPage = args.NavigationRootPage;
+            var group = await ControlInfoDataSource.Instance.GetGroupAsync((string)args.Parameter);
 
-            var menuItem = (Microsoft.UI.Xaml.Controls.NavigationViewItemBase)NavigationRootPage.Current.NavigationView.MenuItems.Single(i => (string)((Microsoft.UI.Xaml.Controls.NavigationViewItemBase)i).Tag == group.UniqueId);
+            var menuItem = (Microsoft.UI.Xaml.Controls.NavigationViewItemBase)navigationRootPage.NavigationView.MenuItems.Single(i => (string)((Microsoft.UI.Xaml.Controls.NavigationViewItemBase)i).Tag == group.UniqueId);
             menuItem.IsSelected = true;
-            NavigationRootPage.Current.NavigationView.Header = menuItem.Content;
+            navigationRootPage.NavigationView.Header = menuItem.Content;
 
             Items = group.Items.OrderBy(i => i.Title).ToList();
         }

--- a/XamlControlsGallery/SettingsPage.xaml.cs
+++ b/XamlControlsGallery/SettingsPage.xaml.cs
@@ -63,8 +63,8 @@ namespace AppUIBasics
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             base.OnNavigatedTo(e);
-
-            NavigationRootPage.Current.NavigationView.Header = "Settings";
+            NavigationRootPageArgs args = (NavigationRootPageArgs)e.Parameter;
+            args.NavigationRootPage.NavigationView.Header = "Settings";
         }
 
         private async void OnFeedbackButtonClick(object sender, RoutedEventArgs e)
@@ -83,11 +83,32 @@ namespace AppUIBasics
             var selectedTheme = ((RadioButton)sender)?.Tag?.ToString();
 #if UNIVERSAL
             ApplicationViewTitleBar titleBar = ApplicationView.GetForCurrentView().TitleBar;
+            Action<Windows.UI.Color> SetTitleBarButtonForegroundColor = (Windows.UI.Color color) => { titleBar.ButtonForegroundColor = color; };
+#else
+            Action<Windows.UI.Color> SetTitleBarButtonForegroundColor = (Windows.UI.Color color) => {};
 #endif
-
             if (selectedTheme != null)
             {
                 ThemeHelper.RootTheme = App.GetEnum<ElementTheme>(selectedTheme);
+                if (selectedTheme == "Dark")
+                {
+                    SetTitleBarButtonForegroundColor(Colors.White);
+                }
+                else if (selectedTheme == "Light")
+                {
+                    SetTitleBarButtonForegroundColor(Colors.Black);
+                }
+                else
+                {
+                    if (Application.Current.RequestedTheme == ApplicationTheme.Dark)
+                    {
+                        SetTitleBarButtonForegroundColor(Colors.White);
+                    }
+                    else
+                    {
+                        SetTitleBarButtonForegroundColor(Colors.Black);
+                    }
+                }
             }
         }
 
@@ -95,7 +116,7 @@ namespace AppUIBasics
         {
             if (e.Key == VirtualKey.Up)
             {
-                NavigationRootPage.Current.PageHeader.Focus(FocusState.Programmatic);
+                NavigationRootPage.GetForElement(this).PageHeader.Focus(FocusState.Programmatic);
             }
         }
         private void spatialSoundBox_Checked(object sender, RoutedEventArgs e)
@@ -125,7 +146,7 @@ namespace AppUIBasics
 
         private void navigationToggle_Toggled(object sender, RoutedEventArgs e)
         {
-            NavigationOrientationHelper.IsLeftMode = navigationLocation.SelectedIndex == 0;
+            NavigationOrientationHelper.IsLeftModeForElement(navigationLocation.SelectedIndex == 0, this);
         }
 
         private void screenshotModeToggle_Toggled(object sender, RoutedEventArgs e)
@@ -143,7 +164,7 @@ namespace AppUIBasics
 
         private void navigationLocation_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            NavigationOrientationHelper.IsLeftMode = navigationLocation.SelectedIndex == 0;
+            NavigationOrientationHelper.IsLeftModeForElement(navigationLocation.SelectedIndex == 0, this);
         }
 
         private async void FolderButton_Click(object sender, RoutedEventArgs e)

--- a/XamlControlsGallery/TabViewPages/MyTabContentControl.xaml
+++ b/XamlControlsGallery/TabViewPages/MyTabContentControl.xaml
@@ -11,8 +11,9 @@
 
     <StackPanel Padding="12">
         <TextBlock Text="{Binding}" Style="{ThemeResource TitleTextBlockStyle}" />
-        <TextBlock Text="Drag the Tab outside of the window to spawn a new window." Style="{ThemeResource SubtitleTextBlockStyle}" />
-        <TextBlock Text="Notice that the state of the Tab is maintained in the new window. For example, if you toggle the ToggleSwitch ON, it will remain ON in the new window." Style="{ThemeResource BodyTextBlockStyle}" />
+        <TextBlock x:Name="DesktopTextBlock" Visibility="Collapsed" Text="Dragging a Tab to create a new Window is not yet supported." Style="{ThemeResource SubtitleTextBlockStyle}" />
+        <TextBlock x:Name="UwpTextBlock1" Text="Drag the Tab outside of the window to spawn a new window." Style="{ThemeResource SubtitleTextBlockStyle}" />
+        <TextBlock x:Name="UwpTextBlock2" Text="Notice that the state of the Tab is maintained in the new window. For example, if you toggle the ToggleSwitch ON, it will remain ON in the new window." Style="{ThemeResource BodyTextBlockStyle}" />
         <ToggleSwitch x:Name="ControlToggle" Header="Turn on ProgressRing" Margin="0,8" />
         <ProgressRing IsActive="{x:Bind ControlToggle.IsOn, Mode=OneWay}" HorizontalAlignment="Left" />
     </StackPanel>

--- a/XamlControlsGallery/TabViewPages/MyTabContentControl.xaml.cs
+++ b/XamlControlsGallery/TabViewPages/MyTabContentControl.xaml.cs
@@ -10,6 +10,12 @@ namespace AppUIBasics.TabViewPages
         public MyTabContentControl()
         {
             this.InitializeComponent();
+
+#if !UNIVERSAL
+            DesktopTextBlock.Visibility = Visibility.Visible;
+            UwpTextBlock1.Visibility = Visibility.Collapsed;
+            UwpTextBlock2.Visibility = Visibility.Collapsed;
+#endif
         }
     }
 }

--- a/XamlControlsGallery/TabViewPages/TabViewWindowingSamplePage.xaml.cs
+++ b/XamlControlsGallery/TabViewPages/TabViewWindowingSamplePage.xaml.cs
@@ -27,7 +27,7 @@ namespace AppUIBasics.TabViewPages
             // If there are no more tabs, close the window.
             if (sender.TabItems.Count == 0)
             {
-                App.CurrentWindow.Close();
+                WindowHelper.GetWindowForElement(this).Close();
             }
         }
 

--- a/XamlControlsGallery/standalone.props
+++ b/XamlControlsGallery/standalone.props
@@ -1,12 +1,12 @@
 <Project>
   <PropertyGroup>
     <!-- The NuGet versions of dependencies to build against. -->
-    <ProjectReunionPackageVersion>1.0.0</ProjectReunionPackageVersion>
+    <ProjectReunionPackageVersion>1.0.1</ProjectReunionPackageVersion>
     <ProjectReunionWinUIPackageVersion>1.0.0</ProjectReunionWinUIPackageVersion>
     <MicrosoftNETCoreUniversalWindowsPlatformVersion>6.2.11</MicrosoftNETCoreUniversalWindowsPlatformVersion>
     <Win2DWinUIVersion>0.1.0.3</Win2DWinUIVersion>
     <ColorCodeVersion>2.0.13</ColorCodeVersion>
-    <MicrosoftCsWinRTPackageVersion>1.4.1</MicrosoftCsWinRTPackageVersion>
+    <MicrosoftCsWinRTPackageVersion>1.5.0</MicrosoftCsWinRTPackageVersion>
     <!-- Where to place the files generated from CSWinRT from XamlControlsGallery.Desktop.-->
     <GeneratedFilesDir>obj\generated</GeneratedFilesDir>
     <!-- We have multiple projects in the same directory, which means we need to separate their output paths-->


### PR DESCRIPTION
## Description
This change improves XamlControlsGallery's Multi-Window support.

Update XCG to use WinAppSDK 1.0.1 and CsWinRT 1.5.0.

NavigationRootPage now passes a reference to itself to the child page when it navigates.  It also replaces the Current attribute with GetForElement() so that NavigationRootPage is no longer assumed to be a singleton. Much of the change is moving to this new system.

Uses of App.CurrentWindow have been replaced with Window.Current.

A new class named WindowHelper tracks the Windows on the thread so that given a random UIElement, we can find the Window it lives in.  CreateWindow is also present here so that the helper can maintain that list.

A new class has been added to provide interop with win32 calls:
- GetActiveWindow
- GotModuleHandle
- LoadIcon
- SendMessage

ThemeHelper has been updated to work with multiple windows.

IdleSynchronizer has been updated to work with multiple windows.

The NavigationOrientationHelper has changed IsLeftMode from an attribute to a method.

Add a new example to show the creation of multiple windows.

Add a new example to show the various customization options for the titlebar (system, custom, fallback).

Allow the TabViewPage to create a new Window again

## Motivation and Context
WinAppSDK 1.0.1 fixed multiple issues that prevented proper use of multiple windows and  titlebars.  The fixing of these issues has unblocked the use of both of these in XCG.

## How Has This Been Tested?
Manual testing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
