### PR TITLE
Fixing a few a11y issues in the app

### DIFF
--- a/XamlControlsGallery/ConnectedAnimationPages/CardPage.xaml
+++ b/XamlControlsGallery/ConnectedAnimationPages/CardPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page
+<Page
     x:Class="AppUIBasics.ConnectedAnimationPages.CardPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -17,16 +17,16 @@
             </GridView.ItemContainerStyle>
             <GridView.ItemTemplate>
                 <DataTemplate>
-                    <Grid x:Name="connectedElement" Height="250" Width="190">
+                    <Grid x:Name="connectedElement" Height="250" Width="190" AutomationProperties.Name="{Binding}">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
                         <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{ThemeResource SystemAccentColor}" Height="100">
-                            <TextBlock Text="Header" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{ThemeResource TitleTextBlockStyle}" />
+                            <TextBlock Text="Item" HorizontalAlignment="Center" VerticalAlignment="Center" Style="{ThemeResource TitleTextBlockStyle}" />
                         </Grid>
                         <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}" Grid.Row="1">
-                            <TextBlock Text="Content" Margin="12" />
+                            <TextBlock Text="{Binding}" Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center"/>
                         </Grid>
                     </Grid>
                 </DataTemplate>

--- a/XamlControlsGallery/ConnectedAnimationPages/CardPage.xaml.cs
+++ b/XamlControlsGallery/ConnectedAnimationPages/CardPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;

--- a/XamlControlsGallery/ConnectedAnimationPages/CollectionPage.xaml.cs
+++ b/XamlControlsGallery/ConnectedAnimationPages/CollectionPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media.Animation;
@@ -42,6 +42,9 @@ namespace AppUIBasics.ConnectedAnimationPages
 
                     await collection.TryStartConnectedAnimationAsync(animation, _storeditem, "connectedElement");
                 }
+
+                // Set focus on the list
+                collection.Focus(FocusState.Programmatic);
             }
         }
 

--- a/XamlControlsGallery/ConnectedAnimationPages/DetailedInfoPage.xaml
+++ b/XamlControlsGallery/ConnectedAnimationPages/DetailedInfoPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page
+<Page
     x:Class="AppUIBasics.ConnectedAnimationPages.DetailedInfoPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -13,7 +13,7 @@
         </Grid.RowDefinitions>
 
         <Grid x:Name="headerBackground" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{ThemeResource SystemControlAcrylicElementBrush}">
-            <Button Content="Go Back" HorizontalAlignment="Left" VerticalAlignment="Top" Background="{ThemeResource SystemAccentColor}" Click="BackButton_Click" />
+            <Button x:Name="GoBackButton" Content="Go Back" HorizontalAlignment="Left" VerticalAlignment="Top" Background="{ThemeResource SystemAccentColor}" Click="BackButton_Click" />
         </Grid>
 
         <Grid x:Name="headerContent" Margin="20,52,20,20">

--- a/XamlControlsGallery/ConnectedAnimationPages/DetailedInfoPage.xaml.cs
+++ b/XamlControlsGallery/ConnectedAnimationPages/DetailedInfoPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
 using AppUIBasics.ControlPages;
@@ -12,6 +12,13 @@ namespace AppUIBasics.ConnectedAnimationPages
         public DetailedInfoPage()
         {
             this.InitializeComponent();
+            GoBackButton.Loaded += GoBackButton_Loaded;
+        }
+
+        private void GoBackButton_Loaded(object sender, RoutedEventArgs e)
+        {
+            // When we land in page, put focus on the back button
+            GoBackButton.Focus(FocusState.Programmatic);
         }
 
         protected override void OnNavigatedTo(NavigationEventArgs e)

--- a/XamlControlsGallery/ControlPages/ItemsRepeaterPage.xaml
+++ b/XamlControlsGallery/ControlPages/ItemsRepeaterPage.xaml
@@ -31,15 +31,15 @@
         </DataTemplate>
 
         <DataTemplate x:Key="NormalItemTemplate" x:DataType="x:Int32">
-            <Button HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{ThemeResource SystemChromeLowColor}">
-                <TextBlock Text="{x:Bind}"/>
-            </Button>
+            <Border Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}">
+                <TextBlock Text="{x:Bind}" HorizontalAlignment="Center" VerticalAlignment="Center" />
+            </Border>
         </DataTemplate>
 
         <DataTemplate x:Key="AccentItemTemplate" x:DataType="x:Int32">
-            <Button HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{ThemeResource SystemAccentColor}">
-                <TextBlock Text="{x:Bind}"/>
-            </Button>
+            <Border  Background="{ThemeResource SystemControlBackgroundAccentBrush}" >
+                <TextBlock Text="{x:Bind}"  HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{ThemeResource SystemControlForegroundChromeWhiteBrush}"/>
+            </Border>
         </DataTemplate>
 
         <DataTemplate x:Key="StringDataTemplate" x:DataType="x:String">
@@ -243,8 +243,10 @@ the following attributes: Height, MaxHeight, Length, MaxLength, Diameter, and Ma
                               Grid.Column="0"
                               Height="175"
                               Width="250">
-                    <muxc:ItemsRepeater x:Name="animatedScrollRepeater">
-                            <DataTemplate x:DataType="x:String">
+                    <muxc:ItemsRepeater x:Name="animatedScrollRepeater"
+                                        GettingFocus="OnAnimatedScrollRepeaterGettingFocus"
+                                        KeyDown="OnAnimatedScrollRepeaterKeyDown">
+                        <DataTemplate x:DataType="x:String">
                             <Button Content="{x:Bind}"
                                         Background="{x:Bind}"
                                         Click="OnAnimatedItemClicked"

--- a/XamlControlsGallery/ControlPages/ItemsRepeaterPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ItemsRepeaterPage.xaml.cs
@@ -26,6 +26,7 @@ namespace AppUIBasics.ControlPages
         private double AnimatedBtnHeight;
         private Thickness AnimatedBtnMargin;
         private Button LastSelectedColorButton;
+        private int PreviouslyFocusedAnimatedScrollRepeaterIndex = -1;
 
         public ItemsRepeaterPage()
         {
@@ -162,7 +163,7 @@ namespace AppUIBasics.ControlPages
         {
             string itemTemplateKey = string.Empty;
             var selected = (sender as Microsoft.UI.Xaml.Controls.RadioButtons).SelectedItem;
-            if(selected == null)
+            if (selected == null)
             {
                 // No point in continuing if selected element is null
                 return;
@@ -244,11 +245,29 @@ namespace AppUIBasics.ControlPages
         private void OnAnimatedItemGotFocus(object sender, RoutedEventArgs e)
         {
             var item = sender as FrameworkElement;
+
+            // Store the last focused Index so we can land back on it when focus leaves
+            // and comes back to the repeater.
+            PreviouslyFocusedAnimatedScrollRepeaterIndex = animatedScrollRepeater.GetElementIndex(sender as UIElement);
+
             item.StartBringIntoView(new BringIntoViewOptions()
             {
                 VerticalAlignmentRatio = 0.5,
                 AnimationDesired = true,
             });
+        }
+
+        private void OnAnimatedScrollRepeaterGettingFocus(UIElement sender, Windows.UI.Xaml.Input.GettingFocusEventArgs args)
+        {
+            // If we have a previously focused index and focus moving from outside the repeater to inside,
+            // then we can pick the previously focused index and land on that item again.
+            var lastFocus = args.OldFocusedElement as UIElement;
+            if (PreviouslyFocusedAnimatedScrollRepeaterIndex != -1 &&
+                lastFocus != null && animatedScrollRepeater.GetElementIndex(lastFocus) == -1)
+            {
+                var item = animatedScrollRepeater.TryGetElement(PreviouslyFocusedAnimatedScrollRepeaterIndex);
+                args.NewFocusedElement = item;
+            }
         }
 
         private void OnAnimatedItemClicked(object sender, RoutedEventArgs e)
@@ -403,6 +422,31 @@ namespace AppUIBasics.ControlPages
 
             peer.RaiseNotificationEvent(AutomationNotificationKind.Other, AutomationNotificationProcessing.ImportantMostRecent, $"Filtered recipes, {sortedFilteredTypes.Count()} results.", "RecipesFilteredNotificationActivityId");
         }
+
+        private void OnAnimatedScrollRepeaterKeyDown(object sender, Windows.UI.Xaml.Input.KeyRoutedEventArgs e)
+        {
+            if (e.Handled != true)
+            {
+                var targetIndex = -1;
+                if (e.Key == Windows.System.VirtualKey.Home)
+                {
+                    targetIndex = PreviouslyFocusedAnimatedScrollRepeaterIndex != 0 ? 0 : -1;
+                }
+                else if (e.Key == Windows.System.VirtualKey.End)
+                {
+                    targetIndex = PreviouslyFocusedAnimatedScrollRepeaterIndex != animatedScrollRepeater.ItemsSourceView.Count - 1 ?
+                        animatedScrollRepeater.ItemsSourceView.Count - 1 : -1;
+                }
+
+                if (targetIndex != -1)
+                {
+                    var element = animatedScrollRepeater.GetOrCreateElement(targetIndex);
+                    element.StartBringIntoView();
+                    (element as Control).Focus(FocusState.Programmatic);
+                    e.Handled = true;
+                }
+            }
+        }
     }
 
     public class NestedCategory
@@ -415,7 +459,6 @@ namespace AppUIBasics.ControlPages
             CategoryItems = catItems;
         }
     }
-
 
     public class MyDataTemplateSelector : DataTemplateSelector
     {

--- a/XamlControlsGallery/ItemsPageBase.cs
+++ b/XamlControlsGallery/ItemsPageBase.cs
@@ -77,7 +77,7 @@ namespace AppUIBasics
             }
         }
 
-        protected async void OnItemGridViewLoaded(object sender, RoutedEventArgs e)
+        protected void OnItemGridViewLoaded(object sender, RoutedEventArgs e)
         {
             if (_itemId != null)
             {

--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
@@ -384,7 +384,6 @@ namespace AppUIBasics
             {
                 var infoDataItem = args.ChosenSuggestion as ControlInfoDataItem;
                 var itemId = infoDataItem.UniqueId;
-                bool changedSelection = false;
                 EnsureItemIsVisibleInNavigation(infoDataItem.Title);
                 NavigationRootPage.RootFrame.Navigate(typeof(ItemPage), itemId);
             }

--- a/XamlControlsGallery/TabViewPages/TabViewWindowingSamplePage.xaml.cs
+++ b/XamlControlsGallery/TabViewPages/TabViewWindowingSamplePage.xaml.cs
@@ -121,7 +121,7 @@ namespace AppUIBasics.TabViewPages
         }
 
         // Create a new Window once the Tab is dragged outside.
-        private async void Tabs_TabDroppedOutside(TabView sender, TabViewTabDroppedOutsideEventArgs args)
+        private void Tabs_TabDroppedOutside(TabView sender, TabViewTabDroppedOutsideEventArgs args)
         {
             MoveTabToNewWindow(args.Tab);
         }
@@ -163,7 +163,7 @@ namespace AppUIBasics.TabViewPages
             args.Data.RequestedOperation = DataPackageOperation.Move;
         }
 
-        private async void Tabs_TabStripDrop(object sender, DragEventArgs e)
+        private void Tabs_TabStripDrop(object sender, DragEventArgs e)
         {
             // This event is called when we're dragging between different TabViews
             // It is responsible for handling the drop of the item into the second TabView


### PR DESCRIPTION
## Description
Fixing a handful of accessibility issues in the app.

## Motivation and Context
Fixes the following issues
Internal: [Bug 37700602](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/37700602): [XCG]ItemsRepeater does not meet contrast requirements in Aquatic High Contrast theme

Images after the fix in Normal and Aquatic themes.
![image](https://user-images.githubusercontent.com/28935693/161855089-96a9f057-9d62-4443-90d1-10021ce75afb.png)
![image](https://user-images.githubusercontent.com/28935693/161855106-95fbe1d0-da17-4638-a245-0f4003f0337d.png)

Internal [Bug 38293529](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/38293529): [XCG] WinUI Accessibility->Connected Animation card: When any item is invoked, KB focus does not fall on the immediate interactive control(Go back button)
Setting focus on the correct item after the connected animation.

Internal [Bug 37020621](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/37020621): [XCG] WinUI 3 Controls Gallery->Connected Animation: Narrator does not announce Control type of different menu items
Setting missing accessibility name for the item.

Internal [Bug 36430620](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/36430620): [XCG][GitHub] Animated Scrolling and Content Display selected button value gets changed when we re-enter again. · Issue #378 · microsoft/Xaml-Controls-Gallery (github.com)
Fixes #378
We need to keep track of the last item that was focused so we put focus back on the same item.

Internal [Bug 36430694](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/36430694): [XCG][GitHub] Narrator is silent and focus lands to "Aqua" on pressing "Home" Key in the colors list in ItemsRepeater. #377
Fixes #377
we were not handling home and end keys 

## How Has This Been Tested?
Tested manually, visually as well as with Narrator/Accessibility Insights.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
